### PR TITLE
feat(types): better types for consumer api: mode, fallbackMode

### DIFF
--- a/src/clients/consumer/types.ts
+++ b/src/clients/consumer/types.ts
@@ -29,6 +29,7 @@ export const MessagesStreamModes = {
   MANUAL: 'manual'
 } as const
 export type MessagesStreamMode = keyof typeof MessagesStreamModes
+export type MessagesStreamModeValue = (typeof MessagesStreamModes)[keyof typeof MessagesStreamModes]
 
 export const MessagesStreamFallbackModes = {
   LATEST: 'latest',
@@ -36,7 +37,7 @@ export const MessagesStreamFallbackModes = {
   FAIL: 'fail'
 } as const
 export type MessagesStreamFallbackMode = keyof typeof MessagesStreamFallbackModes
-
+export type MessagesStreamFallbackModeValue = (typeof MessagesStreamFallbackModes)[keyof typeof MessagesStreamFallbackModes]
 export interface GroupOptions {
   sessionTimeout?: number
   rebalanceTimeout?: number
@@ -56,8 +57,8 @@ export interface ConsumeBaseOptions<Key, Value, HeaderKey, HeaderValue> {
 
 export interface StreamOptions {
   topics: string[]
-  mode?: string
-  fallbackMode?: string
+  mode?: MessagesStreamModeValue
+  fallbackMode?: MessagesStreamFallbackModeValue
   offsets?: TopicWithPartitionAndOffset[]
 }
 


### PR DESCRIPTION
This PR improves the TypeScript definitions for the `consumer` API by enabling autocompletion for the `mode` and  `fallbackMode` properties through stricter typing.

`mode`
![image](https://github.com/user-attachments/assets/95f4192a-93bf-4669-a972-18574324e97c)

`fallbackMode`:
![image](https://github.com/user-attachments/assets/3cbc2310-5273-44fa-9010-7ba6bea98e02)

