### PR TITLE
fix: Handle length of -1 in readVarIntBytes

### DIFF
--- a/src/protocol/reader.ts
+++ b/src/protocol/reader.ts
@@ -280,7 +280,10 @@ export class Reader {
   }
 
   readVarIntBytes (): Buffer {
-    const length = this.readVarInt()
+    let length = this.readVarInt()
+    if (length === -1) {
+      length = 0
+    }
     const value = this.buffer.slice(this.position, this.position + length)
 
     this.position += length

--- a/test/protocol/reader.test.ts
+++ b/test/protocol/reader.test.ts
@@ -458,14 +458,22 @@ test('readBytes', () => {
 
 test('readVarIntBytes', () => {
   const buffer = Buffer.from([
-    // length as VarInt (1 - ZigZag encoded would be 2, but for length it's not ZigZag)
     2, // This is the actual encoding for length 1 in VarInt
     // Buffer content [10]
-    10
+    10,
+    1, // This is the actual encoding for length -1 in VarInt
+    // Buffer content is empty
+    0, // This is the actual encoding for length 0 in VarInt
+    // Buffer content is empty
+    4, // This is the actual encoding for length 2 in VarInt
+    1, 2 // Buffer content [1, 2]
   ])
 
   const reader = new Reader(new DynamicBuffer(buffer))
   deepStrictEqual(reader.readVarIntBytes(), Buffer.from([10]))
+  deepStrictEqual(reader.readVarIntBytes(), Buffer.from([]))
+  deepStrictEqual(reader.readVarIntBytes(), Buffer.from([]))
+  deepStrictEqual(reader.readVarIntBytes(), Buffer.from([1, 2]))
 })
 
 test('readNullableArray', () => {


### PR DESCRIPTION
Presumably for old message records, Kafka can send a length of -1 for empty fields in the record. This commit adds the missing check for this case.
