### PR TITLE
Proposal: Improve callback typings

### DIFF
--- a/playground/clients/producer-idempotent.ts
+++ b/playground/clients/producer-idempotent.ts
@@ -23,7 +23,8 @@ function callbackProduce (cb?: Function): void {
       ],
       acks: ProduceAcks.ALL
     },
-    (error, result) => {
+    (...args) => {
+      const [error, result] = args
       if (error) {
         console.error('ERROR', error)
         return

--- a/src/apis/callbacks.ts
+++ b/src/apis/callbacks.ts
@@ -41,18 +41,22 @@ export function runConcurrentCallbacks<ReturnType> (
 
   let i = 0
 
-  function operationCallback (index: number, e: Error | null, result: ReturnType): void {
+  function operationCallback (index: number, e: Error | null, result?: ReturnType): void {
     if (e) {
       hasErrors = true
       errors[index] = e
     } else {
-      results[index] = result
+      results[index] = result!
     }
 
     remaining--
 
     if (remaining === 0) {
-      callback(hasErrors ? new MultipleErrors(errorMessage, errors) : null, results)
+      if (hasErrors) {
+        callback(new MultipleErrors(errorMessage, errors))
+      } else {
+        callback(null, results)
+      }
     }
   }
 

--- a/src/apis/definitions.ts
+++ b/src/apis/definitions.ts
@@ -3,7 +3,7 @@ import { type Connection } from '../network/connection.ts'
 import { type Reader } from '../protocol/reader.ts'
 import { type Writer } from '../protocol/writer.ts'
 
-export type Callback<ReturnType> = (error: Error | null, payload: ReturnType) => void
+export type Callback<ReturnType> = (...args: [error: Error] | [error: null, value: ReturnType]) => void
 
 export type CallbackArguments<ReturnType> = [cb: Callback<ReturnType>]
 

--- a/src/clients/admin/admin.ts
+++ b/src/clients/admin/admin.ts
@@ -87,7 +87,7 @@ export class Admin extends Base<AdminOptions> {
 
     const validationError = this[kValidateOptions](options, listTopicsOptionsValidator, '/options', false)
     if (validationError) {
-      callback(validationError, undefined as unknown as string[])
+      callback(validationError)
       return callback[kCallbackPromise]
     }
 
@@ -119,7 +119,7 @@ export class Admin extends Base<AdminOptions> {
 
     const validationError = this[kValidateOptions](options, createTopicsOptionsValidator, '/options', false)
     if (validationError) {
-      callback(validationError, undefined as unknown as CreatedTopic[])
+      callback(validationError)
       return callback[kCallbackPromise]
     }
 
@@ -148,7 +148,7 @@ export class Admin extends Base<AdminOptions> {
 
     const validationError = this[kValidateOptions](options, deleteTopicsOptionsValidator, '/options', false)
     if (validationError) {
-      callback(validationError, undefined as unknown as void)
+      callback(validationError)
       return callback[kCallbackPromise]
     }
 
@@ -184,7 +184,7 @@ export class Admin extends Base<AdminOptions> {
 
     const validationError = this[kValidateOptions](options, listGroupsOptionsValidator, '/options', false)
     if (validationError) {
-      callback(validationError, undefined as unknown as Map<string, GroupBase>)
+      callback(validationError)
       return callback[kCallbackPromise]
     }
 
@@ -218,7 +218,7 @@ export class Admin extends Base<AdminOptions> {
 
     const validationError = this[kValidateOptions](options, describeGroupsOptionsValidator, '/options', false)
     if (validationError) {
-      callback(validationError, undefined as unknown as Map<string, Group>)
+      callback(validationError)
       return callback[kCallbackPromise]
     }
 
@@ -247,7 +247,7 @@ export class Admin extends Base<AdminOptions> {
 
     const validationError = this[kValidateOptions](options, deleteGroupsOptionsValidator, '/options', false)
     if (validationError) {
-      callback(validationError, undefined as unknown as void)
+      callback(validationError)
       return callback[kCallbackPromise]
     }
 
@@ -272,15 +272,17 @@ export class Admin extends Base<AdminOptions> {
         this[kPerformWithRetry]<MetadataResponse>(
           'metadata',
           retryCallback => {
-            this[kGetBootstrapConnection]((error, connection) => {
+            this[kGetBootstrapConnection]((...args) => {
+              const [error, connection] = args
               if (error) {
-                retryCallback(error, undefined as unknown as MetadataResponse)
+                retryCallback(error)
                 return
               }
 
-              this[kGetApi]<MetadataRequest, MetadataResponse>('Metadata', (error, api) => {
+              this[kGetApi]<MetadataRequest, MetadataResponse>('Metadata', (...args) => {
+                const [error, api] = args
                 if (error) {
-                  retryCallback(error, undefined as unknown as MetadataResponse)
+                  retryCallback(error)
                   return
                 }
 
@@ -288,9 +290,10 @@ export class Admin extends Base<AdminOptions> {
               })
             })
           },
-          (error: Error | null, metadata: MetadataResponse) => {
+          (...args) => {
+            const [error, metadata] = args
             if (error) {
-              deduplicateCallback(error, undefined as unknown as string[])
+              deduplicateCallback(error)
               return
             }
 
@@ -337,18 +340,20 @@ export class Admin extends Base<AdminOptions> {
     this[kPerformDeduplicated](
       'createTopics',
       deduplicateCallback => {
-        this[kPerformWithRetry](
+        this[kPerformWithRetry]<CreateTopicsResponse>(
           'createTopics',
           retryCallback => {
-            this[kGetBootstrapConnection]((error, connection) => {
+            this[kGetBootstrapConnection]((...args) => {
+              const [error, connection] = args
               if (error) {
-                retryCallback(error, undefined as unknown as CreateTopicsResponse)
+                retryCallback(error)
                 return
               }
 
-              this[kGetApi]<CreateTopicsRequest, CreateTopicsResponse>('CreateTopics', (error, api) => {
+              this[kGetApi]<CreateTopicsRequest, CreateTopicsResponse>('CreateTopics', (...args) => {
+                const [error, api] = args
                 if (error) {
-                  retryCallback(error, undefined as unknown as CreateTopicsResponse)
+                  retryCallback(error)
                   return
                 }
 
@@ -357,14 +362,15 @@ export class Admin extends Base<AdminOptions> {
                   requests,
                   this[kOptions].timeout!,
                   false,
-                  retryCallback as unknown as Callback<CreateTopicsResponse>
+                  retryCallback
                 )
               })
             })
           },
-          (error: Error | null, response: CreateTopicsResponse) => {
+          (...args) => {
+            const [error, response] = args
             if (error) {
-              deduplicateCallback(error, undefined as unknown as CreatedTopic[])
+              deduplicateCallback(error)
               return
             }
 
@@ -402,9 +408,10 @@ export class Admin extends Base<AdminOptions> {
         this[kPerformWithRetry](
           'deleteTopics',
           retryCallback => {
-            this[kGetBootstrapConnection]((error, connection) => {
+            this[kGetBootstrapConnection]((...args) => {
+              const [error, connection] = args
               if (error) {
-                retryCallback(error, undefined)
+                retryCallback(error)
                 return
               }
 
@@ -413,9 +420,10 @@ export class Admin extends Base<AdminOptions> {
                 requests.push({ name: topic })
               }
 
-              this[kGetApi]<DeleteTopicsRequest, DeleteTopicsResponse>('DeleteTopics', (error, api) => {
+              this[kGetApi]<DeleteTopicsRequest, DeleteTopicsResponse>('DeleteTopics', (...args) => {
+                const [error, api] = args
                 if (error) {
-                  retryCallback(error, undefined as unknown as DeleteTopicsResponse)
+                  retryCallback(error)
                   return
                 }
 
@@ -432,15 +440,16 @@ export class Admin extends Base<AdminOptions> {
           0
         )
       },
-      error => callback(error)
+      callback
     )
   }
 
   #listGroups (options: ListGroupsOptions, callback: CallbackWithPromise<Map<string, GroupBase>>): void {
     // Find all the brokers in the cluster
-    this[kMetadata]({ topics: [] }, (error, metadata) => {
+    this[kMetadata]({ topics: [] }, (...args) => {
+      const [error, metadata] = args
       if (error) {
-        callback(error, undefined as unknown as Map<string, GroupBase>)
+        callback(error)
         return
       }
 
@@ -448,21 +457,20 @@ export class Admin extends Base<AdminOptions> {
         'Listing groups failed.',
         metadata.brokers,
         ([, broker], concurrentCallback) => {
-          this[kGetConnection](broker, (error, connection) => {
+          this[kGetConnection](broker, (...args) => {
+            const [error, connection] = args
             if (error) {
-              concurrentCallback(error, undefined as unknown as ListGroupsResponse)
+              concurrentCallback(error)
               return
             }
 
             this[kPerformWithRetry]<ListGroupsResponse>(
               'listGroups',
               retryCallback => {
-                this[kGetApi]<ListGroupsRequestV4 | ListGroupsRequestV5, ListGroupsResponse>('ListGroups', (
-                  error,
-                  api
-                ) => {
+                this[kGetApi]<ListGroupsRequestV4 | ListGroupsRequestV5, ListGroupsResponse>('ListGroups', (...args) => {
+                  const [error, api] = args
                   if (error) {
-                    retryCallback(error, undefined as unknown as ListGroupsResponse)
+                    retryCallback(error)
                     return
                   }
 
@@ -479,9 +487,10 @@ export class Admin extends Base<AdminOptions> {
             )
           })
         },
-        (error, results) => {
+        (...args) => {
+          const [error, results] = args
           if (error) {
-            callback(error, undefined as unknown as Map<string, GroupBase>)
+            callback(error)
             return
           }
 
@@ -504,15 +513,17 @@ export class Admin extends Base<AdminOptions> {
   }
 
   #describeGroups (options: DescribeGroupsOptions, callback: CallbackWithPromise<Map<string, Group>>): void {
-    this[kMetadata]({ topics: [] }, (error, metadata) => {
+    this[kMetadata]({ topics: [] }, (...args) => {
+      const [error, metadata] = args
       if (error) {
-        callback(error, undefined as unknown as Map<string, Group>)
+        callback(error)
         return
       }
 
-      this.#findGroupCoordinator(options.groups, (error, response) => {
+      this.#findGroupCoordinator(options.groups, (...args) => {
+        const [error, response] = args
         if (error) {
-          callback(error, undefined as unknown as Map<string, Group>)
+          callback(error)
           return
         }
 
@@ -532,18 +543,20 @@ export class Admin extends Base<AdminOptions> {
           'Describing groups failed.',
           coordinators,
           ([node, groups], concurrentCallback) => {
-            this[kGetConnection](metadata.brokers.get(node)!, (error, connection) => {
+            this[kGetConnection](metadata.brokers.get(node)!, (...args) => {
+              const [error, connection] = args
               if (error) {
-                concurrentCallback(error, undefined as unknown as DescribeGroupsResponse)
+                concurrentCallback(error)
                 return
               }
 
               this[kPerformWithRetry]<DescribeGroupsResponse>(
                 'describeGroups',
                 retryCallback => {
-                  this[kGetApi]<DescribeGroupsRequest, DescribeGroupsResponse>('DescribeGroups', (error, api) => {
+                  this[kGetApi]<DescribeGroupsRequest, DescribeGroupsResponse>('DescribeGroups', (...args) => {
+                    const [error, api] = args
                     if (error) {
-                      retryCallback(error, undefined as unknown as DescribeGroupsResponse)
+                      retryCallback(error)
                       return
                     }
 
@@ -555,9 +568,10 @@ export class Admin extends Base<AdminOptions> {
               )
             })
           },
-          (error, results) => {
+          (...args) => {
+            const [error, results] = args
             if (error) {
-              callback(error, undefined as unknown as Map<string, Group>)
+              callback(error)
               return
             }
 
@@ -616,13 +630,15 @@ export class Admin extends Base<AdminOptions> {
   }
 
   #deleteGroups (options: DeleteGroupsOptions, callback: CallbackWithPromise<void>): void {
-    this[kMetadata]({ topics: [] }, (error, metadata) => {
+    this[kMetadata]({ topics: [] }, (...args) => {
+      const [error, metadata] = args
       if (error) {
         callback(error)
         return
       }
 
-      this.#findGroupCoordinator(options.groups, (error, response) => {
+      this.#findGroupCoordinator(options.groups, (...args) => {
+        const [error, response] = args
         if (error) {
           callback(error)
           return
@@ -640,22 +656,24 @@ export class Admin extends Base<AdminOptions> {
           coordinator.push(group)
         }
 
-        runConcurrentCallbacks(
+        runConcurrentCallbacks<DeleteGroupsResponse>(
           'Deleting groups failed.',
           coordinators,
           ([node, groups], concurrentCallback) => {
-            this[kGetConnection](metadata.brokers.get(node)!, (error, connection) => {
+            this[kGetConnection](metadata.brokers.get(node)!, (...args) => {
+              const [error, connection] = args
               if (error) {
-                concurrentCallback(error, undefined)
+                concurrentCallback(error)
                 return
               }
 
-              this[kPerformWithRetry](
+              this[kPerformWithRetry]<DeleteGroupsResponse>(
                 'deleteGroups',
                 retryCallback => {
-                  this[kGetApi]<DeleteGroupsRequest, DeleteGroupsResponse>('DeleteGroups', (error, api) => {
+                  this[kGetApi]<DeleteGroupsRequest, DeleteGroupsResponse>('DeleteGroups', (...args) => {
+                    const [error, api] = args
                     if (error) {
-                      retryCallback(error, undefined as unknown as CreateTopicsResponse)
+                      retryCallback(error)
                       return
                     }
 
@@ -667,7 +685,8 @@ export class Admin extends Base<AdminOptions> {
               )
             })
           },
-          error => callback(error)
+          // @ts-ignore
+          (...args) => callback(args[0], undefined)
         )
       })
     })
@@ -677,15 +696,17 @@ export class Admin extends Base<AdminOptions> {
     this[kPerformWithRetry]<FindCoordinatorResponse>(
       'findGroupCoordinator',
       retryCallback => {
-        this[kGetBootstrapConnection]((error, connection) => {
+        this[kGetBootstrapConnection]((...args) => {
+          const [error, connection] = args
           if (error) {
-            retryCallback(error, undefined as unknown as FindCoordinatorResponse)
+            retryCallback(error)
             return
           }
 
-          this[kGetApi]<FindCoordinatorRequest, FindCoordinatorResponse>('FindCoordinator', (error, api) => {
+          this[kGetApi]<FindCoordinatorRequest, FindCoordinatorResponse>('FindCoordinator', (...args) => {
+            const [error, api] = args
             if (error) {
-              retryCallback(error, undefined as unknown as FindCoordinatorResponse)
+              retryCallback(error)
               return
             }
 
@@ -693,9 +714,10 @@ export class Admin extends Base<AdminOptions> {
           })
         })
       },
-      (error, response) => {
+      (...args) => {
+        const [error, response] = args
         if (error) {
-          callback(error, undefined as unknown as FindCoordinatorResponse)
+          callback(error)
           return
         }
 

--- a/src/protocol/sasl/scram-sha.ts
+++ b/src/protocol/sasl/scram-sha.ts
@@ -130,12 +130,10 @@ export function authenticate (
   const clientFirstMessageBare = `n=${sanitizeString(username)},r=${clientNonce}`
 
   // First of all, send the first message
-  authenticateAPI(connection, Buffer.from(`${GS2_HEADER}${clientFirstMessageBare}`), (error, firstResponse) => {
+  authenticateAPI(connection, Buffer.from(`${GS2_HEADER}${clientFirstMessageBare}`), (...args) => {
+    const [error, firstResponse] = args
     if (error) {
-      callback(
-        new AuthenticationError('Authentication failed.', { cause: error }),
-        undefined as unknown as SaslAuthenticateResponse
-      )
+      callback(new AuthenticationError('Authentication failed.', { cause: error }))
       return
     }
 
@@ -149,18 +147,10 @@ export function authenticate (
 
     // Validate response
     if (!serverNonce.startsWith(clientNonce)) {
-      callback(
-        new AuthenticationError('Server nonce does not start with client nonce.'),
-        undefined as unknown as SaslAuthenticateResponse
-      )
+      callback(new AuthenticationError('Server nonce does not start with client nonce.'))
       return
     } else if (definition.minIterations > iterations) {
-      callback(
-        new AuthenticationError(
-          `Algorithm ${algorithm} requires at least ${definition.minIterations} iterations, while ${iterations} were requested.`
-        ),
-        undefined as unknown as SaslAuthenticateResponse
-      )
+      callback(new AuthenticationError(`Algorithm ${algorithm} requires at least ${definition.minIterations} iterations, while ${iterations} were requested.`))
 
       return
     }
@@ -186,12 +176,10 @@ export function authenticate (
     authenticateAPI(
       connection,
       Buffer.from(`${clientFinalMessageWithoutProof},p=${clientProof.toString('base64')}`),
-      (error, lastResponse) => {
+      (...args) => {
+        const [error, lastResponse] = args
         if (error) {
-          callback(
-            new AuthenticationError('Authentication failed.', { cause: error }),
-            undefined as unknown as SaslAuthenticateResponse
-          )
+          callback(new AuthenticationError('Authentication failed.', { cause: error }))
           return
         }
 
@@ -199,13 +187,10 @@ export function authenticate (
         const lastData = parseParameters(lastResponse.authBytes)
 
         if (lastData.e) {
-          callback(new AuthenticationError(lastData.e), undefined as unknown as SaslAuthenticateResponse)
+          callback(new AuthenticationError(lastData.e))
           return
         } else if (lastData.v !== serverSignature.toString('base64')) {
-          callback(
-            new AuthenticationError('Invalid server signature.'),
-            undefined as unknown as SaslAuthenticateResponse
-          )
+          callback(new AuthenticationError('Invalid server signature.'))
           return
         }
 

--- a/test/apis/definitions.test.ts
+++ b/test/apis/definitions.test.ts
@@ -17,7 +17,8 @@ test('any API should work in promise mode or callback mode', async t => {
   const promiseResponse = await api.async(connection, 'test-client', '1.0.0')
 
   const callbackResponse = await new Promise((resolve, reject) => {
-    api(connection, 'test-client', '1.0.0', (error, response) => {
+    api(connection, 'test-client', '1.0.0', (...args) => {
+      const [error, response] = args
       if (error) {
         reject(error)
       } else {

--- a/test/clients/admin/admin.test.ts
+++ b/test/clients/admin/admin.test.ts
@@ -56,13 +56,15 @@ test('should support both promise and callback API', (t, done) => {
       partitions: 1,
       replicas: 1
     },
-    (err, created) => {
+    (...args) => {
+      const [err, created] = args
       strictEqual(err, null)
-      strictEqual(created?.length, 1)
-      strictEqual(created?.[0].name, topicName)
+      strictEqual(created.length, 1)
+      strictEqual(created[0].name, topicName)
 
       // Clean up and close
-      admin.deleteTopics({ topics: [topicName] }, err => {
+      admin.deleteTopics({ topics: [topicName] }, (...args) => {
+        const [err] = args
         if (err) {
           done(err)
           return

--- a/test/clients/base/base.test.ts
+++ b/test/clients/base/base.test.ts
@@ -157,7 +157,8 @@ test('listApis should support both callback and promise API', (t, done) => {
   const client = createBase(t)
 
   // Use callback API
-  client.listApis((err, apis) => {
+  client.listApis((...args) => {
+    const [err, apis] = args
     strictEqual(err, null)
     ok(Array.isArray(apis))
 
@@ -342,7 +343,8 @@ test('metadata should support both callback and promise API', (t, done) => {
   const testTopic = `test-topic-${randomUUID()}`
 
   // Use callback API
-  client.metadata({ topics: [testTopic], autocreateTopics: true }, (err, metadata) => {
+  client.metadata({ topics: [testTopic], autocreateTopics: true }, (...args) => {
+    const [err, metadata] = args
     strictEqual(err, null)
     strictEqual(metadata.topics.has(testTopic), true)
 
@@ -541,10 +543,12 @@ test('operations can be aborted without a retry', async t => {
 test('kGetApi should fail on unsupported API', (t, done) => {
   const client = createBase(t)
 
-  client[kGetApi]('foo', (error, api) => {
+  client[kGetApi]('foo', (...args) => {
+    const [error, api] = args
     ok(typeof api === 'undefined')
+    ok(error)
     strictEqual(error instanceof UnsupportedApiError, true)
-    strictEqual(error!.message, 'Unsupported API foo.')
+    strictEqual(error.message, 'Unsupported API foo.')
 
     done()
   })
@@ -562,7 +566,8 @@ test('kGetApi should fail on unsupported API version', (t, done) => {
     ]
   })
 
-  client[kGetApi]('Produce', (error, api) => {
+  client[kGetApi]('Produce', (...args) => {
+    const [error, api] = args
     ok(typeof api === 'undefined')
     strictEqual(error instanceof UnsupportedApiError, true)
     strictEqual((error as UnsupportedApiError).message, 'No usable implementation found for API Produce.')

--- a/test/clients/consumer/consumer.test.ts
+++ b/test/clients/consumer/consumer.test.ts
@@ -277,7 +277,8 @@ test('close should support both promise and callback API', t => {
     const consumer = createConsumer(t)
 
     // Use callback API
-    consumer.close(err => {
+    consumer.close((...args) => {
+      const [err] = args
       if (err) {
         reject(err)
         return
@@ -477,7 +478,8 @@ test('consume should support both promise and callback API', t => {
     const consumer = createConsumer(t)
 
     // Use callback API
-    consumer.consume({ topics: [] }, (err, stream) => {
+    consumer.consume({ topics: [] }, (...args) => {
+      const [err, stream] = args
       if (err) {
         reject(err)
         return
@@ -761,7 +763,8 @@ test('fetch should support both promise and callback API', async t => {
           }
         ]
       },
-      (err, result) => {
+      (...args) => {
+        const [err, result] = args
         if (err) {
           reject(err)
           return
@@ -1099,7 +1102,8 @@ test('commit should support both promise and callback API', async t => {
         }
 
         // Test callback API
-        consumer.commit(commitOptions, err => {
+        consumer.commit(commitOptions, (...args) => {
+          const [err] = args
           if (err) {
             reject(err)
             return
@@ -1290,7 +1294,8 @@ test('listOffsets should support both promise and callback API', async t => {
 
   // Test callback API
   await new Promise<void>((resolve, reject) => {
-    consumer.listOffsets({ topics: [topic] }, (err, offsets) => {
+    consumer.listOffsets({ topics: [topic] }, (...args) => {
+      const [err, offsets] = args
       if (err) {
         reject(err)
         return
@@ -1613,7 +1618,8 @@ test('listCommittedOffsets should support both promise and callback API', async 
 
   // Test callback API
   await new Promise<void>((resolve, reject) => {
-    consumer.listCommittedOffsets({ topics: [{ topic, partitions: [0] }] }, (err, committed) => {
+    consumer.listCommittedOffsets({ topics: [{ topic, partitions: [0] }] }, (...args) => {
+      const [err, committed] = args
       if (err) {
         reject(err)
         return
@@ -1791,7 +1797,8 @@ test('findGroupCoordinator should support both promise and callback API', t => {
     const consumer = createConsumer(t)
 
     // Use callback API
-    consumer.findGroupCoordinator((err, coordinatorId) => {
+    consumer.findGroupCoordinator((...args) => {
+      const [err, coordinatorId] = args
       if (err) {
         reject(err)
         return
@@ -2049,7 +2056,8 @@ test('joinGroup should support both promise and callback API', t => {
     const consumer = createConsumer(t)
 
     // Use callback API
-    consumer.joinGroup({}, (err, memberId) => {
+    consumer.joinGroup({}, (...args) => {
+      const [err, memberId] = args
       if (err) {
         reject(err)
         return
@@ -2396,14 +2404,16 @@ test('leaveGroup should support both promise and callback API', t => {
     const consumer = createConsumer(t)
 
     // First join the group
-    consumer.joinGroup({}, joinErr => {
+    consumer.joinGroup({}, (...args) => {
+      const [joinErr] = args
       if (joinErr) {
         reject(joinErr)
         return
       }
 
       // Now test the callback API for leaving
-      consumer.leaveGroup(leaveErr => {
+      consumer.leaveGroup((...args) => {
+        const [leaveErr] = args
         if (leaveErr) {
           reject(leaveErr)
           return

--- a/test/clients/consumer/messages-stream.test.ts
+++ b/test/clients/consumer/messages-stream.test.ts
@@ -835,7 +835,8 @@ test('should properly handle close', async t => {
 
   // Close the stream - Issue a second call before the first has completed
   const promise = new Promise<void>((resolve, reject) => {
-    stream.close(error => {
+    stream.close((...args) => {
+      const [error] = args
       if (error) {
         reject(error)
         return
@@ -948,7 +949,7 @@ test('should handle errors from Consumer.fetch', async t => {
   consumer.fetch = function (_options: any, callback: CallbackWithPromise<any>) {
     const connectionError = new MultipleErrors(mockedErrorMessage, [new Error('Connection failed to localhost:9092')])
 
-    callback(connectionError, undefined)
+    callback(connectionError)
   } as typeof consumer.fetch
 
   const stream = await consumer.consume({
@@ -979,7 +980,7 @@ test('should handle errors from Consumer.commit', async t => {
   consumer.commit = function (_options: any, callback: CallbackWithPromise<any>) {
     const connectionError = new MultipleErrors(mockedErrorMessage, [new Error('Connection failed to localhost:9092')])
 
-    callback(connectionError, undefined)
+    callback(connectionError)
   } as typeof consumer.commit
 
   const stream = await consumer.consume({
@@ -1011,7 +1012,7 @@ test('should handle errors from Consumer.listOffsets', async t => {
   consumer.listOffsets = function (_options: any, callback: CallbackWithPromise<any>) {
     const connectionError = new MultipleErrors(mockedErrorMessage, [new Error('Connection failed to localhost:9092')])
 
-    callback(connectionError, undefined)
+    callback(connectionError)
   } as typeof consumer.listOffsets
 
   const stream = await consumer.consume({
@@ -1042,7 +1043,7 @@ test('should handle errors from Consumer.listCommittedOffsets', async t => {
   consumer.listCommittedOffsets = function (_options: any, callback: CallbackWithPromise<any>) {
     const connectionError = new MultipleErrors(mockedErrorMessage, [new Error('Connection failed to localhost:9092')])
 
-    callback(connectionError, undefined)
+    callback(connectionError)
   } as typeof consumer.listCommittedOffsets
 
   const stream = await consumer.consume({

--- a/test/clients/producer/producer.test.ts
+++ b/test/clients/producer/producer.test.ts
@@ -100,7 +100,8 @@ test('close should properly clean up resources and set closed state', t => {
     strictEqual(producer.closed, false)
 
     // Close the producer
-    producer.close(err => {
+    producer.close((...args) => {
+      const [err] = args
       if (err) {
         reject(err)
         return
@@ -140,7 +141,8 @@ test('should support both promise and callback API', async t => {
         messages: [{ topic: testTopic, value: Buffer.from('test-message') }],
         acks: ProduceAcks.LEADER
       },
-      (err, result) => {
+      (...args) => {
+        const [err, result] = args
         strictEqual(err, null)
         ok(Array.isArray(result.offsets), 'Should have offsets array')
         strictEqual(result.offsets?.length, 1)

--- a/test/network/connection-pool.test.ts
+++ b/test/network/connection-pool.test.ts
@@ -3,6 +3,7 @@ import { type AddressInfo, createServer as createNetworkServer, type Server, typ
 import { mock, test, type TestContext } from 'node:test'
 import {
   type Broker,
+  type Callback,
   type CallbackWithPromise,
   Connection,
   ConnectionPool,
@@ -108,7 +109,8 @@ test('get should handle connecting error and return same error', (t, done) => {
   // First call will start connecting
   const errors: (Error | null)[] = []
 
-  function callback (error: Error | null) {
+  const callback: Callback<Connection> = (...args) => {
+    const [error] = args
     errors.push(error)
 
     if (errors.length === 2) {
@@ -359,13 +361,14 @@ test('getFirstAvailable with callback parameter', async t => {
 
   // Mock get method to simulate failure
   mock.method(connectionPool, 'get', (_: Broker, callback: CallbackWithPromise<Connection>) => {
-    if (callback) callback(new Error('Connection failed'), undefined as unknown as Connection)
+    if (callback) callback(new Error('Connection failed'))
     return undefined
   })
 
   // Test with callback
   let callbackCalled = false
-  connectionPool.getFirstAvailable(brokers, err => {
+  connectionPool.getFirstAvailable(brokers, (...args) => {
+    const [err] = args
     callbackCalled = true
     ok(err instanceof Error)
   })

--- a/test/network/connection.test.ts
+++ b/test/network/connection.test.ts
@@ -376,7 +376,8 @@ test('Connection.send should enqueue request and process response', async t => {
       parser,
       true, // hasRequestHeaderTaggedFields
       true, // hasResponseHeaderTaggedFields
-      (err, data) => {
+      (...args) => {
+        const [err, data] = args
         if (err) {
           reject(err)
           return
@@ -429,7 +430,8 @@ test('Connection.send should handle requests with no response', async t => {
       }, // Dummy parser
       false, // hasRequestHeaderTaggedFields
       false, // hasResponseHeaderTaggedFields
-      (err, canWrite) => {
+      (...args) => {
+        const [err, canWrite] = args
         if (err) {
           reject(err)
           return
@@ -664,7 +666,8 @@ test('Connection should handle close with in-flight and after-drain requests', a
       },
       false,
       false,
-      err => {
+      (...args) => {
+        const [err] = args
         if (err) {
           reject(err)
         }
@@ -684,7 +687,8 @@ test('Connection should handle close with in-flight and after-drain requests', a
       },
       false,
       false,
-      err => {
+      (...args) => {
+        const [err] = args
         if (err) {
           reject(err)
         }
@@ -809,7 +813,8 @@ test('Connection should handle response parsing errors', async t => {
       parser,
       false,
       false,
-      err => {
+      (...args) => {
+        const [err] = args
         try {
           ok(err instanceof Error)
           strictEqual(err.message, 'Parser error')
@@ -868,7 +873,8 @@ test('Connection should handle response with tagged fields', async t => {
       parser,
       false, // hasRequestHeaderTaggedFields
       true, // hasResponseHeaderTaggedFields - Important!
-      (err, data) => {
+      (...args) => {
+        const [err, data] = args
         if (err) {
           reject(err)
           return
@@ -907,7 +913,8 @@ test('Connection should handle send when not connected', async t => {
       },
       false,
       false,
-      err => {
+      (...args) => {
+        const [err] = args
         try {
           ok(err instanceof NetworkError)
           strictEqual(err.message, 'Connection closed')
@@ -943,7 +950,7 @@ for (const mechanism of SASLMechanisms) {
   )
 }
 
-test('Connection.connect should reject unsupported mechanisms', async t => {
+test('Connection.connect should reject unsupported mechanisms', async () => {
   const connection = new Connection('clientId', {
     // @ts-expect-error - Purposefully using an invalid mechanism
     sasl: { mechanism: 'WHATEVER', username: 'admin', password: 'admin' }

--- a/test/protocol/reader.test.ts
+++ b/test/protocol/reader.test.ts
@@ -466,7 +466,8 @@ test('readVarIntBytes', () => {
     0, // This is the actual encoding for length 0 in VarInt
     // Buffer content is empty
     4, // This is the actual encoding for length 2 in VarInt
-    1, 2 // Buffer content [1, 2]
+    1,
+    2 // Buffer content [1, 2]
   ])
 
   const reader = new Reader(new DynamicBuffer(buffer))

--- a/test/protocol/sasl/plain.test.ts
+++ b/test/protocol/sasl/plain.test.ts
@@ -78,7 +78,8 @@ test('authenticate should create proper payload with username and password - cal
     mockConnection as any,
     'testuser',
     'testpass',
-    (error, result) => {
+    (...args) => {
+      const [error, result] = args
       ifError(error)
 
       // Verify the function was called

--- a/test/protocol/sasl/scram-sha.test.ts
+++ b/test/protocol/sasl/scram-sha.test.ts
@@ -185,6 +185,7 @@ test('authenticate should check for minimum required iterations', async () => {
     }
 
     // Should not get here
+    // @ts-ignore
     callback(null, {})
   }
 
@@ -241,7 +242,7 @@ test('authenticate should include username in initial message', async () => {
     firstMessage = payload!.toString()
 
     // Throw error to stop the authentication process
-    callback(new Error('Stop the test early'), undefined as unknown as SaslAuthenticateResponse)
+    callback(new Error('Stop the test early'))
   }
 
   const mockConnection = {}
@@ -272,7 +273,7 @@ test('authenticate should escape special characters in username', async () => {
     firstMessage = payload!.toString()
 
     // Throw error to stop the authentication process
-    callback(new Error('Stop the test early'), undefined as unknown as SaslAuthenticateResponse)
+    callback(new Error('Stop the test early'))
   }
 
   const mockConnection = {}
@@ -300,7 +301,7 @@ test('authenticate should escape special characters in username', async () => {
 // Test error handling for server nonce mismatch
 test('authenticate should check server nonce starts with client nonce', async () => {
   // Replace with implementation that returns invalid nonce
-  function api (_: Connection, payload: Buffer | null, callback: CallbackWithPromise<SaslAuthenticateResponse>) {
+  function api (_: Connection, __: Buffer | null, callback: CallbackWithPromise<SaslAuthenticateResponse>) {
     // First call - return server response with different nonce
     callback(null, {
       errorCode: 0,
@@ -404,7 +405,7 @@ test('authenticate should handle server failures', async () => {
       })
     } else {
       // Second call - return error
-      callback(new Error('Authentication failed'), undefined as unknown as SaslAuthenticateResponse)
+      callback(new Error('Authentication failed'))
     }
   }
 
@@ -488,7 +489,7 @@ test('authenticate should return the last response on successful authentication'
 
   let serverSignature: Buffer
 
-  function api (_: Connection, payload: Buffer | null, callback: CallbackWithPromise<SaslAuthenticateResponse>) {
+  function api (_: Connection, payload: Buffer, callback: CallbackWithPromise<SaslAuthenticateResponse>) {
     callsCount++
 
     if (callsCount === 1) {
@@ -502,7 +503,7 @@ test('authenticate should return the last response on successful authentication'
       callback(null, {
         errorCode: 0,
         errorMessage: null,
-        authBytes: `v=${serverSignature.toString('base64')}`,
+        authBytes: Buffer.from(`v=${serverSignature.toString('base64')}`),
         sessionLifetimeMs: 3600000n
       })
     }


### PR DESCRIPTION
This change changes the type signature of the callbacks so that
1. Superfluent `undefined`s for values do not have to be supplied in case errors are defined and
2. Combined type narrowing for error and value parameters is possible with rules (value is undefined if error is defined) and (value is defined if error is null).

Defining callbacks with `...args` and subsequent destructuring might be a little weird, but it adds more type safety. Let me know what you think about that.