### PR TITLE
Make messages stream breakable automatically

### DIFF
--- a/src/clients/consumer/types.ts
+++ b/src/clients/consumer/types.ts
@@ -62,6 +62,14 @@ export const MessagesStreamFallbackModes = {
 export type MessagesStreamFallbackMode = keyof typeof MessagesStreamFallbackModes
 export type MessagesStreamFallbackModeValue =
   (typeof MessagesStreamFallbackModes)[keyof typeof MessagesStreamFallbackModes]
+
+export const MessagesStreamBreakModes = {
+  MANUAL: 'manual',
+  AFTER_FIRST_BATCH: 'after-first-batch',
+} as const
+export type MessagesStreamBreakMode = keyof typeof MessagesStreamBreakModes
+export type MessagesStreamBreakModeValue = (typeof MessagesStreamBreakModes)[keyof typeof MessagesStreamBreakModes]
+
 export interface GroupOptions {
   sessionTimeout?: number
   rebalanceTimeout?: number
@@ -83,6 +91,7 @@ export interface ConsumeBaseOptions<Key, Value, HeaderKey, HeaderValue> {
 export interface StreamOptions {
   topics: string[]
   mode?: MessagesStreamModeValue
+  breakMode?: MessagesStreamBreakModeValue
   fallbackMode?: MessagesStreamFallbackModeValue
   offsets?: TopicWithPartitionAndOffset[]
   onCorruptedMessage?: CorruptedMessageHandler


### PR DESCRIPTION
This change introduces an option `breakMode` to the `MessagesStream` class and likewise to the options of the consumer's `consume` method. This option accepts one of two allowed values:

1. 'manual' -> This mode lets the 'MessageStream' work like before. The stream does not terminate by itself, and termination has to be done manually, either within the async while loop or within the `data` event handler.
2. 'after-first-batch' -> This mode lets the `MessageStream` class issue only one fetch request per leader of a topic's partition without requeueing more requests. After all issued requests are completed, the stream ends and returns all the collected messages.

Additionally, the `MessagesStream` class gets a new method `collect` which returns an array of all the messages that are collectable via 2. This method is only supported if the `breakMode` option is set to 'after-first-batch'.

Related:
- https://github.com/platformatic/kafka/issues/71