### PR TITLE
Fix wrong topics in metadata requests

### DIFF
--- a/src/clients/base/base.ts
+++ b/src/clients/base/base.ts
@@ -252,7 +252,7 @@ export class Base<OptionsType extends BaseOptions = BaseOptions> extends EventEm
     const autocreateTopics = options.autocreateTopics ?? this[kOptions].autocreateTopics
 
     this[kPerformDeduplicated](
-      'metadata',
+      `metadata:${options.topics.join(',')}`,
       deduplicateCallback => {
         this[kPerformWithRetry]<MetadataResponse>(
           'metadata',

--- a/src/clients/consumer/consumer.ts
+++ b/src/clients/consumer/consumer.ts
@@ -938,6 +938,7 @@ export class Consumer<Key = Buffer, Value = Buffer, HeaderKey = Buffer, HeaderVa
     let joinNeeded = this.memberId === null
 
     if (trackTopics) {
+      this.topics.untrackAll(...this.topics.current)
       for (const topic of options.topics) {
         if (this.topics.track(topic)) {
           joinNeeded = true

--- a/test/clients/base/base.test.ts
+++ b/test/clients/base/base.test.ts
@@ -249,6 +249,26 @@ test('metadata should fetch topic metadata', async t => {
   strictEqual(Array.isArray(firstPartition.replicas), true)
 })
 
+test('metadata requests with different topics should stay independent', async t => {
+  const client = createBase(t)
+
+  const testTopic1 = `test-topic-${randomUUID()}`
+  const testTopic2 = `test-topic-${randomUUID()}`
+
+  client.metadata({
+    topics: [testTopic1],
+    autocreateTopics: true
+  })
+
+  const mp2 = client.metadata({
+    topics: [testTopic2],
+    autocreateTopics: true
+  })
+
+  const metadata2 = await mp2
+  strictEqual(metadata2.topics.has(testTopic2), true)
+})
+
 test('metadata should cache metadata according to metadataMaxAge', async t => {
   const client = createBase(t, {
     metadataMaxAge: 1000 // 1 second

--- a/test/clients/consumer/messages-stream.test.ts
+++ b/test/clients/consumer/messages-stream.test.ts
@@ -859,7 +859,7 @@ test('should properly handle close', async t => {
   await stream.close()
 })
 
-test.only('should properly handle deleting topics in between', async t => {
+test('should properly handle deleting topics in between', async t => {
   const admin = createAdmin(t)
   const topic1 = await createTopic(t)
   const consumer = createConsumer(t)

--- a/test/clients/consumer/messages-stream.test.ts
+++ b/test/clients/consumer/messages-stream.test.ts
@@ -865,7 +865,7 @@ test.only('should properly handle deleting topics in between', async t => {
   const consumer = createConsumer(t)
   await admin.createTopics({ topics: [topic1] })
 
-  await consumer.consume({
+  const stream1 = await consumer.consume({
     topics: [topic1],
     mode: MessagesStreamModes.EARLIEST,
     autocommit: true,
@@ -877,12 +877,15 @@ test.only('should properly handle deleting topics in between', async t => {
   const topic2 = await createTopic(t)
   await admin.createTopics({ topics: [topic2] })
 
-  await consumer.consume({
+  const stream2 = await consumer.consume({
     topics: [topic2],
     mode: MessagesStreamModes.EARLIEST,
     autocommit: true,
     maxWaitTime: 1000
   })
+
+  stream1.destroy()
+  stream2.destroy()
 
   // For some unknown reason this is necessary, otherwise the test hangs
   // I guess the previous test had the same issue


### PR DESCRIPTION
`consume` is failing in the following workflow:

1. Create topic A
2. Consume on topic A
3. Delete topic A
4. Create topic B
5. Consume on topic B

The issue is that the consumer still holds a reference to the deleted topic, and metadata requests in the `#fetch` method fail as metadata for this topic is not available.

This PR solves this issue by untracking all topics before retracking the target topics inside the function `#performConsume` in the `Consumer` class.

Edit: This change also disentangles metadata requests with different topics. Previously, metadata requests were deduplicated independently on the topics that were requested, potentially leading to wrong results for subsequent metadata requests. Deduplication is now done based on requested topics.