### PR TITLE
Handle empty collection in runConcurrentCallbacks

### DIFF
--- a/src/apis/callbacks.ts
+++ b/src/apis/callbacks.ts
@@ -56,6 +56,10 @@ export function runConcurrentCallbacks<ReturnType> (
     }
   }
 
+  if (remaining === 0) {
+    callback(null, results)
+  }
+
   for (const item of collection) {
     operation(item, operationCallback.bind(null, i++))
   }

--- a/test/clients/callbacks.test.ts
+++ b/test/clients/callbacks.test.ts
@@ -143,7 +143,7 @@ test('runConcurrentCallbacks handles errors correctly', async () => {
   })
 })
 
-test('runConcurrentCallbacks with empty collection', () => {
+test('runConcurrentCallbacks with empty collection', { timeout: 200 }, (_, done) => {
   const testArray: string[] = []
 
   // With empty collection, the callback should be called immediately
@@ -157,6 +157,7 @@ test('runConcurrentCallbacks with empty collection', () => {
     (error, results) => {
       strictEqual(error, null)
       deepStrictEqual(results, [])
+      done()
     }
   )
 })


### PR DESCRIPTION
The implementation missed to handle the case of an empty collection since the corresponding test was broken.
