### PR TITLE
Ensure partition filter matches topic's partitions

### DIFF
--- a/test/clients/consumer/consumer.test.ts
+++ b/test/clients/consumer/consumer.test.ts
@@ -1545,6 +1545,19 @@ test('listOffsetsWithTimestamps should fail when consumer is closed', async t =>
   }
 })
 
+test('listOffsetsWithTimestamps should fail if partition does not exist', async t => {
+  const consumer = createConsumer(t)
+  const topic = await createTopic(t, true)
+
+  try {
+    await consumer.listOffsetsWithTimestamps({ topics: [topic], partitions: { [topic]: [0, 4] } })
+    throw new Error('Expected error not thrown')
+  } catch (error) {
+    strictEqual(error instanceof UserError, true)
+    strictEqual(error.message, `Specified partition(s) not found in topic ${topic}`)
+  }
+})
+
 test('listCommittedOffsets should return committed offset values for topics and partitions and support diagnostic channels', async t => {
   const consumer = createConsumer(t)
   const topic = await createTopic(t, true, 2)


### PR DESCRIPTION
Method listOffsetsWithTimestamps will silently ignore partitions specified as filter if they are not actually part of the topic. On the other hand, specifying a topic that does not exist will raise an error. Hence, this patch introduces an error that notifies the caller about the issue.
