### PR TITLE
fix: appendArray, appendMap null for classic encoding

### DIFF
--- a/src/protocol/writer.ts
+++ b/src/protocol/writer.ts
@@ -201,14 +201,14 @@ export class Writer {
     return this
   }
 
-  appendArray<InputType>(
+  appendArray<InputType> (
     value: InputType[] | null | undefined,
     entryWriter: EntryWriter<InputType>,
     compact: boolean = true,
     appendTrailingTaggedFields = true
   ): this {
     if (value == null) {
-      return compact ? this.appendUnsignedVarInt(0) : this.appendInt32(0)
+      return compact ? this.appendUnsignedVarInt(0) : this.appendInt32(-1)
     }
 
     const length = value.length
@@ -230,14 +230,14 @@ export class Writer {
     return this
   }
 
-  appendMap<Key, Value>(
+  appendMap<Key, Value> (
     value: Map<Key, Value> | null | undefined,
     entryWriter: EntryWriter<[Key, Value]>,
     compact: boolean = true,
     appendTrailingTaggedFields = true
   ): this {
     if (value == null) {
-      return compact ? this.appendUnsignedVarInt(0) : this.appendInt32(0)
+      return compact ? this.appendUnsignedVarInt(0) : this.appendInt32(-1)
     }
 
     const length = value.size
@@ -260,7 +260,7 @@ export class Writer {
     return this
   }
 
-  appendVarIntArray<InputType>(value: InputType[] | null | undefined, entryWriter: EntryWriter<InputType>): this {
+  appendVarIntArray<InputType> (value: InputType[] | null | undefined, entryWriter: EntryWriter<InputType>): this {
     if (value == null) {
       return this.appendVarInt(0)
     }
@@ -274,7 +274,10 @@ export class Writer {
     return this
   }
 
-  appendVarIntMap<Key, Value>(value: Map<Key, Value> | null | undefined, entryWriter: EntryWriter<[Key, Value]>): this {
+  appendVarIntMap<Key, Value> (
+    value: Map<Key, Value> | null | undefined,
+    entryWriter: EntryWriter<[Key, Value]>
+  ): this {
     if (value == null) {
       return this.appendVarInt(0)
     }

--- a/test/protocol/writer.test.ts
+++ b/test/protocol/writer.test.ts
@@ -578,7 +578,7 @@ test('appendArray', () => {
   strictEqual(buffer[pos++], 0) // Tagged field
 
   // Non-compact null array (length 0 as int32)
-  strictEqual(buffer.readInt32BE(pos), 0)
+  strictEqual(buffer.readInt32BE(pos), -1)
   pos += 4
 
   // Non-compact array [4, 5] (length 2 as int32, then 2 elements + tagged fields)
@@ -625,7 +625,7 @@ test('appendArray - undefined', () => {
   strictEqual(buffer[0], 0)
 
   // Non-compact undefined array (length 0 as int32)
-  strictEqual(buffer.readInt32BE(1), 0)
+  strictEqual(buffer.readInt32BE(1), -1)
 })
 
 test('appendMap', () => {
@@ -707,7 +707,7 @@ test('appendMap', () => {
   strictEqual(buffer[pos++], 0) // Tagged field
 
   // Non-compact null map (length 0 as int32)
-  strictEqual(buffer.readInt32BE(pos), 0)
+  strictEqual(buffer.readInt32BE(pos), -1)
   pos += 4
 
   // Non-compact map with one entry (length 1 as int32, then 1 element + tagged field)
@@ -788,7 +788,7 @@ test('appendMap - undefined', () => {
   strictEqual(buffer[0], 0)
 
   // Non-compact undefined map (length 0 as int32)
-  strictEqual(buffer.readInt32BE(1), 0)
+  strictEqual(buffer.readInt32BE(1), -1)
 })
 
 test('appendVarIntArray', () => {


### PR DESCRIPTION

I was fighting one of tests for metadata-v8  for RedPanda and came across this Kafka [specs](https://kafka.apache.org/23/generated/protocol_types.html?utm_source=chatgpt.com).

`ARRAY` and `MAP`, when **null**, use a signed `INT32` length of  `-1`; non-null arrays/maps use lengths ≥ 0  

