### PR TITLE
fix: Correctly use roundrobin when no key is available.

### DIFF
--- a/src/clients/producer/producer.ts
+++ b/src/clients/producer/producer.ts
@@ -337,7 +337,7 @@ export class Producer<Key = Buffer, Value = Buffer, HeaderKey = Buffer, HeaderVa
           partition = murmur2(key) >>> 0
         } else {
           // Use the roundrobin
-          partition = this.#partitionsRoundRobin.postIncrement(topic, 1, -1)
+          partition = this.#partitionsRoundRobin.postIncrement(topic, 1, 0)
         }
       } else {
         partition = message.partition

--- a/test/clients/producer/producer.test.ts
+++ b/test/clients/producer/producer.test.ts
@@ -508,6 +508,27 @@ test('send should support messages with headers', async t => {
   strictEqual(result2.offsets?.length, 1)
 })
 
+test('send should support messages with no key and no partition', async t => {
+  const topic = await createTopic(t, true, 4)
+  const producer = createProducer(t)
+
+  const results = await producer.send({
+    messages: [
+      {
+        topic,
+        value: Buffer.from('message-value')
+      },
+      {
+        topic,
+        value: Buffer.from('message-value')
+      }
+    ]
+  })
+
+  strictEqual(results.offsets![0].partition, 0)
+  strictEqual(results.offsets![1].partition, 1)
+})
+
 test('send should support no response', async t => {
   const producer = createProducer(t)
   const testTopic = await createTopic(t)


### PR DESCRIPTION
Fixes #69.