### PR TITLE
import package.json as module

### DIFF
--- a/src/clients/base/options.ts
+++ b/src/clients/base/options.ts
@@ -1,9 +1,7 @@
-import { readFileSync } from 'node:fs'
 import { SASLMechanisms } from '../../apis/enumerations.ts'
 import { ajv } from '../../utils.ts'
 import { type BaseOptions } from './types.ts'
-
-const packageJson = JSON.parse(readFileSync(new URL('../../../package.json', import.meta.url), 'utf-8'))
+import packageJson from '../../../package.json' with { type: 'json' };
 
 // Note: clientSoftwareName can only contain alphanumeric characters, hyphens and dots
 export const clientSoftwareName = 'platformatic-kafka'


### PR DESCRIPTION
Imports package.json as a JSON module at build time instead of using fs at runtime

Allows bundlers to handle the import

Fixes #91