### PR TITLE
fix(message-stream): use correct overload signature

### DIFF
--- a/src/clients/consumer/messages-stream.ts
+++ b/src/clients/consumer/messages-stream.ts
@@ -146,7 +146,7 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
     notifyCreation('messages-stream', this)
   }
 
-  close (callback?: CallbackWithPromise<void>): void
+  close (callback: CallbackWithPromise<void>): void
   close (): Promise<void>
   close (callback?: CallbackWithPromise<void>): void | Promise<void> {
     if (!callback) {


### PR DESCRIPTION
I noticed that the overload signature is the same as the index signature for the `close` method of the `MessagesStream` class. 
This results in Typescript infering the type of `stream.close()` as `void` instead of `Promise<void>`

This change aligns the overload signature with the way it is done in the `Base` class - [ref](https://github.com/platformatic/kafka/blob/7caa08ecda880e3769e4e9fb2cfae57adc4971f2/src/clients/base/base.ts#L146-L148)