### PR TITLE
fix: prevent consumer crash when reading incomplete record batches

### DIFF
--- a/src/apis/consumer/fetch-v15.ts
+++ b/src/apis/consumer/fetch-v15.ts
@@ -186,7 +186,12 @@ export function parseResponse (
             const recordsBatchesReader = Reader.from(r.buffer.subarray(r.position, r.position + recordsSize))
             partition.records = []
             do {
-              partition.records.push(readRecordsBatch(recordsBatchesReader))
+              const batch = readRecordsBatch(recordsBatchesReader)
+              if (batch) {
+                partition.records.push(batch)
+              } else {
+                break
+              }
             } while (recordsBatchesReader.position < recordsSize)
 
             r.skip(recordsSize)

--- a/src/apis/consumer/fetch-v16.ts
+++ b/src/apis/consumer/fetch-v16.ts
@@ -186,7 +186,12 @@ export function parseResponse (
             const recordsBatchesReader = Reader.from(r.buffer.subarray(r.position, r.position + recordsSize))
             partition.records = []
             do {
-              partition.records.push(readRecordsBatch(recordsBatchesReader))
+              const batch = readRecordsBatch(recordsBatchesReader)
+              if (batch) {
+                partition.records.push(batch)
+              } else {
+                break
+              }
             } while (recordsBatchesReader.position < recordsSize)
 
             r.skip(recordsSize)

--- a/src/apis/consumer/fetch-v17.ts
+++ b/src/apis/consumer/fetch-v17.ts
@@ -186,7 +186,12 @@ export function parseResponse (
             const recordsBatchesReader = Reader.from(r.buffer.subarray(r.position, r.position + recordsSize))
             partition.records = []
             do {
-              partition.records.push(readRecordsBatch(recordsBatchesReader))
+              const batch = readRecordsBatch(recordsBatchesReader)
+              if (batch) {
+                partition.records.push(batch)
+              } else {
+                break
+              }
             } while (recordsBatchesReader.position < recordsSize)
 
             r.skip(recordsSize)

--- a/src/protocol/reader.ts
+++ b/src/protocol/reader.ts
@@ -409,4 +409,8 @@ export class Reader {
       this.skip(length)
     }
   }
+
+  canRead (length: number): boolean {
+    return this.buffer.length - this.position >= length
+  }
 }

--- a/test/protocol/records.test.ts
+++ b/test/protocol/records.test.ts
@@ -389,7 +389,7 @@ test('readRecordsBatch should throw on unsupported compression bitmask', () => {
   // Create a mock batch with an invalid compression bitmask
   const writer = Writer.create()
     .appendInt64(0n) // firstOffset
-    .appendInt32(100) // length
+    .appendInt32(49) // length
     .appendInt32(0) // partitionLeaderEpoch
     .appendInt8(2) // magic
     .appendUnsignedInt32(0) // crc


### PR DESCRIPTION
Added batch buffer boundary checks to prevent crash on incomplete batch. Fixes #108.

I'm not sure if this is a proper fix, or maybe something needs to be adjusted in `connection.ts` for reader to not get incomplete batch in the first place.

@ShogunPanda waiting for your feedback and I'll add/fix tests