### PR TITLE
draft of per-partition streaming

### DIFF
--- a/src/clients/consumer/types.ts
+++ b/src/clients/consumer/types.ts
@@ -3,6 +3,7 @@ import { type FetchIsolationLevel } from '../../apis/enumerations.ts'
 import { type KafkaRecord, type Message } from '../../protocol/records.ts'
 import { type BaseOptions, type ClusterMetadata, type TopicWithPartitionAndOffset } from '../base/types.ts'
 import { type Deserializers } from '../serde.ts'
+import type { MessagesStream } from './messages-stream.ts'
 
 export interface GroupProtocolSubscription {
   name: string
@@ -99,6 +100,10 @@ export interface StreamOptions {
 export type ConsumeOptions<Key, Value, HeaderKey, HeaderValue> = StreamOptions &
   ConsumeBaseOptions<Key, Value, HeaderKey, HeaderValue> &
   GroupOptions
+
+export type ConsumeByPartitionOptions<Key, Value, HeaderKey, HeaderValue> = ConsumeOptions<Key, Value, HeaderKey, HeaderValue> & {
+  onAssignmentChange: (streams: Map<string, MessagesStream<Key, Value, HeaderKey, HeaderValue>>) => void
+}
 
 export type ConsumerOptions<Key, Value, HeaderKey, HeaderValue> = BaseOptions & { groupId: string } & GroupOptions &
   ConsumeBaseOptions<Key, Value, HeaderKey, HeaderValue>


### PR DESCRIPTION
working on a rough pass at #128 

current approach is intended to require minimal refactoring while achieving the developer-facing API i think probably will work best. some tests are not working yet, i will work on getting existing tests to pass and then add some for this new behavior if things seem reasonable.

as i dug into how to make multi-topic consumption and rebalancing work, i adjusted the DX from my initial code example in #128. the idea is to implement a new method, `consumeByPartition`, that upon initial consume returns a map of topic-partition streams where the key is of the form `topic:partition`. after a rebalance/rejoin, IF the assignment has changed such that the downstream app code needs to account for added/removed partitions, then a required `onAssignmentChange()` callback is called with a new map containing the full set of topic-partition streams:

```typescript
let streamMap = consumer.consumeByPartition({
  topics: ['foo'],
  onAssignmentChange: (newStreamMap) => {
    for (const [topicPartition, stream] of newStreamMap) {
      const existingStream = streamMap.get(topicPartition)

      if (!existingStream) {
        // spin up downstream work that consumes the newly assigned topic-partition stream
      }

      streamMap = newStreams
    }
  }
})

for (const [topicPartition, stream] of streamMap) {
  const [topic, partition] = topicPartition.split(':')

  // spin up downstream work that consumes each topic-partition stream after initial join
}

```

when the streams for individual topic-partitions detect that the consumer no longer has an assignment for their topic-partition after a join/rebalance, they automatically close themselves, so in most cases developers do not have to write bespoke logic for cleaning up removed partition streams. if their consuming app code handles the stream ending correctly, their code will do the right thing by default. the case that needs hand-written logic after a rebalance is creating new stream consumers in app code when new partitions are assigned. giving developers a full map of the new topic-partition assignments allows them to serve any advanced/unusual needs they may have around comparing old/new streams.

i originally considered adding a mode/config option to the existing `consume()` method, and also considered adding a config at the `Consumer` class level. but in both cases mixing the type signatures and logic between the two modes was complex, and i didn't feel that complexity was buying a whole lot in terms of DX. i also thing splitting it into a separate method has the nice side benefit of keeping the normal `consume()` api very easy to read in getting started examples so the library stays approachable, while allowing more advanced users to reach for this method if they actually need it.

the primary thing that i'd like to see improved about performance is that calls to listOffsets, listCommittedOffsets, and fetch all still operate at the individual stream level, which means that the number of requests to those operations now increases with the number of partitions instead of one-per-leader. I think to resolve that we'd have to move some of the logic for listing offsets/commits and doing fetching up above the level of individual MessageStreams and coordinate them more. Given that the main goal here is to decouple fetching backpressure between topic-partitions, we likely don't want to fully consolidate fetching together into one coordinated thing, but i can imagine there are better ways to do it than the naive way it works right now. listing offsets/commits only needs to happen on initial join and rebalancing so i think that one is the more important candidate for optimization since ideally we only make one call per rejoin.