### PR TITLE
fix: correct consumer.fetch options typing and docs

### DIFF
--- a/docs/consumer.md
+++ b/docs/consumer.md
@@ -108,10 +108,14 @@ The return value is the raw response from Kafka.
 
 Options:
 
-| Property | Type                  | Description                      |
-| -------- | --------------------- | -------------------------------- |
-| node     | number                | Node to consume data from.       |
-| topics   | `FetchRequestTopic[]` | Topic and partitions to consume. |
+| Property       | Type                  | Default          | Description                                                                                                                                                                      |
+| -------------- | --------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| node           | number                |                  | Node to consume data from.                                                                                                                                                       |
+| topics         | `FetchRequestTopic[]` |                  | Topic and partitions to consume.                                                                                                                                                 |
+| minBytes       | `number`              | `1`              | Minimum amount of data the brokers should return. The value might not be respected by Kafka.                                                                                     |
+| maxBytes       | `number`              | 10MB             | Maximum amount of data the brokers should return. The value might not be respected by Kafka.                                                                                     |
+| maxWaitTime    | `number`              | 5 seconds        | Maximum amount of time in milliseconds the broker will wait before sending a response to a fetch request.                                                                        |
+| isolationLevel | `string`              | `READ_COMMITTED` | Kind of isolation applied to fetch requests. It can be used to only read producers-committed messages.<br/><br/> The valid values are defined in the `FetchIsolationLevels` enumeration. |
 
 Note that all the partitions must be hosted on the node otherwise the operation will fail.
 

--- a/src/clients/consumer/types.ts
+++ b/src/clients/consumer/types.ts
@@ -103,14 +103,13 @@ export type ConsumeOptions<Key, Value, HeaderKey, HeaderValue> = StreamOptions &
 export type ConsumerOptions<Key, Value, HeaderKey, HeaderValue> = BaseOptions & { groupId: string } & GroupOptions &
   ConsumeBaseOptions<Key, Value, HeaderKey, HeaderValue>
 
-export type FetchOptions<Key, Value, HeaderKey, HeaderValue> = Omit<
+export type FetchOptions<Key, Value, HeaderKey, HeaderValue> = Pick<
   ConsumeBaseOptions<Key, Value, HeaderKey, HeaderValue>,
-  'deserializers'
-> &
-  GroupOptions & {
-    node: number
-    topics: FetchRequestTopic[]
-  }
+  'minBytes' | 'maxBytes' | 'maxWaitTime' | 'isolationLevel'
+> & {
+  node: number
+  topics: FetchRequestTopic[]
+}
 
 export interface CommitOptionsPartition extends TopicWithPartitionAndOffset {
   leaderEpoch: number


### PR DESCRIPTION
## Summary
- Fixed incorrect `FetchOptions` type that was allowing unused properties from `GroupOptions`
- Updated documentation to reflect all available options for the `fetch` method

## Changes
The `FetchOptions` type was incorrectly including all properties from `GroupOptions` (sessionTimeout, rebalanceTimeout, heartbeatInterval, protocols, partitionAssigner), which are not used by the `fetch` method.

Updated the type to only allow the properties that are actually used by the implementation:
- `topics` (required)
- `node` (required)
- `maxWaitTime` (optional)
- `minBytes` (optional)
- `maxBytes` (optional)
- `isolationLevel` (optional)

Also updated the `docs/consumer.md` to document all available options for the fetch method, not just `topics` and `node`.

## Test plan
- [x] Build succeeds
- [x] Existing tests pass
- [x] Type safety improved - TypeScript now correctly prevents passing unused options

Fixes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)