### PR TITLE
fix: fix ConsumerGroupHeartbeat v0

### DIFF
--- a/src/apis/consumer/consumer-group-heartbeat-v0.ts
+++ b/src/apis/consumer/consumer-group-heartbeat-v0.ts
@@ -34,7 +34,7 @@ export interface ConsumerGroupHeartbeatResponse {
   memberId: NullableString
   memberEpoch: number
   heartbeatIntervalMs: number
-  assignment: ConsumerGroupHeartbeatResponseAssignment[]
+  assignment: ConsumerGroupHeartbeatResponseAssignment | null
 }
 
 /*
@@ -103,16 +103,14 @@ export function parseResponse (
     memberId: reader.readNullableString(),
     memberEpoch: reader.readInt32(),
     heartbeatIntervalMs: reader.readInt32(),
-    assignment: reader.readArray(r => {
-      return {
-        topicPartitions: r.readArray(r => {
-          return {
-            topicId: r.readUUID(),
-            partitions: r.readArray(r => r.readInt32(), true, false)
-          }
-        })
-      } as ConsumerGroupHeartbeatResponseAssignment
-    })
+    assignment: reader.readNullableStruct(() => ({
+      topicPartitions: reader.readArray(r => {
+        return {
+          topicId: r.readUUID(),
+          partitions: r.readArray(r => r.readInt32(), true, false)
+        }
+      })
+    }))
   }
 
   if (response.errorCode !== 0) {

--- a/src/protocol/reader.ts
+++ b/src/protocol/reader.ts
@@ -402,6 +402,13 @@ export class Reader {
     return map
   }
 
+  readNullableStruct<V> (reader: () => V): V | null {
+    if (this.readInt8() === -1) {
+      return null
+    }
+    return reader()
+  }
+
   // TODO(ShogunPanda): Tagged fields are not supported yet
   readTaggedFields (): void {
     const length = this.readVarInt()


### PR DESCRIPTION
Fix ConsumerGroupHeartbeat response parsing.

## Changes
* Change `ConsumerGroupHeartbeat` response `.assignment` to a nullable struct from an array.
* Add `reader.readNullableStruct` method, following [KIP-893](https://cwiki.apache.org/confluence/display/KAFKA/KIP-893%3A+The+Kafka+protocol+should+support+nullable+structs), which adds nullable struct support.

This is part of https://github.com/platformatic/kafka/pull/133 . 