### PR TITLE
fix: Fix mixed metadata callbacks in kPerformDeduplicated

### DIFF
--- a/src/clients/base/base.ts
+++ b/src/clients/base/base.ts
@@ -356,7 +356,8 @@ export class Base<OptionsType extends BaseOptions = BaseOptions> extends EventEm
     const autocreateTopics = options.autocreateTopics ?? this[kOptions].autocreateTopics
 
     this[kPerformDeduplicated](
-      'metadata',
+      // Unique key to avoid mixing callbacks
+      `metadata-${options.topics.sort().join(',')}-${autocreateTopics}-${options.forceUpdate}`,
       deduplicateCallback => {
         this[kPerformWithRetry]<MetadataResponse>(
           'metadata',


### PR DESCRIPTION
## Related issue
https://github.com/platformatic/kafka/issues/109

## Changes
- Implement universal `operationId` when fetching metadata through kPerformDeduplicated