### PR TITLE
Handle request serialisation errors asynchronously

### DIFF
--- a/src/network/connection.ts
+++ b/src/network/connection.ts
@@ -350,7 +350,7 @@ export class Connection extends EventEmitter {
     } catch (err) {
       diagnostic.error = err as Error
       connectionsApiChannel.error.publish(diagnostic)
-      throw err
+      return callback(err, undefined as unknown as ReturnType)
     }
 
     writer.appendFrom(payload).prependLength()

--- a/test/network/connection.test.ts
+++ b/test/network/connection.test.ts
@@ -752,8 +752,7 @@ test('Connection should handle request serialization errors', async t => {
     throw new Error('Parser error')
   }
 
-  // Send a request
-  await throws(() =>
+  const requestPromise = new Promise((resolve, reject) => {
     connection.send(
       0, // apiKey
       0, // apiVersion
@@ -761,8 +760,19 @@ test('Connection should handle request serialization errors', async t => {
       parser,
       false,
       false,
-      () => {}
-    ))
+      (err: any) => {
+        if (err) {
+          reject(err)
+        }
+
+        resolve(null)
+      }
+    )
+  })
+
+  await rejects(() => requestPromise, {
+    message: 'Serialization error'
+  })
 
   verifyTracingChannel()
 })


### PR DESCRIPTION
Exceptions thrown from the `createPayload()` method in `connections.ts` are not propagated up the callback hierarchy and hence cannot be handled by a try/catch block around the client method invocation, but end up as uncaught exceptions. This happens e.g. when support for an optional compression scheme like `lz4` is not actually installed.

This change fixes the issue by passing the error to the callback instead of re-throwing it.