### PR TITLE
Do not deduplicate topic creations and deletions irrespectively of topics

### DIFF
--- a/src/clients/admin/admin.ts
+++ b/src/clients/admin/admin.ts
@@ -539,7 +539,7 @@ export class Admin extends Base<AdminOptions> {
     }
 
     this[kPerformDeduplicated](
-      'createTopics',
+      `createTopics-${options.topics.join(',')}`,
       deduplicateCallback => {
         this[kPerformWithRetry](
           'createTopics',
@@ -597,7 +597,7 @@ export class Admin extends Base<AdminOptions> {
 
   #deleteTopics (options: DeleteTopicsOptions, callback: CallbackWithPromise<void>): void {
     this[kPerformDeduplicated](
-      'deleteTopics',
+      `deleteTopics-${options.topics.join(',')}`,
       deduplicateCallback => {
         this[kPerformWithRetry](
           'deleteTopics',


### PR DESCRIPTION
As of now creating and deleting multiple topics in a row will ignore most of the topics except the first one. This is due to deduplication that is done based on operation alone without considering the target topics. This change incorporates topic data into the deduplication to avoid the aforementioned issue.

on-behalf-of: @SAP ospo@sap.com
Signed-off-by: Peter Lehnhardt <peter.lehnhardt@sap.com>