### PR TITLE
Adjust default values for replicas and partitions

### DIFF
--- a/src/clients/admin/admin.ts
+++ b/src/clients/admin/admin.ts
@@ -444,8 +444,9 @@ export class Admin extends Base<AdminOptions> {
   }
 
   #createTopics (options: CreateTopicsOptions, callback: CallbackWithPromise<CreatedTopic[]>): void {
-    const numPartitions = options.partitions ?? 1
-    const replicationFactor = options.replicas ?? 1
+    // -1 is required if manual assignments are used. If no manual assignments are used, -1 will default to broker settings.
+    const numPartitions = options.partitions ?? -1
+    const replicationFactor = options.replicas ?? -1
     const assignments: CreateTopicsRequestTopicAssignment[] = []
     const configs = options.configs ?? []
 

--- a/test/clients/admin/admin.test.ts
+++ b/test/clients/admin/admin.test.ts
@@ -439,8 +439,6 @@ test('createTopics using assignments', async t => {
   // Create a topic with a single partition - leader will be automatically assigned
   const created = await admin.createTopics({
     topics: [topicName],
-    partitions: -1,
-    replicas: -1,
     assignments: brokerIds.map((brokerId, i) => ({ partition: i, brokers: [brokerId] }))
   })
 


### PR DESCRIPTION
Requests to create topics will fail if you supply assignments and partitions/replicas together. If you don't supply a value for partitions/replicas at all, default values of 1 will be used which also leads to topic creation failures. Here, the default values for the two settings are changed to -1 so that topic creations do not fail due to conflicting settings. Furthermore, this has the benefit of using the default values set inside the Kafka cluster.

Related:
- https://github.com/tulios/kafkajs/pull/1305

on-behalf-of: @SAP ospo@sap.com
Signed-off-by: Peter Lehnhardt <peter.lehnhardt@sap.com>