### PR TITLE
Make error messages from the server available

### DIFF
--- a/src/apis/admin/alter-client-quotas-v1.ts
+++ b/src/apis/admin/alter-client-quotas-v1.ts
@@ -106,7 +106,7 @@ export function parseResponse (
       }
 
       if (entry.errorCode !== 0) {
-        errors.push([`/entries/${i}`, entry.errorCode])
+        errors.push([`/entries/${i}`, [entry.errorCode, entry.errorMessage]])
       }
 
       return entry

--- a/src/apis/admin/alter-configs-v2.ts
+++ b/src/apis/admin/alter-configs-v2.ts
@@ -73,14 +73,15 @@ export function parseResponse (
     throttleTimeMs: reader.readInt32(),
     responses: reader.readArray((r, i) => {
       const errorCode = r.readInt16()
+      const errorMessage = r.readNullableString()
 
       if (errorCode !== 0) {
-        errors.push([`/responses/${i}`, errorCode])
+        errors.push([`/responses/${i}`, [errorCode, errorMessage]])
       }
 
       return {
         errorCode,
-        errorMessage: r.readNullableString(),
+        errorMessage,
         resourceType: r.readInt8(),
         resourceName: r.readString()
       }

--- a/src/apis/admin/alter-partition-reassignments-v0.ts
+++ b/src/apis/admin/alter-partition-reassignments-v0.ts
@@ -76,15 +76,16 @@ export function parseResponse (
 
   const throttleTimeMs = reader.readInt32()
   const errorCode = reader.readInt16()
+  const errorMessage = reader.readNullableString()
 
   if (errorCode !== 0) {
-    errors.push(['', errorCode])
+    errors.push(['', [errorCode, errorMessage ?? '']])
   }
 
   const response: AlterPartitionReassignmentsResponse = {
     throttleTimeMs,
     errorCode,
-    errorMessage: reader.readNullableString(),
+    errorMessage,
     responses: reader.readArray((r, i) => {
       return {
         name: r.readString(),
@@ -96,7 +97,7 @@ export function parseResponse (
           }
 
           if (partition.errorCode !== 0) {
-            errors.push([`responses/${i}/partitions/${j}`, partition.errorCode])
+            errors.push([`responses/${i}/partitions/${j}`, [partition.errorCode, partition.errorMessage]])
           }
 
           return partition

--- a/src/apis/admin/alter-partition-v3.ts
+++ b/src/apis/admin/alter-partition-v3.ts
@@ -104,7 +104,7 @@ export function parseResponse (
   const errorCode = reader.readInt16()
 
   if (errorCode !== 0) {
-    errors.push(['/', errorCode])
+    errors.push(['/', [errorCode, null]])
   }
 
   const response: AlterPartitionResponse = {
@@ -125,7 +125,7 @@ export function parseResponse (
           }
 
           if (partition.errorCode !== 0) {
-            errors.push([`/topics/${i}/partitions/${j}`, partition.errorCode])
+            errors.push([`/topics/${i}/partitions/${j}`, [partition.errorCode, null]])
           }
 
           return partition

--- a/src/apis/admin/alter-replica-log-dirs-v2.ts
+++ b/src/apis/admin/alter-replica-log-dirs-v2.ts
@@ -76,7 +76,7 @@ export function parseResponse (
           }
 
           if (partition.errorCode !== 0) {
-            errors.push([`/results/${i}/partitions/${j}`, partition.errorCode])
+            errors.push([`/results/${i}/partitions/${j}`, [partition.errorCode, null]])
           }
 
           return partition

--- a/src/apis/admin/alter-user-scram-credentials-v0.ts
+++ b/src/apis/admin/alter-user-scram-credentials-v0.ts
@@ -87,7 +87,7 @@ export function parseResponse (
       }
 
       if (result.errorCode !== 0) {
-        errors.push([`/results/${i}`, result.errorCode])
+        errors.push([`/results/${i}`, [result.errorCode, result.errorMessage]])
       }
 
       return result

--- a/src/apis/admin/consumer-group-describe-v0.ts
+++ b/src/apis/admin/consumer-group-describe-v0.ts
@@ -101,14 +101,15 @@ export function parseResponse (
     throttleTimeMs: reader.readInt32(),
     groups: reader.readArray((r, i) => {
       const errorCode = r.readInt16()
+      const errorMessage = r.readNullableString()
 
       if (errorCode !== 0) {
-        errors.push([`/groups/${i}`, errorCode])
+        errors.push([`/groups/${i}`, [errorCode, errorMessage]])
       }
 
       return {
         errorCode,
-        errorMessage: r.readNullableString(),
+        errorMessage,
         groupId: r.readString(),
         groupState: r.readString(),
         groupEpoch: r.readInt32(),

--- a/src/apis/admin/create-acls-v3.ts
+++ b/src/apis/admin/create-acls-v3.ts
@@ -75,7 +75,7 @@ export function parseResponse (
       }
 
       if (result.errorCode !== 0) {
-        errors.push([`/results/${i}`, result.errorCode])
+        errors.push([`/results/${i}`, [result.errorCode, result.errorMessage]])
       }
 
       return result

--- a/src/apis/admin/create-delegation-token-v3.ts
+++ b/src/apis/admin/create-delegation-token-v3.ts
@@ -83,7 +83,7 @@ export function parseResponse (
   }
 
   if (response.errorCode !== 0) {
-    throw new ResponseError(apiKey, apiVersion, { '': response.errorCode }, response)
+    throw new ResponseError(apiKey, apiVersion, { '/': [response.errorCode, null] }, response)
   }
 
   return response

--- a/src/apis/admin/create-partitions-v1.ts
+++ b/src/apis/admin/create-partitions-v1.ts
@@ -89,7 +89,7 @@ export function parseResponse (
         }
 
         if (result.errorCode !== 0) {
-          errors.push([`/results/${i}`, result.errorCode])
+          errors.push([`/results/${i}`, [result.errorCode, result.errorMessage]])
         }
 
         return result

--- a/src/apis/admin/create-partitions-v2.ts
+++ b/src/apis/admin/create-partitions-v2.ts
@@ -79,7 +79,7 @@ export function parseResponse (
       }
 
       if (result.errorCode !== 0) {
-        errors.push([`/results/${i}`, result.errorCode])
+        errors.push([`/results/${i}`, [result.errorCode, result.errorMessage]])
       }
 
       return result

--- a/src/apis/admin/create-partitions-v3.ts
+++ b/src/apis/admin/create-partitions-v3.ts
@@ -79,7 +79,7 @@ export function parseResponse (
       }
 
       if (result.errorCode !== 0) {
-        errors.push([`/results/${i}`, result.errorCode])
+        errors.push([`/results/${i}`, [result.errorCode, result.errorMessage]])
       }
 
       return result

--- a/src/apis/admin/create-topics-v7.ts
+++ b/src/apis/admin/create-topics-v7.ts
@@ -132,7 +132,7 @@ export function parseResponse (
       }
 
       if (topic.errorCode !== 0) {
-        errors.push([`/topics/${i}`, topic.errorCode])
+        errors.push([`/topics/${i}`, [topic.errorCode, topic.errorMessage]])
       }
 
       return topic

--- a/src/apis/admin/delete-acls-v3.ts
+++ b/src/apis/admin/delete-acls-v3.ts
@@ -91,24 +91,26 @@ export function parseResponse (
     throttleTimeMs: reader.readInt32(),
     filterResults: reader.readArray((r, i) => {
       const errorCode = r.readInt16()
+      const errorMessage = r.readNullableString()
 
       if (errorCode !== 0) {
-        errors.push([`/filter_results/${i}`, errorCode])
+        errors.push([`/filter_results/${i}`, [errorCode, errorMessage]])
       }
 
       return {
         errorCode,
-        errorMessage: r.readNullableString(),
+        errorMessage,
         matchingAcls: r.readArray((r, j) => {
           const errorCode = r.readInt16()
+          const errorMessage = r.readNullableString()
 
           if (errorCode !== 0) {
-            errors.push([`/filter_results/${i}/matching_acls/${j}`, errorCode])
+            errors.push([`/filter_results/${i}/matching_acls/${j}`, [errorCode, errorMessage]])
           }
 
           return {
             errorCode,
-            errorMessage: r.readNullableString(),
+            errorMessage,
             resourceType: r.readInt8(),
             resourceName: r.readString(),
             patternType: r.readInt8(),

--- a/src/apis/admin/delete-groups-v2.ts
+++ b/src/apis/admin/delete-groups-v2.ts
@@ -49,7 +49,7 @@ export function parseResponse (
       }
 
       if (group.errorCode !== 0) {
-        errors.push([`/results/${i}`, group.errorCode])
+        errors.push([`/results/${i}`, [group.errorCode, null]])
       }
 
       return group

--- a/src/apis/admin/delete-records-v2.ts
+++ b/src/apis/admin/delete-records-v2.ts
@@ -82,7 +82,7 @@ export function parseResponse (
           }
 
           if (partition.errorCode !== 0) {
-            errors.push([`topics[${i}].partitions[${j}]`, partition.errorCode])
+            errors.push([`topics[${i}].partitions[${j}]`, [partition.errorCode, null]])
           }
 
           return partition

--- a/src/apis/admin/delete-topics-v6.ts
+++ b/src/apis/admin/delete-topics-v6.ts
@@ -67,7 +67,7 @@ export function parseResponse (
       }
 
       if (topicResponse.errorCode !== 0) {
-        errors.push([`/responses/${i}`, topicResponse.errorCode])
+        errors.push([`/responses/${i}`, [topicResponse.errorCode, topicResponse.errorMessage]])
       }
 
       return topicResponse

--- a/src/apis/admin/describe-acls-v3.ts
+++ b/src/apis/admin/describe-acls-v3.ts
@@ -99,7 +99,7 @@ export function parseResponse (
   }
 
   if (response.errorCode) {
-    throw new ResponseError(apiKey, apiVersion, { '': response.errorCode }, response)
+    throw new ResponseError(apiKey, apiVersion, { '/': [response.errorCode, response.errorMessage] }, response)
   }
 
   return response

--- a/src/apis/admin/describe-client-quotas-v0.ts
+++ b/src/apis/admin/describe-client-quotas-v0.ts
@@ -101,7 +101,7 @@ export function parseResponse (
   }
 
   if (response.errorCode !== 0) {
-    throw new ResponseError(apiKey, apiVersion, { '': response.errorCode }, response)
+    throw new ResponseError(apiKey, apiVersion, { '/': [response.errorCode, response.errorMessage] }, response)
   }
 
   return response

--- a/src/apis/admin/describe-cluster-v1.ts
+++ b/src/apis/admin/describe-cluster-v1.ts
@@ -73,7 +73,7 @@ export function parseResponse (
   }
 
   if (response.errorCode !== 0) {
-    throw new ResponseError(apiKey, apiVersion, { '': response.errorCode }, response)
+    throw new ResponseError(apiKey, apiVersion, { '/': [response.errorCode, response.errorMessage] }, response)
   }
 
   return response

--- a/src/apis/admin/describe-configs-v2.ts
+++ b/src/apis/admin/describe-configs-v2.ts
@@ -105,14 +105,15 @@ export function parseResponse (
     results: reader.readArray(
       (r, i) => {
         const errorCode = r.readInt16()
+        const errorMessage = r.readNullableString(false)
 
         if (errorCode !== 0) {
-          errors.push([`/results/${i}`, errorCode])
+          errors.push([`/results/${i}`, [errorCode, errorMessage]])
         }
 
         return {
           errorCode,
-          errorMessage: r.readNullableString(false),
+          errorMessage,
           resourceType: r.readInt8(),
           resourceName: r.readString(false),
           configs: r.readArray(

--- a/src/apis/admin/describe-configs-v3.ts
+++ b/src/apis/admin/describe-configs-v3.ts
@@ -105,14 +105,15 @@ export function parseResponse (
     results: reader.readArray(
       (r, i) => {
         const errorCode = r.readInt16()
+        const errorMessage = r.readNullableString(false)
 
         if (errorCode !== 0) {
-          errors.push([`/results/${i}`, errorCode])
+          errors.push([`/results/${i}`, [errorCode, errorMessage]])
         }
 
         return {
           errorCode,
-          errorMessage: r.readNullableString(false),
+          errorMessage,
           resourceType: r.readInt8(),
           resourceName: r.readString(false),
           configs: r.readArray(

--- a/src/apis/admin/describe-configs-v4.ts
+++ b/src/apis/admin/describe-configs-v4.ts
@@ -100,14 +100,15 @@ export function parseResponse (
     throttleTimeMs: reader.readInt32(),
     results: reader.readArray((r, i) => {
       const errorCode = r.readInt16()
+      const errorMessage = r.readNullableString()
 
       if (errorCode !== 0) {
-        errors.push([`/results/${i}`, errorCode])
+        errors.push([`/results/${i}`, [errorCode, errorMessage]])
       }
 
       return {
         errorCode,
-        errorMessage: r.readNullableString(),
+        errorMessage,
         resourceType: r.readInt8(),
         resourceName: r.readString(),
         configs: r.readArray(r => {

--- a/src/apis/admin/describe-delegation-token-v3.ts
+++ b/src/apis/admin/describe-delegation-token-v3.ts
@@ -95,7 +95,7 @@ export function parseResponse (
   }
 
   if (response.errorCode !== 0) {
-    throw new ResponseError(apiKey, apiVersion, { '': response.errorCode }, response)
+    throw new ResponseError(apiKey, apiVersion, { '/': [response.errorCode, null] }, response)
   }
 
   return response

--- a/src/apis/admin/describe-groups-v5.ts
+++ b/src/apis/admin/describe-groups-v5.ts
@@ -91,7 +91,7 @@ export function parseResponse (
       }
 
       if (group.errorCode !== 0) {
-        errors.push([`/groups/${i}`, group.errorCode])
+        errors.push([`/groups/${i}`, [group.errorCode, null]])
       }
 
       return group

--- a/src/apis/admin/describe-log-dirs-v4.ts
+++ b/src/apis/admin/describe-log-dirs-v4.ts
@@ -79,7 +79,7 @@ export function parseResponse (
   const errorCode = reader.readInt16()
 
   if (errorCode !== 0) {
-    errors.push(['', errorCode])
+    errors.push(['/', [errorCode, null]])
   }
 
   const response: DescribeLogDirsResponse = {
@@ -89,7 +89,7 @@ export function parseResponse (
       const errorCode = r.readInt16()
 
       if (errorCode !== 0) {
-        errors.push([`/results/${i}`, errorCode])
+        errors.push([`/results/${i}`, [errorCode, null]])
       }
 
       return {

--- a/src/apis/admin/describe-producers-v0.ts
+++ b/src/apis/admin/describe-producers-v0.ts
@@ -99,7 +99,7 @@ export function parseResponse (
           }
 
           if (partition.errorCode !== 0) {
-            errors.push([`/partitions/${i}`, partition.errorCode])
+            errors.push([`/partitions/${i}`, [partition.errorCode, partition.errorMessage]])
           }
 
           return partition

--- a/src/apis/admin/describe-quorum-v2.ts
+++ b/src/apis/admin/describe-quorum-v2.ts
@@ -115,13 +115,14 @@ export function parseResponse (
   const errors: ResponseErrorWithLocation[] = []
 
   const errorCode = reader.readInt16()
+  const errorMessage = reader.readNullableString()
 
   if (errorCode !== 0) {
-    errors.push(['', errorCode])
+    errors.push(['', [errorCode, errorMessage]])
   }
   const response: DescribeQuorumResponse = {
     errorCode,
-    errorMessage: reader.readNullableString(),
+    errorMessage,
     topics: reader.readArray((r, i) => {
       return {
         topicName: r.readString(),
@@ -154,7 +155,7 @@ export function parseResponse (
           }
 
           if (partition.errorCode !== 0) {
-            errors.push([`/topics/${i}/partitions/${j}`, partition.errorCode])
+            errors.push([`/topics/${i}/partitions/${j}`, [partition.errorCode, partition.errorMessage]])
           }
 
           return partition

--- a/src/apis/admin/describe-topic-partitions-v0.ts
+++ b/src/apis/admin/describe-topic-partitions-v0.ts
@@ -111,7 +111,7 @@ export function parseResponse (
       const errorCode = r.readInt16()
 
       if (errorCode !== 0) {
-        errors.push([`/topics/${i}`, errorCode])
+        errors.push([`/topics/${i}`, [errorCode, null]])
       }
 
       return {
@@ -123,7 +123,7 @@ export function parseResponse (
           const errorCode = r.readInt16()
 
           if (errorCode !== 0) {
-            errors.push([`/topics/${i}/partitions/${j}`, errorCode])
+            errors.push([`/topics/${i}/partitions/${j}`, [errorCode, null]])
           }
 
           return {

--- a/src/apis/admin/describe-transactions-v0.ts
+++ b/src/apis/admin/describe-transactions-v0.ts
@@ -79,7 +79,7 @@ export function parseResponse (
       }
 
       if (state.errorCode !== 0) {
-        errors.push([`/transaction_states/${i}`, state.errorCode])
+        errors.push([`/transaction_states/${i}`, [state.errorCode, null]])
       }
 
       return state

--- a/src/apis/admin/describe-user-scram-credentials-v0.ts
+++ b/src/apis/admin/describe-user-scram-credentials-v0.ts
@@ -63,27 +63,29 @@ export function parseResponse (
 
   const throttleTimeMs = reader.readInt32()
   const errorCode = reader.readInt16()
+  const errorMessage = reader.readNullableString()
 
   if (errorCode !== 0) {
-    errors.push(['', errorCode])
+    errors.push(['', [errorCode, errorMessage]])
   }
 
   const response: DescribeUserScramCredentialsResponse = {
     throttleTimeMs,
     errorCode,
-    errorMessage: reader.readNullableString(),
+    errorMessage,
     results: reader.readArray((r, i) => {
       const user = r.readString()
       const errorCode = r.readInt16()
+      const errorMessage = r.readNullableString()
 
       if (errorCode !== 0) {
-        errors.push([`/results/${i}`, errorCode])
+        errors.push([`/results/${i}`, [errorCode, errorMessage]])
       }
 
       return {
         user,
         errorCode,
-        errorMessage: r.readNullableString(),
+        errorMessage,
         credentialInfos: r.readArray(r => {
           return {
             mechanism: r.readInt8(),

--- a/src/apis/admin/envelope-v0.ts
+++ b/src/apis/admin/envelope-v0.ts
@@ -45,7 +45,7 @@ export function parseResponse (
   }
 
   if (response.errorCode) {
-    throw new ResponseError(apiKey, apiVersion, { '': response.errorCode }, response)
+    throw new ResponseError(apiKey, apiVersion, { '/': [response.errorCode, null] }, response)
   }
 
   return response

--- a/src/apis/admin/expire-delegation-token-v2.ts
+++ b/src/apis/admin/expire-delegation-token-v2.ts
@@ -39,7 +39,7 @@ export function parseResponse (
   }
 
   if (response.errorCode !== 0) {
-    throw new ResponseError(apiKey, apiVersion, { '': response.errorCode }, response)
+    throw new ResponseError(apiKey, apiVersion, { '/': [response.errorCode, null] }, response)
   }
 
   return response

--- a/src/apis/admin/incremental-alter-configs-v1.ts
+++ b/src/apis/admin/incremental-alter-configs-v1.ts
@@ -75,14 +75,15 @@ export function parseResponse (
     throttleTimeMs: reader.readInt32(),
     responses: reader.readArray((r, i) => {
       const errorCode = r.readInt16()
+      const errorMessage = r.readNullableString()
 
       if (errorCode !== 0) {
-        errors.push([`/responses/${i}`, errorCode])
+        errors.push([`/responses/${i}`, [errorCode, errorMessage]])
       }
 
       return {
         errorCode,
-        errorMessage: r.readNullableString(),
+        errorMessage,
         resourceType: r.readInt8(),
         resourceName: r.readString()
       }

--- a/src/apis/admin/list-groups-v4.ts
+++ b/src/apis/admin/list-groups-v4.ts
@@ -57,7 +57,7 @@ export function parseResponse (
   }
 
   if (response.errorCode !== 0) {
-    throw new ResponseError(apiKey, apiVersion, { '': response.errorCode }, response)
+    throw new ResponseError(apiKey, apiVersion, { '/': [response.errorCode, null] }, response)
   }
 
   return response

--- a/src/apis/admin/list-groups-v5.ts
+++ b/src/apis/admin/list-groups-v5.ts
@@ -61,7 +61,7 @@ export function parseResponse (
   }
 
   if (response.errorCode !== 0) {
-    throw new ResponseError(apiKey, apiVersion, { '': response.errorCode }, response)
+    throw new ResponseError(apiKey, apiVersion, { '/': [response.errorCode, null] }, response)
   }
 
   return response

--- a/src/apis/admin/list-partition-reassignments-v0.ts
+++ b/src/apis/admin/list-partition-reassignments-v0.ts
@@ -85,7 +85,7 @@ export function parseResponse (
   }
 
   if (response.errorCode !== 0) {
-    throw new ResponseError(apiKey, apiVersion, { '': response.errorCode }, response)
+    throw new ResponseError(apiKey, apiVersion, { '/': [response.errorCode, response.errorMessage] }, response)
   }
 
   return response

--- a/src/apis/admin/list-transactions-v1.ts
+++ b/src/apis/admin/list-transactions-v1.ts
@@ -67,7 +67,7 @@ export function parseResponse (
   }
 
   if (response.errorCode !== 0) {
-    throw new ResponseError(apiKey, apiVersion, { '': response.errorCode }, response)
+    throw new ResponseError(apiKey, apiVersion, { '/': [response.errorCode, null] }, response)
   }
 
   return response

--- a/src/apis/admin/offset-delete-v0.ts
+++ b/src/apis/admin/offset-delete-v0.ts
@@ -72,7 +72,7 @@ export function parseResponse (
   const errorCode = reader.readInt16()
 
   if (errorCode !== 0) {
-    errors.push(['', errorCode])
+    errors.push(['', [errorCode, null]])
   }
 
   const response: OffsetDeleteResponse = {
@@ -88,7 +88,7 @@ export function parseResponse (
           }
 
           if (partition.errorCode !== 0) {
-            errors.push([`/topics/${i}/partitions/${j}`, partition.errorCode])
+            errors.push([`/topics/${i}/partitions/${j}`, [partition.errorCode, null]])
           }
 
           return partition

--- a/src/apis/admin/renew-delegation-token-v2.ts
+++ b/src/apis/admin/renew-delegation-token-v2.ts
@@ -39,7 +39,7 @@ export function parseResponse (
   }
 
   if (response.errorCode !== 0) {
-    throw new ResponseError(apiKey, apiVersion, { '': response.errorCode }, response)
+    throw new ResponseError(apiKey, apiVersion, { '/': [response.errorCode, null] }, response)
   }
 
   return response

--- a/src/apis/admin/unregister-broker-v0.ts
+++ b/src/apis/admin/unregister-broker-v0.ts
@@ -39,7 +39,7 @@ export function parseResponse (
   }
 
   if (response.errorCode !== 0) {
-    throw new ResponseError(apiKey, apiVersion, { '': response.errorCode }, response)
+    throw new ResponseError(apiKey, apiVersion, { '/': [response.errorCode, response.errorMessage] }, response)
   }
 
   return response

--- a/src/apis/admin/update-features-v1.ts
+++ b/src/apis/admin/update-features-v1.ts
@@ -68,15 +68,16 @@ export function parseResponse (
 
   const throttleTimeMs = reader.readInt32()
   const errorCode = reader.readInt16()
+  const errorMessage = reader.readNullableString()
 
   if (errorCode !== 0) {
-    errors.push(['', errorCode])
+    errors.push(['', [errorCode, errorMessage]])
   }
 
   const response: UpdateFeaturesResponse = {
     throttleTimeMs,
     errorCode,
-    errorMessage: reader.readNullableString(),
+    errorMessage,
     results: reader.readArray((r, i) => {
       const result = {
         feature: r.readString(),
@@ -85,7 +86,7 @@ export function parseResponse (
       }
 
       if (result.errorCode !== 0) {
-        errors.push([`/results/${i}`, result.errorCode])
+        errors.push([`/results/${i}`, [result.errorCode, result.errorMessage]])
       }
 
       return result

--- a/src/apis/consumer/consumer-group-heartbeat-v0.ts
+++ b/src/apis/consumer/consumer-group-heartbeat-v0.ts
@@ -114,7 +114,7 @@ export function parseResponse (
   }
 
   if (response.errorCode !== 0) {
-    throw new ResponseError(apiKey, apiVersion, { '': response.errorCode }, response)
+    throw new ResponseError(apiKey, apiVersion, { '/': [response.errorCode, response.errorMessage] }, response)
   }
 
   return response

--- a/src/apis/consumer/fetch-v12.ts
+++ b/src/apis/consumer/fetch-v12.ts
@@ -150,7 +150,7 @@ export function parseResponse (
   const errorCode = reader.readInt16()
 
   if (errorCode !== 0) {
-    errors.push(['', errorCode])
+    errors.push(['/', [errorCode, null]])
   }
 
   const response: FetchResponse = {
@@ -177,7 +177,7 @@ export function parseResponse (
           }
 
           if (partition.errorCode !== 0) {
-            errors.push([`/responses/${i}/partitions/${j}`, partition.errorCode])
+            errors.push([`/responses/${i}/partitions/${j}`, [partition.errorCode, null]])
           }
 
           // We need to reduce the size by one to follow the COMPACT_RECORDS specification.

--- a/src/apis/consumer/fetch-v13.ts
+++ b/src/apis/consumer/fetch-v13.ts
@@ -150,7 +150,7 @@ export function parseResponse (
   const errorCode = reader.readInt16()
 
   if (errorCode !== 0) {
-    errors.push(['', errorCode])
+    errors.push(['/', [errorCode, null]])
   }
 
   const response: FetchResponse = {
@@ -177,7 +177,7 @@ export function parseResponse (
           }
 
           if (partition.errorCode !== 0) {
-            errors.push([`/responses/${i}/partitions/${j}`, partition.errorCode])
+            errors.push([`/responses/${i}/partitions/${j}`, [partition.errorCode, null]])
           }
 
           // We need to reduce the size by one to follow the COMPACT_RECORDS specification.

--- a/src/apis/consumer/fetch-v14.ts
+++ b/src/apis/consumer/fetch-v14.ts
@@ -150,7 +150,7 @@ export function parseResponse (
   const errorCode = reader.readInt16()
 
   if (errorCode !== 0) {
-    errors.push(['', errorCode])
+    errors.push(['/', [errorCode, null]])
   }
 
   const response: FetchResponse = {
@@ -177,7 +177,7 @@ export function parseResponse (
           }
 
           if (partition.errorCode !== 0) {
-            errors.push([`/responses/${i}/partitions/${j}`, partition.errorCode])
+            errors.push([`/responses/${i}/partitions/${j}`, [partition.errorCode, null]])
           }
 
           // We need to reduce the size by one to follow the COMPACT_RECORDS specification.

--- a/src/apis/consumer/fetch-v15.ts
+++ b/src/apis/consumer/fetch-v15.ts
@@ -148,7 +148,7 @@ export function parseResponse (
   const errorCode = reader.readInt16()
 
   if (errorCode !== 0) {
-    errors.push(['', errorCode])
+    errors.push(['', [errorCode, null]])
   }
 
   const response: FetchResponse = {
@@ -175,7 +175,7 @@ export function parseResponse (
           }
 
           if (partition.errorCode !== 0) {
-            errors.push([`/responses/${i}/partitions/${j}`, partition.errorCode])
+            errors.push([`/responses/${i}/partitions/${j}`, [partition.errorCode, null]])
           }
 
           // We need to reduce the size by one to follow the COMPACT_RECORDS specification.

--- a/src/apis/consumer/fetch-v16.ts
+++ b/src/apis/consumer/fetch-v16.ts
@@ -148,7 +148,7 @@ export function parseResponse (
   const errorCode = reader.readInt16()
 
   if (errorCode !== 0) {
-    errors.push(['', errorCode])
+    errors.push(['', [errorCode, null]])
   }
 
   const response: FetchResponse = {
@@ -175,7 +175,7 @@ export function parseResponse (
           }
 
           if (partition.errorCode !== 0) {
-            errors.push([`/responses/${i}/partitions/${j}`, partition.errorCode])
+            errors.push([`/responses/${i}/partitions/${j}`, [partition.errorCode, null]])
           }
 
           // We need to reduce the size by one to follow the COMPACT_RECORDS specification.

--- a/src/apis/consumer/fetch-v17.ts
+++ b/src/apis/consumer/fetch-v17.ts
@@ -148,7 +148,7 @@ export function parseResponse (
   const errorCode = reader.readInt16()
 
   if (errorCode !== 0) {
-    errors.push(['', errorCode])
+    errors.push(['', [errorCode, null]])
   }
 
   const response: FetchResponse = {
@@ -175,7 +175,7 @@ export function parseResponse (
           }
 
           if (partition.errorCode !== 0) {
-            errors.push([`/responses/${i}/partitions/${j}`, partition.errorCode])
+            errors.push([`/responses/${i}/partitions/${j}`, [partition.errorCode, null]])
           }
 
           // We need to reduce the size by one to follow the COMPACT_RECORDS specification.

--- a/src/apis/consumer/heartbeat-v4.ts
+++ b/src/apis/consumer/heartbeat-v4.ts
@@ -49,7 +49,7 @@ export function parseResponse (
   }
 
   if (response.errorCode !== 0) {
-    throw new ResponseError(apiKey, apiVersion, { '': response.errorCode }, response)
+    throw new ResponseError(apiKey, apiVersion, { '/': [response.errorCode, null] }, response)
   }
 
   return response

--- a/src/apis/consumer/join-group-v9.ts
+++ b/src/apis/consumer/join-group-v9.ts
@@ -107,7 +107,7 @@ export function parseResponse (
   }
 
   if (response.errorCode !== 0) {
-    throw new ResponseError(apiKey, apiVersion, { '': response.errorCode }, response)
+    throw new ResponseError(apiKey, apiVersion, { '/': [response.errorCode, null] }, response)
   }
 
   return response

--- a/src/apis/consumer/leave-group-v5.ts
+++ b/src/apis/consumer/leave-group-v5.ts
@@ -63,7 +63,7 @@ export function parseResponse (
   const errorCode = reader.readInt16()
 
   if (errorCode !== 0) {
-    errors.push(['', errorCode])
+    errors.push(['', [errorCode, null]])
   }
 
   const response: LeaveGroupResponse = {
@@ -77,7 +77,7 @@ export function parseResponse (
       }
 
       if (member.errorCode !== 0) {
-        errors.push([`/members/${i}`, member.errorCode])
+        errors.push([`/members/${i}`, [member.errorCode, null]])
       }
 
       return member

--- a/src/apis/consumer/list-offsets-v8.ts
+++ b/src/apis/consumer/list-offsets-v8.ts
@@ -94,7 +94,7 @@ export function parseResponse (
           }
 
           if (partition.errorCode !== 0) {
-            errors.push([`/topics/${i}/partitions/${j}`, partition.errorCode])
+            errors.push([`/topics/${i}/partitions/${j}`, [partition.errorCode, null]])
           }
 
           return partition

--- a/src/apis/consumer/list-offsets-v9.ts
+++ b/src/apis/consumer/list-offsets-v9.ts
@@ -94,7 +94,7 @@ export function parseResponse (
           }
 
           if (partition.errorCode !== 0) {
-            errors.push([`/topics/${i}/partitions/${j}`, partition.errorCode])
+            errors.push([`/topics/${i}/partitions/${j}`, [partition.errorCode, null]])
           }
 
           return partition

--- a/src/apis/consumer/offset-commit-v8.ts
+++ b/src/apis/consumer/offset-commit-v8.ts
@@ -99,7 +99,7 @@ export function parseResponse (
           }
 
           if (partition.errorCode !== 0) {
-            errors.push([`/topics/${i}/partitions/${j}`, partition.errorCode])
+            errors.push([`/topics/${i}/partitions/${j}`, [partition.errorCode, null]])
           }
 
           return partition

--- a/src/apis/consumer/offset-commit-v9.ts
+++ b/src/apis/consumer/offset-commit-v9.ts
@@ -99,7 +99,7 @@ export function parseResponse (
           }
 
           if (partition.errorCode !== 0) {
-            errors.push([`/topics/${i}/partitions/${j}`, partition.errorCode])
+            errors.push([`/topics/${i}/partitions/${j}`, [partition.errorCode, null]])
           }
 
           return partition

--- a/src/apis/consumer/offset-fetch-v8.ts
+++ b/src/apis/consumer/offset-fetch-v8.ts
@@ -105,7 +105,7 @@ export function parseResponse (
               }
 
               if (partition.errorCode !== 0) {
-                errors.push([`/groups/${i}/topics/${j}/partitions/${k}`, partition.errorCode])
+                errors.push([`/groups/${i}/topics/${j}/partitions/${k}`, [partition.errorCode, null]])
               }
 
               return partition
@@ -116,7 +116,7 @@ export function parseResponse (
       }
 
       if (group.errorCode !== 0) {
-        errors.push([`/groups/${i}`, group.errorCode])
+        errors.push([`/groups/${i}`, [group.errorCode, null]])
       }
 
       return group

--- a/src/apis/consumer/offset-fetch-v9.ts
+++ b/src/apis/consumer/offset-fetch-v9.ts
@@ -108,7 +108,7 @@ export function parseResponse (
               }
 
               if (partition.errorCode !== 0) {
-                errors.push([`/groups/${i}/topics/${j}/partitions/${k}`, partition.errorCode])
+                errors.push([`/groups/${i}/topics/${j}/partitions/${k}`, [partition.errorCode, null]])
               }
 
               return partition
@@ -119,7 +119,7 @@ export function parseResponse (
       }
 
       if (group.errorCode !== 0) {
-        errors.push([`/groups/${i}`, group.errorCode])
+        errors.push([`/groups/${i}`, [group.errorCode, null]])
       }
 
       return group

--- a/src/apis/consumer/offset-for-leader-epoch-v4.ts
+++ b/src/apis/consumer/offset-for-leader-epoch-v4.ts
@@ -85,7 +85,7 @@ export function parseResponse (
           const errorCode = r.readInt16()
 
           if (errorCode !== 0) {
-            errors.push([`/topics/${i}/partitions/${j}`, errorCode])
+            errors.push([`/topics/${i}/partitions/${j}`, [errorCode, null]])
           }
 
           return {

--- a/src/apis/consumer/sync-group-v5.ts
+++ b/src/apis/consumer/sync-group-v5.ts
@@ -75,7 +75,7 @@ export function parseResponse (
   }
 
   if (response.errorCode !== 0) {
-    throw new ResponseError(apiKey, apiVersion, { '': response.errorCode }, response)
+    throw new ResponseError(apiKey, apiVersion, { '/': [response.errorCode, null] }, response)
   }
 
   return response

--- a/src/apis/definitions.ts
+++ b/src/apis/definitions.ts
@@ -2,6 +2,7 @@ import { promisify } from 'node:util'
 import { type Connection } from '../network/connection.ts'
 import { type Reader } from '../protocol/reader.ts'
 import { type Writer } from '../protocol/writer.ts'
+import { type NullableString } from '../protocol/definitions.ts'
 
 export type Callback<ReturnType> = (error: Error | null, payload: ReturnType) => void
 
@@ -16,7 +17,7 @@ export type ResponseParser<ReturnType> = (
   reader: Reader
 ) => ReturnType | Promise<ReturnType>
 
-export type ResponseErrorWithLocation = [string, number]
+export type ResponseErrorWithLocation = [string, [number, NullableString]]
 
 export type APIWithCallback<RequestArguments extends Array<unknown>, ResponseType> = (
   connection: Connection,

--- a/src/apis/metadata/api-versions-v3.ts
+++ b/src/apis/metadata/api-versions-v3.ts
@@ -59,7 +59,7 @@ export function parseResponse (
   }
 
   if (response.errorCode !== 0) {
-    throw new ResponseError(apiKey, apiVersion, { '': response.errorCode }, response)
+    throw new ResponseError(apiKey, apiVersion, { '/': [response.errorCode, null] }, response)
   }
 
   return response

--- a/src/apis/metadata/api-versions-v4.ts
+++ b/src/apis/metadata/api-versions-v4.ts
@@ -59,7 +59,7 @@ export function parseResponse (
   }
 
   if (response.errorCode !== 0) {
-    throw new ResponseError(apiKey, apiVersion, { '': response.errorCode }, response)
+    throw new ResponseError(apiKey, apiVersion, { '/': [response.errorCode, null] }, response)
   }
 
   return response

--- a/src/apis/metadata/find-coordinator-v4.ts
+++ b/src/apis/metadata/find-coordinator-v4.ts
@@ -64,7 +64,7 @@ export function parseResponse (
       }
 
       if (coordinator.errorCode !== 0) {
-        errors.push([`/coordinators/${i}`, coordinator.errorCode])
+        errors.push([`/coordinators/${i}`, [coordinator.errorCode, coordinator.errorMessage]])
       }
 
       return coordinator

--- a/src/apis/metadata/find-coordinator-v5.ts
+++ b/src/apis/metadata/find-coordinator-v5.ts
@@ -64,7 +64,7 @@ export function parseResponse (
       }
 
       if (coordinator.errorCode !== 0) {
-        errors.push([`/coordinators/${i}`, coordinator.errorCode])
+        errors.push([`/coordinators/${i}`, [coordinator.errorCode, coordinator.errorMessage]])
       }
 
       return coordinator

--- a/src/apis/metadata/find-coordinator-v6.ts
+++ b/src/apis/metadata/find-coordinator-v6.ts
@@ -64,7 +64,7 @@ export function parseResponse (
       }
 
       if (coordinator.errorCode !== 0) {
-        errors.push([`/coordinators/${i}`, coordinator.errorCode])
+        errors.push([`/coordinators/${i}`, [coordinator.errorCode, coordinator.errorMessage]])
       }
 
       return coordinator

--- a/src/apis/metadata/metadata-v10.ts
+++ b/src/apis/metadata/metadata-v10.ts
@@ -112,7 +112,7 @@ export function parseResponse (
       const errorCode = r.readInt16()
 
       if (errorCode !== 0) {
-        errors.push([`/topics/${i}`, errorCode])
+        errors.push([`/topics/${i}`, [errorCode, null]])
       }
 
       return {
@@ -124,7 +124,7 @@ export function parseResponse (
           const errorCode = r.readInt16()
 
           if (errorCode !== 0) {
-            errors.push([`/topics/${i}/partitions/${j}`, errorCode])
+            errors.push([`/topics/${i}/partitions/${j}`, [errorCode, null]])
           }
 
           return {

--- a/src/apis/metadata/metadata-v11.ts
+++ b/src/apis/metadata/metadata-v11.ts
@@ -112,7 +112,7 @@ export function parseResponse (
       const errorCode = r.readInt16()
 
       if (errorCode !== 0) {
-        errors.push([`/topics/${i}`, errorCode])
+        errors.push([`/topics/${i}`, [errorCode, null]])
       }
 
       return {
@@ -124,7 +124,7 @@ export function parseResponse (
           const errorCode = r.readInt16()
 
           if (errorCode !== 0) {
-            errors.push([`/topics/${i}/partitions/${j}`, errorCode])
+            errors.push([`/topics/${i}/partitions/${j}`, [errorCode, null]])
           }
 
           return {

--- a/src/apis/metadata/metadata-v12.ts
+++ b/src/apis/metadata/metadata-v12.ts
@@ -109,7 +109,7 @@ export function parseResponse (
       const errorCode = r.readInt16()
 
       if (errorCode !== 0) {
-        errors.push([`/topics/${i}`, errorCode])
+        errors.push([`/topics/${i}`, [errorCode, null]])
       }
 
       return {
@@ -121,7 +121,7 @@ export function parseResponse (
           const errorCode = r.readInt16()
 
           if (errorCode !== 0) {
-            errors.push([`/topics/${i}/partitions/${j}`, errorCode])
+            errors.push([`/topics/${i}/partitions/${j}`, [errorCode, null]])
           }
 
           return {

--- a/src/apis/metadata/metadata-v9.ts
+++ b/src/apis/metadata/metadata-v9.ts
@@ -111,7 +111,7 @@ export function parseResponse (
       const errorCode = r.readInt16()
 
       if (errorCode !== 0) {
-        errors.push([`/topics/${i}`, errorCode])
+        errors.push([`/topics/${i}`, [errorCode, null]])
       }
 
       const name = r.readNullableString()
@@ -125,7 +125,7 @@ export function parseResponse (
           const errorCode = r.readInt16()
 
           if (errorCode !== 0) {
-            errors.push([`/topics/${i}/partitions/${j}`, errorCode])
+            errors.push([`/topics/${i}/partitions/${j}`, [errorCode, null]])
           }
 
           return {

--- a/src/apis/producer/add-offsets-to-txn-v4.ts
+++ b/src/apis/producer/add-offsets-to-txn-v4.ts
@@ -48,7 +48,7 @@ export function parseResponse (
   }
 
   if (response.errorCode !== 0) {
-    throw new ResponseError(apiKey, apiVersion, { '': response.errorCode }, response)
+    throw new ResponseError(apiKey, apiVersion, { '/': [response.errorCode, null] }, response)
   }
 
   return response

--- a/src/apis/producer/add-partitions-to-txn-v5.ts
+++ b/src/apis/producer/add-partitions-to-txn-v5.ts
@@ -93,7 +93,7 @@ export function parseResponse (
   const errorCode = reader.readInt16()
 
   if (errorCode !== 0) {
-    errors.push(['', errorCode])
+    errors.push(['', [errorCode, null]])
   }
 
   const response: AddPartitionsToTxnResponse = {
@@ -114,7 +114,7 @@ export function parseResponse (
               if (partition.partitionErrorCode !== 0) {
                 errors.push([
                   `/results_by_transaction/${i}/topic_results/${j}/results_by_partitions/${k}`,
-                  partition.partitionErrorCode
+                  [partition.partitionErrorCode, null]
                 ])
               }
 

--- a/src/apis/producer/end-txn-v4.ts
+++ b/src/apis/producer/end-txn-v4.ts
@@ -48,7 +48,7 @@ export function parseResponse (
   }
 
   if (response.errorCode !== 0) {
-    throw new ResponseError(apiKey, apiVersion, { '': response.errorCode }, response)
+    throw new ResponseError(apiKey, apiVersion, { '/': [response.errorCode, null] }, response)
   }
 
   return response

--- a/src/apis/producer/init-producer-id-v4.ts
+++ b/src/apis/producer/init-producer-id-v4.ts
@@ -64,7 +64,7 @@ export function parseResponse (
   }
 
   if (response.errorCode !== 0) {
-    throw new ResponseError(apiKey, apiVersion, { '': response.errorCode }, response)
+    throw new ResponseError(apiKey, apiVersion, { '/': [response.errorCode, null] }, response)
   }
 
   return response

--- a/src/apis/producer/init-producer-id-v5.ts
+++ b/src/apis/producer/init-producer-id-v5.ts
@@ -64,7 +64,7 @@ export function parseResponse (
   }
 
   if (response.errorCode !== 0) {
-    throw new ResponseError(apiKey, apiVersion, { '': response.errorCode }, response)
+    throw new ResponseError(apiKey, apiVersion, { '/': [response.errorCode, null] }, response)
   }
 
   return response

--- a/src/apis/producer/produce-v7.ts
+++ b/src/apis/producer/produce-v7.ts
@@ -123,7 +123,7 @@ export function parseResponse (
               const errorCode = r.readInt16()
 
               if (errorCode !== 0) {
-                errors.push([`/responses/${i}/partition_responses/${j}`, errorCode])
+                errors.push([`/responses/${i}/partition_responses/${j}`, [errorCode, null]])
               }
 
               return {

--- a/src/apis/producer/txn-offset-commit-v4.ts
+++ b/src/apis/producer/txn-offset-commit-v4.ts
@@ -108,7 +108,7 @@ export function parseResponse (
           }
 
           if (partition.errorCode !== 0) {
-            errors.push([`/topics/${i}/partitions/${j}`, partition.errorCode])
+            errors.push([`/topics/${i}/partitions/${j}`, [partition.errorCode, null]])
           }
 
           return partition

--- a/src/apis/security/sasl-authenticate-v2.ts
+++ b/src/apis/security/sasl-authenticate-v2.ts
@@ -44,7 +44,7 @@ export function parseResponse (
   }
 
   if (response.errorCode !== 0) {
-    throw new ResponseError(apiKey, apiVersion, { '': response.errorCode }, response)
+    throw new ResponseError(apiKey, apiVersion, { '/': [response.errorCode, response.errorMessage] }, response)
   }
 
   return response

--- a/src/apis/security/sasl-handshake-v1.ts
+++ b/src/apis/security/sasl-handshake-v1.ts
@@ -6,8 +6,8 @@ import { createAPI } from '../definitions.ts'
 export type SaslHandshakeRequest = Parameters<typeof createRequest>
 
 export interface SaslHandshakeResponse {
-  errorCode?: number
-  mechanisms?: string[]
+  errorCode: number
+  mechanisms: string[]
 }
 
 /*
@@ -41,7 +41,7 @@ export function parseResponse (
   }
 
   if (response.errorCode !== 0) {
-    throw new ResponseError(apiKey, apiVersion, { '': response.errorCode! }, response)
+    throw new ResponseError(apiKey, apiVersion, { '/': [response.errorCode, null] }, response)
   }
 
   return response

--- a/src/apis/telemetry/get-telemetry-subscriptions-v0.ts
+++ b/src/apis/telemetry/get-telemetry-subscriptions-v0.ts
@@ -50,7 +50,7 @@ export function parseResponse (
   const errorCode = reader.readInt16()
 
   if (errorCode !== 0) {
-    errors.push(['', errorCode])
+    errors.push(['', [errorCode, null]])
   }
 
   const response: GetTelemetrySubscriptionsResponse = {

--- a/src/apis/telemetry/list-client-metrics-resources-v0.ts
+++ b/src/apis/telemetry/list-client-metrics-resources-v0.ts
@@ -46,7 +46,7 @@ export function parseResponse (
   }
 
   if (response.errorCode !== 0) {
-    throw new ResponseError(apiKey, apiVersion, { '': response.errorCode }, response)
+    throw new ResponseError(apiKey, apiVersion, { '/': [response.errorCode, null] }, response)
   }
 
   return response

--- a/src/apis/telemetry/push-telemetry-v0.ts
+++ b/src/apis/telemetry/push-telemetry-v0.ts
@@ -51,7 +51,7 @@ export function parseResponse (
   }
 
   if (response.errorCode !== 0) {
-    throw new ResponseError(apiKey, apiVersion, { '': response.errorCode }, response)
+    throw new ResponseError(apiKey, apiVersion, { '/': [response.errorCode, null] }, response)
   }
 
   return response

--- a/test/clients/consumer/consumer-consumer-group-protocol.test.ts
+++ b/test/clients/consumer/consumer-consumer-group-protocol.test.ts
@@ -121,7 +121,7 @@ test('consumer should handle fenced member epoch error', skipConsumerGroupProtoc
     new ResponseError(
       consumerGroupHeartbeatV0.api.key,
       0,
-      { '': 110 },
+      { '/': [110, null] },
       {
         throttleTimeMs: 0,
         errorCode: 110,

--- a/test/clients/consumer/consumer.test.ts
+++ b/test/clients/consumer/consumer.test.ts
@@ -3068,7 +3068,7 @@ test('joinGroup should cancel when membership has been cancelled during rejoin (
   mockAPI(
     consumer[kConnections],
     syncGroupV5.api.key,
-    new ProtocolError('REBALANCE_IN_PROGRESS', { cancelMembership: true })
+    new ProtocolError('REBALANCE_IN_PROGRESS', null, { cancelMembership: true })
   )
 
   deepStrictEqual(await consumer.joinGroup({}), undefined)
@@ -3080,7 +3080,7 @@ test('joinGroup should cancel when membership has been cancelled during rejoin (
   mockAPI(
     consumer[kConnections],
     syncGroupV5.api.key,
-    new ProtocolError('UNKNOWN_MEMBER_ID', { cancelMembership: true })
+    new ProtocolError('UNKNOWN_MEMBER_ID', null, { cancelMembership: true })
   )
 
   deepStrictEqual(await consumer.joinGroup({}), undefined)

--- a/test/clients/producer/producer.test.ts
+++ b/test/clients/producer/producer.test.ts
@@ -997,7 +997,7 @@ test('send should repeat the operation in case of stale metadata', async t => {
   mockAPI(
     producer[kConnections],
     produceV11.api.key,
-    new ProtocolError('UNKNOWN_TOPIC_OR_PARTITION', { topic: testTopic })
+    new ProtocolError('UNKNOWN_TOPIC_OR_PARTITION', null, { topic: testTopic })
   )
 
   await producer.send({

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -152,7 +152,7 @@ test('NetworkError', () => {
 })
 
 test('ProtocolError with string code', () => {
-  const error = new ProtocolError('UNKNOWN_TOPIC_OR_PARTITION', { topic: 'test-topic' })
+  const error = new ProtocolError('UNKNOWN_TOPIC_OR_PARTITION', null, { topic: 'test-topic' })
   deepStrictEqual(error.code, 'PLT_KFK_PROTOCOL')
   deepStrictEqual(error.message, 'This server does not host this topic-partition.')
   deepStrictEqual(error.apiId, 'UNKNOWN_TOPIC_OR_PARTITION')
@@ -163,7 +163,7 @@ test('ProtocolError with string code', () => {
 })
 
 test('ProtocolError with numeric code', () => {
-  const error = new ProtocolError(3, { partition: 1 })
+  const error = new ProtocolError(3, null, { partition: 1 })
   deepStrictEqual(error.code, 'PLT_KFK_PROTOCOL')
   deepStrictEqual(error.message, 'This server does not host this topic-partition.')
   deepStrictEqual(error.apiId, 'UNKNOWN_TOPIC_OR_PARTITION')
@@ -175,7 +175,7 @@ test('ProtocolError with numeric code', () => {
 
 test('ProtocolError with response containing memberId', () => {
   const response = { memberId: 'test-member-id' }
-  const error = new ProtocolError('REBALANCE_IN_PROGRESS', {}, response)
+  const error = new ProtocolError('REBALANCE_IN_PROGRESS', null, {}, response)
   deepStrictEqual(error.code, 'PLT_KFK_PROTOCOL')
   deepStrictEqual(error.apiId, 'REBALANCE_IN_PROGRESS')
   ok(error.rebalanceInProgress)
@@ -186,9 +186,9 @@ test('ProtocolError with response containing memberId', () => {
 test('ResponseError', () => {
   const apiName = 3 // Metadata
   const apiVersion = 1
-  const errors = {
-    'topics[0]': 3, // UNKNOWN_TOPIC_OR_PARTITION
-    'topics[1]': 5 // LEADER_NOT_AVAILABLE
+  const errors: Record<string, [number, null]> = {
+    'topics[0]': [3, null], // UNKNOWN_TOPIC_OR_PARTITION
+    'topics[1]': [5, null] // LEADER_NOT_AVAILABLE
   }
   const response = { topics: ['topic1', 'topic2'] }
 


### PR DESCRIPTION
Many APIs return error codes and error messages in case of errors. Previously, only error codes have been handled which were used to construct generic protocol errors with predefined error messages. Error messages from the Kafka cluster were skipped altogether. This PR makes the error messages from the Kafka cluster available inside the protocol errors if those have been provided. This way, more detailed information about the issue can be accessed.

on-behalf-of: @SAP ospo@sap.com
Signed-off-by: Peter Lehnhardt <peter.lehnhardt@sap.com>