### PR TITLE
Fix unhandled errors on custom connection errors

### DIFF
--- a/src/network/connection.ts
+++ b/src/network/connection.ts
@@ -625,8 +625,7 @@ export class Connection extends EventEmitter {
       const request = this.#inflightRequests.get(correlationId)
 
       if (!request) {
-        this.emit(
-          'error',
+        this.#socket.destroy(
           new UnexpectedCorrelationIdError(`Received unexpected response with correlation_id=${correlationId}`, {
             raw: this.#responseReader.buffer.slice(0, this.#nextMessage + INT32_SIZE)
           })

--- a/test/network/connection.test.ts
+++ b/test/network/connection.test.ts
@@ -45,6 +45,7 @@ import {
   mockedErrorMessage,
   mockedOperationId
 } from '../helpers.ts'
+import { scheduler } from 'node:timers/promises'
 
 // Create passwords as Confluent Kafka images don't support it via environment
 const saslBroker = parseBroker(kafkaSaslBootstrapServers[0])
@@ -582,7 +583,21 @@ test('Connection should handle unexpected correlation IDs', async t => {
       response.writeInt32BE(8, 0) // size (8 bytes payload)
       response.writeInt32BE(99999, 4) // Unexpected correlationId
       response.writeInt32BE(123, 8) // mock result
-      socket.end(response)
+      socket.write(response)
+
+      // Put next write on event loop to ensure onData is first processing only the first response
+      setTimeout(() => {
+        if (socket.writable) {
+          // Send another response with another unexpected correlation ID
+          // If this is received and processed by the connection, it will lead to an unhandled exception, because the
+          // connection only attaches an error handler via 'once'.
+          const response2 = Buffer.alloc(4 + 4 + 4) // size + correlationId + result
+          response2.writeInt32BE(8, 0) // size (8 bytes payload)
+          response2.writeInt32BE(100000, 4) // Unexpected correlationId
+          response2.writeInt32BE(124, 8) // mock result
+          socket.write(response2)
+        }
+      }, 0)
     })
   })
 
@@ -617,8 +632,12 @@ test('Connection should handle unexpected correlation IDs', async t => {
 
   // Wait for error
   const error = await errorPromise
-  ok(error instanceof UnexpectedCorrelationIdError)
-  strictEqual(error.message, 'Received unexpected response with correlation_id=99999')
+  ok(error instanceof NetworkError)
+  ok(error.cause instanceof UnexpectedCorrelationIdError)
+  strictEqual(error.cause.message, 'Received unexpected response with correlation_id=99999')
+
+  // Put test finish on event loop to allow server to send the second unexpected correlation ID
+  await scheduler.wait(0)
 })
 
 test('Connection should handle socket errors', async t => {


### PR DESCRIPTION
This change addresses crashes caused by unhandled errors that occur when multiple packets with unknown correlation IDs are received consecutively. The connection pool attaches an error handler via `connection.once('error', ...)`, which detaches the error handler after it has been invoked once. This error handler does not close the connection/socket. Further emitted errors will be handled as uncaught exceptions and will cause the program to exit, as the socket remains open when emitting this error and continues to listen for incoming messages. By destroying the socket and providing the appropriate error, we prevent the socket from handling any more packets, thus preventing uncaught exceptions.

Furthermore, by providing the error as a parameter to the socket destruction, we remain within the normal socket lifecycle, and all cleanup on socket closure is performed, which was previously also skipped entirely.


on-behalf-of: @SAP ospo@sap.com
Signed-off-by: Peter Lehnhardt <peter.lehnhardt@sap.com>