### PR TITLE
Implement Request Timeouts

### DIFF
--- a/src/apis/callbacks.ts
+++ b/src/apis/callbacks.ts
@@ -1,4 +1,4 @@
-import { MultipleErrors, TimeoutError } from '../errors.ts'
+import { MultipleErrors } from '../errors.ts'
 import { PromiseWithResolvers } from '../utils.ts'
 import { type Callback } from './definitions.ts'
 
@@ -63,27 +63,5 @@ export function runConcurrentCallbacks<ReturnType> (
 
   for (const item of collection) {
     operation(item, operationCallback.bind(null, i++))
-  }
-}
-
-export function createTimeoutCallback<ReturnType> (
-  callback: Callback<ReturnType>,
-  timeout: number,
-  errorMessage: string
-): Callback<ReturnType> {
-  let timeoutFired = false
-  const timeoutHandle = setTimeout(() => {
-    timeoutFired = true
-    callback(new TimeoutError(errorMessage), undefined as unknown as ReturnType)
-  }, timeout)
-
-  return (error: Error | null, result: ReturnType) => {
-    /* c8 ignore next 3 - Hard to test */
-    if (timeoutFired) {
-      return
-    }
-
-    clearTimeout(timeoutHandle)
-    callback(error, result)
   }
 }

--- a/src/clients/consumer/consumer.ts
+++ b/src/clients/consumer/consumer.ts
@@ -2,7 +2,6 @@ import { type ValidateFunction } from 'ajv'
 import {
   type CallbackWithPromise,
   createPromisifiedCallback,
-  createTimeoutCallback,
   kCallbackPromise,
   runConcurrentCallbacks
 } from '../../apis/callbacks.ts'
@@ -1141,8 +1140,6 @@ export class Consumer<Key = Buffer, Value = Buffer, HeaderKey = Buffer, HeaderVa
             return
           }
 
-          const timeoutCallback = createTimeoutCallback(groupCallback, this[kOptions].timeout!, 'Heartbeat timeout.')
-
           api(
             connection,
             this.groupId,
@@ -1154,7 +1151,7 @@ export class Consumer<Key = Buffer, Value = Buffer, HeaderKey = Buffer, HeaderVa
             this.topics.current,
             this.#groupRemoteAssignor,
             this.#assignments,
-            timeoutCallback
+            groupCallback
           )
         })
       },

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -139,7 +139,7 @@ export class NetworkError extends GenericError {
   static code: ErrorCode = 'PLT_KFK_NETWORK'
 
   constructor (message: string, properties: ErrorProperties = {}) {
-    super(NetworkError.code, message, properties)
+    super(NetworkError.code, message, { canRetry: true, ...properties })
   }
 }
 
@@ -199,7 +199,7 @@ export class TimeoutError extends GenericError {
   static code: ErrorCode = 'PLT_KFK_TIMEOUT'
 
   constructor (message: string, properties: ErrorProperties = {}) {
-    super(NetworkError.code, message, properties)
+    super(NetworkError.code, message, { canRetry: false, ...properties })
   }
 }
 

--- a/test/clients/base/base.test.ts
+++ b/test/clients/base/base.test.ts
@@ -11,6 +11,7 @@ import {
   Connection,
   MultipleErrors,
   sleep,
+  TimeoutError,
   UnsupportedApiError,
   type ClientDiagnosticEvent,
   type ClusterMetadata
@@ -541,22 +542,13 @@ test('metadata should handle connection failures to non-existent broker', async 
     strictEqual(['MultipleErrors', 'AggregateError'].includes(error.name), true)
 
     // Error message should indicate failure
-    strictEqual(error.message.includes('failed'), true)
+    strictEqual(error.message, 'Cannot connect to any broker.')
 
     // Should contain nested errors
     strictEqual(Array.isArray(error.errors), true)
-    strictEqual(error.errors.length > 0, true)
-
-    // At least one error should be a network error
-    const hasNetworkError = error.errors.some(
-      (err: any) =>
-        err.message.includes('ECONNREFUSED') ||
-        err.message.includes('ETIMEDOUT') ||
-        err.message.includes('getaddrinfo') ||
-        err.message.includes('connect')
-    )
-
-    strictEqual(hasNetworkError, true)
+    strictEqual(error.errors.length, 1)
+    strictEqual(error.errors[0] instanceof TimeoutError, true)
+    strictEqual(error.errors[0].message, 'Connection to 192.0.2.1:9092 timed out.')
   }
 })
 

--- a/test/clients/consumer/consumer.test.ts
+++ b/test/clients/consumer/consumer.test.ts
@@ -929,7 +929,7 @@ test('fetch should support both promise and callback API', async t => {
   const topicInfo = metadata.topics.get(topic)!
 
   await new Promise<void>((resolve, reject) => {
-    const consumer = createConsumer(t)
+    const consumer = createConsumer(t, { requestTimeout: 100000 })
 
     // First test callback API
     consumer.fetch(

--- a/test/clients/producer/producer.test.ts
+++ b/test/clients/producer/producer.test.ts
@@ -715,7 +715,7 @@ test('send should handle synchronuous error during payload creation', async t =>
   const testTopic = await createTopic(t)
 
   const compression = 'lz4'
-  const expectedError = new GenericError('PLT_KFK_UNSUPPORTED_COMPRESSION', 'Avoid RUD')
+  const expectedError = new GenericError('PLT_KFK_UNSUPPORTED_COMPRESSION', 'Avoid RUD', { canRetry: false })
   t.mock.method(compressionsAlgorithms[compression], 'compressSync', () => {
     throw expectedError
   })

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -131,7 +131,9 @@ export function mockMethod (
   fn?: (original: (...args: any[]) => void, ...args: any[]) => boolean | void
 ) {
   if (typeof errorToMock === 'undefined') {
-    errorToMock = new MultipleErrors(mockedErrorMessage, [new Error(mockedErrorMessage + ' (internal)')])
+    errorToMock = new MultipleErrors(mockedErrorMessage, [new Error(mockedErrorMessage + ' (internal)')], {
+      canRetry: false
+    })
   }
 
   const original = target[method].bind(target)
@@ -260,7 +262,9 @@ export function mockAPI (
   fn?: (original: (...args: any[]) => void, ...args: any[]) => boolean | void
 ) {
   if (typeof errorToMock === 'undefined') {
-    errorToMock = new MultipleErrors(mockedErrorMessage, [new Error(mockedErrorMessage + ' (internal)')])
+    errorToMock = new MultipleErrors(mockedErrorMessage, [new Error(mockedErrorMessage + ' (internal)')], {
+      canRetry: false
+    })
   }
 
   const originalGet = pool.get.bind(pool)


### PR DESCRIPTION
This change implements request timeouts for any request sent to the Kafka cluster. The timeout's duration can be configured via option `requestTimeout` in every client type.

Additionally, the retrying logic in the base class is changed so that it retries only if every error in the current error chain is marked as retriable. Otherwise, timeout errors, which should be handled as non-retriable errors, would potentially lead to much longer timeouts due to multiple attempts being made.

(But also in general, I would assume that every non-retriable error encountered should block any additional attempt)

on-behalf-of: @SAP ospo@sap.com
Signed-off-by: Peter Lehnhardt <peter.lehnhardt@sap.com>