### PR TITLE
Fix 41/NOT_CONTROLLER for non-Kraft clusters

### DIFF
--- a/src/clients/base/base.ts
+++ b/src/clients/base/base.ts
@@ -590,7 +590,8 @@ export class Base<OptionsType extends BaseOptions = BaseOptions> extends EventEm
                 id: metadata.clusterId!,
                 brokers: new Map(),
                 topics: new Map(),
-                lastUpdate
+                lastUpdate,
+                controllerId: metadata.controllerId
               }
             } else {
               this.#metadata.lastUpdate = lastUpdate

--- a/src/clients/base/types.ts
+++ b/src/clients/base/types.ts
@@ -23,6 +23,7 @@ export interface ClusterTopicMetadata {
 export interface ClusterMetadata {
   id: string
   brokers: Map<number, Broker>
+  controllerId: number
   topics: Map<string, ClusterTopicMetadata>
   lastUpdate: number
 }


### PR DESCRIPTION
For non-Kraft clusters, requests to create and delete clusters must be sent to the controller broker. Non-controller brokers are answering such requests with error 41/NOT_CONTROLLER. This change ensures that those requests are sent to the correct controller in case we receive error code 41 upon creating or deleting topics.

on-behalf-of: @SAP ospo@sap.com
Signed-off-by: Peter Lehnhardt <peter.lehnhardt@sap.com>