### PR TITLE
Implement Consumer Group Offset APIs

### DIFF
--- a/docs/admin.md
+++ b/docs/admin.md
@@ -154,6 +154,45 @@ Options:
 | -------- | ------------------------------- | -------------------------------------------------------------------------------- |
 | topics   | `DescribeLogDirsRequestTopic[]` | Array of topics specifying the topics and partitions for which to describe logs. |
 
+### `listConsumerGroupOffsets(options[, callback])`
+
+Lists committed offsets for consumer groups.
+
+The return value is an array of groups with information about committed offsets per partition per topic.
+
+Options:
+
+| Property      | Type                        | Description                                                                 |
+| ------------- | --------------------------- | --------------------------------------------------------------------------- |
+| groups        | `OffsetFetchRequestGroup[]` | Array of groups specifying the groups and topics for which to list offsets. |
+| requireStable | `boolean`                   | Whether to require stable offsets.                                          |
+
+### `alterConsumerGroupOffsets(options[, callback])`
+
+Alters committed offsets for a consumer group. Note, that the consumer group must be empty to succeed.
+
+The return value is `void`.
+
+Options:
+
+| Property | Type                               | Description                                                  |
+| -------- | ---------------------------------- | ------------------------------------------------------------ |
+| groupId  | `string`                           | The consumer group ID for which to alter offsets.            |
+| topics   | `AlterConsumerGroupOffsetsTopic[]` | Array of topics with partitions and their new offset values. |
+
+### `deleteConsumerGroupOffsets(options[, callback])`
+
+Deletes committed offsets for specific topics of a consumer group.
+
+The return value is an array of topic partitions indicating which offsets were deleted.
+
+Options:
+
+| Property | Type                                             | Description                                                 |
+| -------- | ------------------------------------------------ | ----------------------------------------------------------- |
+| groupId  | `string`                                         | The consumer group ID from which to delete offsets.         |
+| topics   | `{ name: string, partitionIndexes: number[] }[]` | Array of topics and partitions for which to delete offsets. |
+
 ### `close([callback])`
 
 Closes the admin and all its connections.

--- a/docs/diagnostic.md
+++ b/docs/diagnostic.md
@@ -62,23 +62,24 @@ Each tracing channel publishes events with the following common properties:
 
 ## Published tracing channels
 
-| Name                                | Target           | Description                                                                                                                  |
-| ----------------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `plt:kafka:connections:connects`    | `Connection`     | Traces a connection attempt to a broker.                                                                                     |
-| `plt:kafka:connections:api`         | `Connection`     | Traces a low level API request.                                                                                              |
-| `plt:kafka:connections:pools:gets`  | `ConnectionPool` | Traces a connection retrieval attempt from a connection pool.                                                                |
-| `plt:kafka:base:apis`               | `Base`           | Traces a `Base.listApis` request.                                                                                            |
-| `plt:kafka:base:metadata`           | `Base`           | Traces a `Base.metadata` request.                                                                                            |
-| `plt:kafka:admin:topics`            | `Admin`          | Traces a `Admin.createTopics` or `Admin.deleteTopics` request.                                                               |
-| `plt:kafka:admin:groups`            | `Admin`          | Traces a `Admin.listGroups`, `Admin.describeGroups`, `Admin.deleteGroups` or `Admin.removeMembersFromConsumerGroup` request. |
-| `plt:kafka:admin:clientQuotas`      | `Admin`          | Traces a `Admin.describeClientQuotas` or `Admin.alterClientQuotas` request.                                                  |
-| `plt:kafka:admin:logDirs`           | `Admin`          | Traces a `Admin.describeLogDirs` request.                                                                                    |
-| `plt:kafka:producer:initIdempotent` | `Producer`       | Traces a `Producer.initIdempotentProducer` request.                                                                          |
-| `plt:kafka:producer:sends`          | `Producer`       | Traces a `Producer.send` request.                                                                                            |
-| `plt:kafka:consumer:group`          | `Consumer`       | Traces a `Consumer.findGroupCoordinator`, `Consumer.joinGroup` or `Consumer.leaveGroup` requests.                            |
-| `plt:kafka:consumer:heartbeat`      | `Consumer`       | Traces the `Consumer` heartbeat requests.                                                                                    |
-| `plt:kafka:consumer:receives`       | `Consumer`       | Traces processing of every message.                                                                                          |
-| `plt:kafka:consumer:fetches`        | `Consumer`       | Traces a `Consumer.fetch` request.                                                                                           |
-| `plt:kafka:consumer:consumes`       | `Consumer`       | Traces a `Consumer.consume` request.                                                                                         |
-| `plt:kafka:consumer:commits`        | `Consumer`       | Traces a `Consumer.commit` request.                                                                                          |
-| `plt:kafka:consumer:offsets`        | `Consumer`       | Traces a `Consumer.listOffsets` or `Consumer.listCommittedOffsets` request.                                                  |
+| Name                                   | Target           | Description                                                                                                                  |
+| -------------------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `plt:kafka:connections:connects`       | `Connection`     | Traces a connection attempt to a broker.                                                                                     |
+| `plt:kafka:connections:api`            | `Connection`     | Traces a low level API request.                                                                                              |
+| `plt:kafka:connections:pools:gets`     | `ConnectionPool` | Traces a connection retrieval attempt from a connection pool.                                                                |
+| `plt:kafka:base:apis`                  | `Base`           | Traces a `Base.listApis` request.                                                                                            |
+| `plt:kafka:base:metadata`              | `Base`           | Traces a `Base.metadata` request.                                                                                            |
+| `plt:kafka:admin:topics`               | `Admin`          | Traces a `Admin.createTopics` or `Admin.deleteTopics` request.                                                               |
+| `plt:kafka:admin:groups`               | `Admin`          | Traces a `Admin.listGroups`, `Admin.describeGroups`, `Admin.deleteGroups` or `Admin.removeMembersFromConsumerGroup` request. |
+| `plt:kafka:admin:clientQuotas`         | `Admin`          | Traces a `Admin.describeClientQuotas` or `Admin.alterClientQuotas` request.                                                  |
+| `plt:kafka:admin:logDirs`              | `Admin`          | Traces a `Admin.describeLogDirs` request.                                                                                    |
+| `plt:kafka:admin:consumerGroupOffsets` | `Admin`          | Traces a `Admin.listConsumerGroupOffsets` or `Admin.deleteConsumerGroupOffsets` request.                                     |
+| `plt:kafka:producer:initIdempotent`    | `Producer`       | Traces a `Producer.initIdempotentProducer` request.                                                                          |
+| `plt:kafka:producer:sends`             | `Producer`       | Traces a `Producer.send` request.                                                                                            |
+| `plt:kafka:consumer:group`             | `Consumer`       | Traces a `Consumer.findGroupCoordinator`, `Consumer.joinGroup` or `Consumer.leaveGroup` requests.                            |
+| `plt:kafka:consumer:heartbeat`         | `Consumer`       | Traces the `Consumer` heartbeat requests.                                                                                    |
+| `plt:kafka:consumer:receives`          | `Consumer`       | Traces processing of every message.                                                                                          |
+| `plt:kafka:consumer:fetches`           | `Consumer`       | Traces a `Consumer.fetch` request.                                                                                           |
+| `plt:kafka:consumer:consumes`          | `Consumer`       | Traces a `Consumer.consume` request.                                                                                         |
+| `plt:kafka:consumer:commits`           | `Consumer`       | Traces a `Consumer.commit` request.                                                                                          |
+| `plt:kafka:consumer:offsets`           | `Consumer`       | Traces a `Consumer.listOffsets` or `Consumer.listCommittedOffsets` request.                                                  |

--- a/playground/apis/admin/offset-delete.ts
+++ b/playground/apis/admin/offset-delete.ts
@@ -9,11 +9,7 @@ await performAPICallWithRetry('OffsetDelete', () =>
   offsetDeleteV0.async(connection, 'g2', [
     {
       name: 'temp',
-      partitions: [
-        {
-          partitionIndex: 0
-        }
-      ]
+      partitions: [{ partitionIndex: 0 }]
     }
   ]))
 

--- a/src/apis/admin/offset-delete-v0.ts
+++ b/src/apis/admin/offset-delete-v0.ts
@@ -78,23 +78,31 @@ export function parseResponse (
   const response: OffsetDeleteResponse = {
     errorCode,
     throttleTimeMs: reader.readInt32(),
-    topics: reader.readArray((r, i) => {
-      return {
-        name: r.readString(),
-        partitions: r.readArray((r, j) => {
-          const partition = {
-            partitionIndex: r.readInt32(),
-            errorCode: r.readInt16()
-          }
+    topics: reader.readArray(
+      (r, i) => {
+        return {
+          name: r.readString(false),
+          partitions: r.readArray(
+            (r, j) => {
+              const partition = {
+                partitionIndex: r.readInt32(),
+                errorCode: r.readInt16()
+              }
 
-          if (partition.errorCode !== 0) {
-            errors.push([`/topics/${i}/partitions/${j}`, [partition.errorCode, null]])
-          }
+              if (partition.errorCode !== 0) {
+                errors.push([`/topics/${i}/partitions/${j}`, [partition.errorCode, null]])
+              }
 
-          return partition
-        })
-      }
-    })
+              return partition
+            },
+            false,
+            false
+          )
+        }
+      },
+      false,
+      false
+    )
   }
 
   if (errors.length) {

--- a/src/apis/consumer/offset-commit-v9.ts
+++ b/src/apis/consumer/offset-commit-v9.ts
@@ -50,7 +50,7 @@ export interface OffsetCommitResponse {
 export function createRequest (
   groupId: string,
   generationIdOrMemberEpoch: number,
-  memberId: string,
+  memberId: NullableString,
   groupInstanceId: NullableString,
   topics: OffsetCommitRequestTopic[]
 ): Writer {

--- a/src/apis/consumer/offset-fetch-v8.ts
+++ b/src/apis/consumer/offset-fetch-v8.ts
@@ -1,5 +1,5 @@
 import { ResponseError } from '../../errors.ts'
-import { type NullableString } from '../../protocol/definitions.ts'
+import { type Nullable, type NullableString } from '../../protocol/definitions.ts'
 import { type Reader } from '../../protocol/reader.ts'
 import { Writer } from '../../protocol/writer.ts'
 import { createAPI, type ResponseErrorWithLocation } from '../definitions.ts'
@@ -13,7 +13,7 @@ export interface OffsetFetchRequestGroup {
   groupId: string
   memberId?: NullableString
   memberEpoch: number
-  topics: OffsetFetchRequestTopic[]
+  topics?: Nullable<OffsetFetchRequestTopic[]>
 }
 
 export type OffsetFetchRequest = Parameters<typeof createRequest>

--- a/src/apis/consumer/offset-fetch-v9.ts
+++ b/src/apis/consumer/offset-fetch-v9.ts
@@ -1,5 +1,5 @@
 import { ResponseError } from '../../errors.ts'
-import { type NullableString } from '../../protocol/definitions.ts'
+import { type Nullable, type NullableString } from '../../protocol/definitions.ts'
 import { type Reader } from '../../protocol/reader.ts'
 import { Writer } from '../../protocol/writer.ts'
 import { createAPI, type ResponseErrorWithLocation } from '../definitions.ts'
@@ -13,7 +13,7 @@ export interface OffsetFetchRequestGroup {
   groupId: string
   memberId?: NullableString
   memberEpoch: number
-  topics: OffsetFetchRequestTopic[]
+  topics?: Nullable<OffsetFetchRequestTopic[]>
 }
 
 export type OffsetFetchRequest = Parameters<typeof createRequest>

--- a/src/clients/admin/admin.ts
+++ b/src/clients/admin/admin.ts
@@ -4,6 +4,17 @@ import {
   type AlterClientQuotasResponseEntries
 } from '../../apis/admin/alter-client-quotas-v1.ts'
 import { type CreatePartitionsRequest, type CreatePartitionsResponse } from '../../apis/admin/create-partitions-v3.ts'
+import { type OffsetDeleteRequest, type OffsetDeleteResponse } from '../../apis/admin/offset-delete-v0.ts'
+import {
+  type OffsetFetchRequest,
+  type OffsetFetchResponse,
+  type OffsetFetchRequestGroup
+} from '../../apis/consumer/offset-fetch-v9.ts'
+import {
+  type OffsetCommitRequest,
+  type OffsetCommitRequestTopic,
+  type OffsetCommitResponse
+} from '../../apis/consumer/offset-commit-v9.ts'
 import {
   type CreateTopicsRequest,
   type CreateTopicsRequestTopic,
@@ -45,6 +56,7 @@ import { type FindCoordinatorRequest, type FindCoordinatorResponse } from '../..
 import { type MetadataRequest, type MetadataResponse } from '../../apis/metadata/metadata-v12.ts'
 import {
   adminClientQuotasChannel,
+  adminConsumerGroupOffsetsChannel,
   adminGroupsChannel,
   adminLogDirsChannel,
   adminTopicsChannel,
@@ -80,7 +92,10 @@ import {
   describeLogDirsOptionsValidator,
   listGroupsOptionsValidator,
   listTopicsOptionsValidator,
-  removeMembersFromConsumerGroupOptionsValidator
+  removeMembersFromConsumerGroupOptionsValidator,
+  alterConsumerGroupOffsetsOptionsValidator,
+  deleteConsumerGroupOffsetsOptionsValidator,
+  listConsumerGroupOffsetsOptionsValidator
 } from './options.ts'
 import {
   type AdminOptions,
@@ -92,6 +107,9 @@ import {
   type DeleteGroupsOptions,
   type DeleteTopicsOptions,
   type DescribeClientQuotasOptions,
+  type DeleteConsumerGroupOffsetsOptions,
+  type ListConsumerGroupOffsetsOptions,
+  type AlterConsumerGroupOffsetsOptions,
   type DescribeGroupsOptions,
   type DescribeLogDirsOptions,
   type Group,
@@ -99,7 +117,8 @@ import {
   type GroupMember,
   type ListGroupsOptions,
   type ListTopicsOptions,
-  type RemoveMembersFromConsumerGroupOptions
+  type RemoveMembersFromConsumerGroupOptions,
+  type ListConsumerGroupOffsetsGroup
 } from './types.ts'
 
 export class Admin extends Base<AdminOptions> {
@@ -467,6 +486,120 @@ export class Admin extends Base<AdminOptions> {
       this.#describeLogDirs,
       1,
       createDiagnosticContext({ client: this, operation: 'describeLogDirs', options }),
+      this,
+      options,
+      callback
+    )
+
+    return callback[kCallbackPromise]
+  }
+
+  listConsumerGroupOffsets (
+    options: ListConsumerGroupOffsetsOptions,
+    callback: CallbackWithPromise<ListConsumerGroupOffsetsGroup[]>
+  ): void
+  listConsumerGroupOffsets (options: ListConsumerGroupOffsetsOptions): Promise<ListConsumerGroupOffsetsGroup[]>
+  listConsumerGroupOffsets (
+    options: ListConsumerGroupOffsetsOptions,
+    callback?: CallbackWithPromise<ListConsumerGroupOffsetsGroup[]>
+  ): void | Promise<ListConsumerGroupOffsetsGroup[]> {
+    if (!callback) {
+      callback = createPromisifiedCallback()
+    }
+
+    if (this[kCheckNotClosed](callback)) {
+      return callback[kCallbackPromise]
+    }
+
+    const validationError = this[kValidateOptions](options, listConsumerGroupOffsetsOptionsValidator, '/options', false)
+    if (validationError) {
+      callback(validationError, undefined as unknown as ListConsumerGroupOffsetsGroup[])
+      return callback[kCallbackPromise]
+    }
+
+    adminConsumerGroupOffsetsChannel.traceCallback(
+      this.#listConsumerGroupOffsets,
+      1,
+      createDiagnosticContext({ client: this, operation: 'listConsumerGroupOffsets', options }),
+      this,
+      options,
+      callback
+    )
+
+    return callback[kCallbackPromise]
+  }
+
+  alterConsumerGroupOffsets (options: AlterConsumerGroupOffsetsOptions, callback: CallbackWithPromise<void>): void
+  alterConsumerGroupOffsets (options: AlterConsumerGroupOffsetsOptions): Promise<void>
+  alterConsumerGroupOffsets (
+    options: AlterConsumerGroupOffsetsOptions,
+    callback?: CallbackWithPromise<void>
+  ): void | Promise<void> {
+    if (!callback) {
+      callback = createPromisifiedCallback()
+    }
+
+    if (this[kCheckNotClosed](callback)) {
+      return callback[kCallbackPromise]
+    }
+
+    const validationError = this[kValidateOptions](
+      options,
+      alterConsumerGroupOffsetsOptionsValidator,
+      '/options',
+      false
+    )
+    if (validationError) {
+      callback(validationError)
+      return callback[kCallbackPromise]
+    }
+
+    adminConsumerGroupOffsetsChannel.traceCallback(
+      this.#alterConsumerGroupOffsets,
+      1,
+      createDiagnosticContext({ client: this, operation: 'alterConsumerGroupOffsets', options }),
+      this,
+      options,
+      callback
+    )
+
+    return callback[kCallbackPromise]
+  }
+
+  deleteConsumerGroupOffsets (
+    options: DeleteConsumerGroupOffsetsOptions,
+    callback: CallbackWithPromise<{ name: string; partitionIndexes: number[] }[]>
+  ): void
+  deleteConsumerGroupOffsets (
+    options: DeleteConsumerGroupOffsetsOptions
+  ): Promise<{ name: string; partitionIndexes: number[] }[]>
+  deleteConsumerGroupOffsets (
+    options: DeleteConsumerGroupOffsetsOptions,
+    callback?: CallbackWithPromise<{ name: string; partitionIndexes: number[] }[]>
+  ): void | Promise<{ name: string; partitionIndexes: number[] }[]> {
+    if (!callback) {
+      callback = createPromisifiedCallback()
+    }
+
+    if (this[kCheckNotClosed](callback)) {
+      return callback[kCallbackPromise]
+    }
+
+    const validationError = this[kValidateOptions](
+      options,
+      deleteConsumerGroupOffsetsOptionsValidator,
+      '/options',
+      false
+    )
+    if (validationError) {
+      callback(validationError, undefined as unknown as { name: string; partitionIndexes: number[] }[])
+      return callback[kCallbackPromise]
+    }
+
+    adminConsumerGroupOffsetsChannel.traceCallback(
+      this.#deleteConsumerGroupOffsets,
+      1,
+      createDiagnosticContext({ client: this, operation: 'deleteConsumerGroupOffsets', options }),
       this,
       options,
       callback
@@ -1228,6 +1361,285 @@ export class Admin extends Base<AdminOptions> {
         },
         callback
       )
+    })
+  }
+
+  #listConsumerGroupOffsets (
+    options: ListConsumerGroupOffsetsOptions,
+    callback: CallbackWithPromise<ListConsumerGroupOffsetsGroup[]>
+  ): void {
+    this[kMetadata]({ topics: [] }, (error, metadata) => {
+      if (error) {
+        callback(error, undefined as unknown as ListConsumerGroupOffsetsGroup[])
+        return
+      }
+
+      const groupIds = options.groups.map(group => (typeof group === 'string' ? group : group.groupId))
+
+      this.#findGroupCoordinator(groupIds, (error, response) => {
+        if (error) {
+          callback(
+            new MultipleErrors('Listing consumer group offsets failed.', [error]),
+            undefined as unknown as ListConsumerGroupOffsetsGroup[]
+          )
+          return
+        }
+
+        const coordinators: Map<number, OffsetFetchRequestGroup[]> = new Map()
+        for (const { key: groupId, nodeId: node } of response.coordinators) {
+          const groupRequest: OffsetFetchRequestGroup = {
+            groupId,
+            memberId: null,
+            memberEpoch: -1
+          }
+
+          for (const group of options.groups) {
+            if (typeof group !== 'string' && group.groupId === groupId && !!group.topics && group.topics.length > 0) {
+              groupRequest.topics = group.topics
+              break
+            }
+          }
+
+          let coordinator = coordinators.get(node)
+          if (!coordinator) {
+            coordinator = []
+            coordinators.set(node, coordinator)
+          }
+
+          coordinator.push(groupRequest)
+        }
+
+        runConcurrentCallbacks<OffsetFetchResponse>(
+          'Listing consumer group offsets failed.',
+          coordinators,
+          ([node, groups], concurrentCallback) => {
+            this[kGetConnection](metadata.brokers.get(node)!, (error, connection) => {
+              if (error) {
+                concurrentCallback(error, undefined as unknown as OffsetFetchResponse)
+                return
+              }
+
+              this[kPerformWithRetry]<OffsetFetchResponse>(
+                'offsetFetch',
+                retryCallback => {
+                  this[kGetApi]<OffsetFetchRequest, OffsetFetchResponse>('OffsetFetch', (error, api) => {
+                    if (error) {
+                      retryCallback(error, undefined as unknown as OffsetFetchResponse)
+                      return
+                    }
+
+                    api(connection, groups, options.requireStable ?? false, retryCallback)
+                  })
+                },
+                concurrentCallback,
+                0
+              )
+            })
+          },
+          (error, responses) => {
+            if (error) {
+              callback(error, undefined as unknown as ListConsumerGroupOffsetsGroup[])
+              return
+            }
+
+            callback(
+              null,
+              responses.flatMap(r =>
+                r.groups.map(group => ({
+                  groupId: group.groupId,
+                  topics: group.topics.map(topic => ({
+                    name: topic.name,
+                    partitions: topic.partitions.map(p => ({
+                      partitionIndex: p.partitionIndex,
+                      committedOffset: p.committedOffset,
+                      committedLeaderEpoch: p.committedLeaderEpoch,
+                      metadata: p.metadata
+                    }))
+                  }))
+                })))
+            )
+          }
+        )
+      })
+    })
+  }
+
+  #alterConsumerGroupOffsets (options: AlterConsumerGroupOffsetsOptions, callback: CallbackWithPromise<void>): void {
+    this[kMetadata]({ topics: [] }, (error, metadata) => {
+      if (error) {
+        callback(error, undefined)
+        return
+      }
+
+      this.#findGroupCoordinator([options.groupId], (error, response) => {
+        if (error) {
+          callback(new MultipleErrors('Altering consumer group offsets failed.', [error]))
+          return
+        }
+
+        const coordinator = response.coordinators.find(c => c.key === options.groupId)
+        if (!coordinator) {
+          callback(
+            new MultipleErrors('Altering consumer group offsets failed.', [
+              new Error(`No coordinator found for group ${options.groupId}`)
+            ])
+          )
+          return
+        }
+
+        const broker = metadata.brokers.get(coordinator.nodeId)
+        if (!broker) {
+          callback(
+            new MultipleErrors('Altering consumer group offsets failed.', [
+              new Error(`Broker ${coordinator.nodeId} not found`)
+            ])
+          )
+          return
+        }
+
+        this[kGetConnection](broker, (error, connection) => {
+          if (error) {
+            callback(new MultipleErrors('Altering consumer group offsets failed.', [error]))
+            return
+          }
+
+          this[kPerformWithRetry]<OffsetCommitResponse>(
+            'alterConsumerGroupOffsets',
+            retryCallback => {
+              this[kGetApi]<OffsetCommitRequest, OffsetCommitResponse>('OffsetCommit', (error, api) => {
+                if (error) {
+                  retryCallback(error, undefined as unknown as OffsetCommitResponse)
+                  return
+                }
+
+                const topics: OffsetCommitRequestTopic[] = []
+                for (const topic of options.topics) {
+                  const partitions = topic.partitionOffsets.map(p => ({
+                    partitionIndex: p.partition,
+                    committedOffset: p.offset,
+                    committedLeaderEpoch: -1,
+                    committedMetadata: null
+                  }))
+                  topics.push({ name: topic.name, partitions })
+                }
+
+                api(
+                  connection,
+                  options.groupId,
+                  -1,
+                  '',
+                  null,
+                  topics,
+                  retryCallback as unknown as Callback<OffsetCommitResponse>
+                )
+              })
+            },
+            (error: Error | null) => {
+              if (error) {
+                callback(new MultipleErrors('Altering consumer group offsets failed.', [error]))
+                return
+              }
+
+              callback(null)
+            },
+            0
+          )
+        })
+      })
+    })
+  }
+
+  #deleteConsumerGroupOffsets (
+    options: DeleteConsumerGroupOffsetsOptions,
+    callback: CallbackWithPromise<{ name: string; partitionIndexes: number[] }[]>
+  ): void {
+    this[kMetadata]({ topics: [] }, (error, metadata) => {
+      if (error) {
+        callback(error, undefined as unknown as { name: string; partitionIndexes: number[] }[])
+        return
+      }
+
+      this.#findGroupCoordinator([options.groupId], (error, response) => {
+        if (error) {
+          callback(
+            new MultipleErrors('Deleting consumer group offsets failed.', [error]),
+            undefined as unknown as { name: string; partitionIndexes: number[] }[]
+          )
+          return
+        }
+
+        const coordinator = response.coordinators.find(c => c.key === options.groupId)
+        if (!coordinator) {
+          callback(
+            new MultipleErrors('Deleting consumer group offsets failed.', [
+              new Error(`No coordinator found for group ${options.groupId}`)
+            ]),
+            undefined as unknown as { name: string; partitionIndexes: number[] }[]
+          )
+          return
+        }
+
+        const broker = metadata.brokers.get(coordinator.nodeId)
+        if (!broker) {
+          callback(
+            new MultipleErrors('Deleting consumer group offsets failed.', [
+              new Error(`Broker ${coordinator.nodeId} not found`)
+            ]),
+            undefined as unknown as { name: string; partitionIndexes: number[] }[]
+          )
+          return
+        }
+
+        this[kGetConnection](broker, (error, connection) => {
+          if (error) {
+            callback(
+              new MultipleErrors('Deleting consumer group offsets failed.', [error]),
+              undefined as unknown as { name: string; partitionIndexes: number[] }[]
+            )
+            return
+          }
+
+          this[kPerformWithRetry]<OffsetDeleteResponse>(
+            'deleteOffset',
+            retryCallback => {
+              this[kGetApi]<OffsetDeleteRequest, OffsetDeleteResponse>('OffsetDelete', (error, api) => {
+                if (error) {
+                  retryCallback(error, undefined as unknown as OffsetDeleteResponse)
+                  return
+                }
+
+                api(
+                  connection,
+                  options.groupId,
+                  options.topics.map(t => ({
+                    name: t.name,
+                    partitions: t.partitionIndexes.map(p => ({ partitionIndex: p }))
+                  })),
+                  retryCallback as unknown as Callback<OffsetDeleteResponse>
+                )
+              })
+            },
+            (error: Error | null, response: OffsetDeleteResponse) => {
+              if (error) {
+                callback(
+                  new MultipleErrors('Deleting consumer group offsets failed.', [error]),
+                  undefined as unknown as { name: string; partitionIndexes: number[] }[]
+                )
+                return
+              }
+
+              callback(
+                null,
+                response.topics.map(topic => ({
+                  name: topic.name,
+                  partitionIndexes: topic.partitions.map(p => p.partitionIndex)
+                }))
+              )
+            },
+            0
+          )
+        })
+      })
     })
   }
 }

--- a/src/clients/admin/options.ts
+++ b/src/clients/admin/options.ts
@@ -254,6 +254,111 @@ export const describeLogDirsOptionsSchema = {
   additionalProperties: false
 }
 
+export const listConsumerGroupOffsetsOptionsSchema = {
+  type: 'object',
+  properties: {
+    groups: {
+      type: 'array',
+      items: {
+        oneOf: [
+          { type: 'string', minLength: 1 },
+          {
+            type: 'object',
+            properties: {
+              groupId: { type: 'string', minLength: 1 },
+              topics: {
+                type: ['array', 'null'],
+                items: {
+                  type: 'object',
+                  properties: {
+                    name: { type: 'string', minLength: 1 },
+                    partitionIndexes: {
+                      type: 'array',
+                      items: { type: 'number', minimum: 0 },
+                      minItems: 1
+                    }
+                  },
+                  required: ['name', 'partitionIndexes'],
+                  additionalProperties: false
+                },
+                minItems: 1
+              }
+            },
+            required: ['groupId'],
+            additionalProperties: false
+          }
+        ]
+      },
+      minItems: 1
+    },
+    requireStable: {
+      type: 'boolean'
+    }
+  },
+  required: ['groups'],
+  additionalProperties: false
+}
+
+export const alterConsumerGroupOffsetsOptionsSchema = {
+  type: 'object',
+  properties: {
+    groupId: { type: 'string', minLength: 1 },
+    topics: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          name: { type: 'string', minLength: 1 },
+          partitionOffsets: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                partition: { type: 'number', minimum: 0 },
+                offset: { bigint: true }
+              },
+              required: ['partition', 'offset'],
+              additionalProperties: false
+            },
+            minItems: 1
+          }
+        },
+        required: ['name', 'partitionOffsets'],
+        additionalProperties: false
+      },
+      minItems: 1
+    }
+  },
+  required: ['groupId', 'topics'],
+  additionalProperties: false
+}
+
+export const deleteConsumerGroupOffsetsOptionsSchema = {
+  type: 'object',
+  properties: {
+    groupId: { type: 'string', minLength: 1 },
+    topics: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          name: { type: 'string', minLength: 1 },
+          partitionIndexes: {
+            type: 'array',
+            items: { type: 'number', minimum: 0 },
+            minItems: 1
+          }
+        },
+        required: ['name', 'partitionIndexes'],
+        additionalProperties: false
+      },
+      minItems: 1
+    }
+  },
+  required: ['groupId', 'topics'],
+  additionalProperties: false
+}
+
 export const createTopicsOptionsValidator = ajv.compile(createTopicOptionsSchema)
 export const createPartitionsOptionsValidator = ajv.compile(createPartitionsOptionsSchema)
 export const listTopicsOptionsValidator = ajv.compile(listTopicOptionsSchema)
@@ -265,3 +370,6 @@ export const removeMembersFromConsumerGroupOptionsValidator = ajv.compile(remove
 export const describeClientQuotasOptionsValidator = ajv.compile(describeClientQuotasOptionsSchema)
 export const alterClientQuotasOptionsValidator = ajv.compile(alterClientQuotasOptionsSchema)
 export const describeLogDirsOptionsValidator = ajv.compile(describeLogDirsOptionsSchema)
+export const alterConsumerGroupOffsetsOptionsValidator = ajv.compile(alterConsumerGroupOffsetsOptionsSchema)
+export const deleteConsumerGroupOffsetsOptionsValidator = ajv.compile(deleteConsumerGroupOffsetsOptionsSchema)
+export const listConsumerGroupOffsetsOptionsValidator = ajv.compile(listConsumerGroupOffsetsOptionsSchema)

--- a/src/clients/admin/types.ts
+++ b/src/clients/admin/types.ts
@@ -114,3 +114,50 @@ export interface BrokerLogDirDescription {
   throttleTimeMs: DescribeLogDirsResponse['throttleTimeMs']
   results: Omit<DescribeLogDirsResponseResult, 'errorCode'>[]
 }
+
+interface GroupWithTopicPartitions {
+  groupId: string
+  topics?: Nullable<{ name: string; partitionIndexes: number[] }[]>
+}
+
+export interface ListConsumerGroupOffsetsOptions {
+  groups: (string | GroupWithTopicPartitions)[]
+  requireStable?: boolean
+}
+
+interface ListConsumerGroupOffsetsPartition {
+  partitionIndex: number
+  committedOffset: bigint
+  committedLeaderEpoch: number
+  metadata: NullableString
+}
+
+interface ListConsumerGroupOffsetsTopic {
+  name: string
+  partitions: ListConsumerGroupOffsetsPartition[]
+}
+
+export interface ListConsumerGroupOffsetsGroup {
+  groupId: string
+  topics: ListConsumerGroupOffsetsTopic[]
+}
+
+interface PartitionOffset {
+  partition: number
+  offset: bigint
+}
+
+interface AlterConsumerGroupOffsetsTopic {
+  name: string
+  partitionOffsets: PartitionOffset[]
+}
+
+export interface AlterConsumerGroupOffsetsOptions {
+  groupId: string
+  topics: AlterConsumerGroupOffsetsTopic[]
+}
+
+export interface DeleteConsumerGroupOffsetsOptions {
+  groupId: string
+  topics: { name: string; partitionIndexes: number[] }[]
+}

--- a/src/clients/consumer/consumer.ts
+++ b/src/clients/consumer/consumer.ts
@@ -28,8 +28,8 @@ import {
   type OffsetCommitResponse
 } from '../../apis/consumer/offset-commit-v9.ts'
 import {
-  type OffsetFetchRequest,
   type OffsetFetchRequestTopic,
+  type OffsetFetchRequest,
   type OffsetFetchResponse
 } from '../../apis/consumer/offset-fetch-v9.ts'
 import {

--- a/src/diagnostic.ts
+++ b/src/diagnostic.ts
@@ -77,6 +77,8 @@ export const adminTopicsChannel = createTracingChannel<ClientDiagnosticEvent>('a
 export const adminGroupsChannel = createTracingChannel<ClientDiagnosticEvent>('admin:groups')
 export const adminClientQuotasChannel = createTracingChannel<ClientDiagnosticEvent>('admin:clientQuotas')
 export const adminLogDirsChannel = createTracingChannel<ClientDiagnosticEvent>('admin:logDirs')
+export const adminConsumerGroupOffsetsChannel =
+  createTracingChannel<ClientDiagnosticEvent>('admin:consumerGroupOffsets')
 
 // Producer channels
 export const producerInitIdempotentChannel = createTracingChannel<ClientDiagnosticEvent>('producer:initIdempotent')

--- a/test/apis/admin/offset-delete-v0.test.ts
+++ b/test/apis/admin/offset-delete-v0.test.ts
@@ -210,10 +210,17 @@ test('parseResponse correctly processes a successful response', () => {
         }
       ],
       (w, topic) => {
-        w.appendString(topic.name).appendArray(topic.partitions, (w, partition) => {
-          w.appendInt32(partition.partitionIndex).appendInt16(partition.errorCode)
-        })
-      }
+        w.appendString(topic.name, false).appendArray(
+          topic.partitions,
+          (w, partition) => {
+            w.appendInt32(partition.partitionIndex).appendInt16(partition.errorCode)
+          },
+          false,
+          false
+        )
+      },
+      false,
+      false
     )
 
   const response = parseResponse(1, 47, 0, Reader.from(writer))
@@ -267,10 +274,17 @@ test('parseResponse correctly processes multiple topics', () => {
         }
       ],
       (w, topic) => {
-        w.appendString(topic.name).appendArray(topic.partitions, (w, partition) => {
-          w.appendInt32(partition.partitionIndex).appendInt16(partition.errorCode)
-        })
-      }
+        w.appendString(topic.name, false).appendArray(
+          topic.partitions,
+          (w, partition) => {
+            w.appendInt32(partition.partitionIndex).appendInt16(partition.errorCode)
+          },
+          false,
+          false
+        )
+      },
+      false,
+      false
     )
 
   const response = parseResponse(1, 47, 0, Reader.from(writer))
@@ -310,10 +324,17 @@ test('parseResponse correctly processes multiple partitions', () => {
         }
       ],
       (w, topic) => {
-        w.appendString(topic.name).appendArray(topic.partitions, (w, partition) => {
-          w.appendInt32(partition.partitionIndex).appendInt16(partition.errorCode)
-        })
-      }
+        w.appendString(topic.name, false).appendArray(
+          topic.partitions,
+          (w, partition) => {
+            w.appendInt32(partition.partitionIndex).appendInt16(partition.errorCode)
+          },
+          false,
+          false
+        )
+      },
+      false,
+      false
     )
 
   const response = parseResponse(1, 47, 0, Reader.from(writer))
@@ -345,10 +366,17 @@ test('parseResponse handles partition level errors correctly', () => {
         }
       ],
       (w, topic) => {
-        w.appendString(topic.name).appendArray(topic.partitions, (w, partition) => {
-          w.appendInt32(partition.partitionIndex).appendInt16(partition.errorCode)
-        })
-      }
+        w.appendString(topic.name, false).appendArray(
+          topic.partitions,
+          (w, partition) => {
+            w.appendInt32(partition.partitionIndex).appendInt16(partition.errorCode)
+          },
+          false,
+          false
+        )
+      },
+      false,
+      false
     )
 
   // Verify that parsing throws ResponseError
@@ -389,10 +417,17 @@ test('parseResponse handles mixed partition successes and errors', () => {
         }
       ],
       (w, topic) => {
-        w.appendString(topic.name).appendArray(topic.partitions, (w, partition) => {
-          w.appendInt32(partition.partitionIndex).appendInt16(partition.errorCode)
-        })
-      }
+        w.appendString(topic.name, false).appendArray(
+          topic.partitions,
+          (w, partition) => {
+            w.appendInt32(partition.partitionIndex).appendInt16(partition.errorCode)
+          },
+          false,
+          false
+        )
+      },
+      false,
+      false
     )
 
   // Verify that parsing throws ResponseError
@@ -426,7 +461,7 @@ test('parseResponse handles top-level error correctly', () => {
   const writer = Writer.create()
     .appendInt16(16) // GROUP_AUTHORIZATION_FAILED
     .appendInt32(0) // throttleTimeMs
-    .appendArray([], () => {}) // Empty topics array
+    .appendArray([], () => {}, false, false) // Empty topics array
 
   // Verify that parsing throws ResponseError
   throws(
@@ -460,10 +495,17 @@ test('parseResponse handles throttle time correctly', () => {
         }
       ],
       (w, topic) => {
-        w.appendString(topic.name).appendArray(topic.partitions, (w, partition) => {
-          w.appendInt32(partition.partitionIndex).appendInt16(partition.errorCode)
-        })
-      }
+        w.appendString(topic.name, false).appendArray(
+          topic.partitions,
+          (w, partition) => {
+            w.appendInt32(partition.partitionIndex).appendInt16(partition.errorCode)
+          },
+          false,
+          false
+        )
+      },
+      false,
+      false
     )
 
   const response = parseResponse(1, 47, 0, Reader.from(writer))


### PR DESCRIPTION
This change implements `listConsumerGroupOffsets`, `alterConsumerGroupOffsets`, and `deleteConsumerGroupOffsets` on the admin client.

on-behalf-of: @SAP ospo@sap.com
Signed-off-by: Peter Lehnhardt <peter.lehnhardt@sap.com>