### PR TITLE
Implement Consumer Group Member Removal API

### DIFF
--- a/docs/admin.md
+++ b/docs/admin.md
@@ -90,6 +90,19 @@ Options:
 | -------- | ---------- | ----------------- |
 | groups   | `string[]` | Groups to delete. |
 
+### `removeMembersFromConsumerGroup(options[, callback])`
+
+Removes members from a consumer group.
+
+The return value is `void`.
+
+Options:
+
+| Property | Type                                  | Description                                                                                                                                                               |
+| -------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| groupId  | `string`                              | The consumer group ID.                                                                                                                                                    |
+| members  | `(string \| MemberRemoval)[] \| null` | Array of member IDs to remove (as strings), or an array of `MemberRemoval` objects with `memberId` and optional `reason`, or `null` to remove all members from the group. |
+
 ### `describeClientQuotas(options[, callback])`
 
 Gets detailed information about client quotas.

--- a/docs/diagnostic.md
+++ b/docs/diagnostic.md
@@ -62,23 +62,23 @@ Each tracing channel publishes events with the following common properties:
 
 ## Published tracing channels
 
-| Name                                | Target           | Description                                                                                       |
-| ----------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------- |
-| `plt:kafka:connections:connects`    | `Connection`     | Traces a connection attempt to a broker.                                                          |
-| `plt:kafka:connections:api`         | `Connection`     | Traces a low level API request.                                                                   |
-| `plt:kafka:connections:pools:gets`  | `ConnectionPool` | Traces a connection retrieval attempt from a connection pool.                                     |
-| `plt:kafka:base:apis`               | `Base`           | Traces a `Base.listApis` request.                                                                 |
-| `plt:kafka:base:metadata`           | `Base`           | Traces a `Base.metadata` request.                                                                 |
-| `plt:kafka:admin:topics`            | `Admin`          | Traces a `Admin.createTopics` or `Admin.deleteTopics` request.                                    |
-| `plt:kafka:admin:groups`            | `Admin`          | Traces a `Admin.listGroups`, `Admin.describeGroups` or `Admin.deleteGroups` request.              |
-| `plt:kafka:admin:clientQuotas`      | `Admin`          | Traces a `Admin.describeClientQuotas` or `Admin.alterClientQuotas` request.                       |
-| `plt:kafka:admin:logDirs`           | `Admin`          | Traces a `Admin.describeLogDirs` request.                                                         |
-| `plt:kafka:producer:initIdempotent` | `Producer`       | Traces a `Producer.initIdempotentProducer` request.                                               |
-| `plt:kafka:producer:sends`          | `Producer`       | Traces a `Producer.send` request.                                                                 |
-| `plt:kafka:consumer:group`          | `Consumer`       | Traces a `Consumer.findGroupCoordinator`, `Consumer.joinGroup` or `Consumer.leaveGroup` requests. |
-| `plt:kafka:consumer:heartbeat`      | `Consumer`       | Traces the `Consumer` heartbeat requests.                                                         |
-| `plt:kafka:consumer:receives`       | `Consumer`       | Traces processing of every message.                                                               |
-| `plt:kafka:consumer:fetches`        | `Consumer`       | Traces a `Consumer.fetch` request.                                                                |
-| `plt:kafka:consumer:consumes`       | `Consumer`       | Traces a `Consumer.consume` request.                                                              |
-| `plt:kafka:consumer:commits`        | `Consumer`       | Traces a `Consumer.commit` request.                                                               |
-| `plt:kafka:consumer:offsets`        | `Consumer`       | Traces a `Consumer.listOffsets` or `Consumer.listCommittedOffsets` request.                       |
+| Name                                | Target           | Description                                                                                                                  |
+| ----------------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `plt:kafka:connections:connects`    | `Connection`     | Traces a connection attempt to a broker.                                                                                     |
+| `plt:kafka:connections:api`         | `Connection`     | Traces a low level API request.                                                                                              |
+| `plt:kafka:connections:pools:gets`  | `ConnectionPool` | Traces a connection retrieval attempt from a connection pool.                                                                |
+| `plt:kafka:base:apis`               | `Base`           | Traces a `Base.listApis` request.                                                                                            |
+| `plt:kafka:base:metadata`           | `Base`           | Traces a `Base.metadata` request.                                                                                            |
+| `plt:kafka:admin:topics`            | `Admin`          | Traces a `Admin.createTopics` or `Admin.deleteTopics` request.                                                               |
+| `plt:kafka:admin:groups`            | `Admin`          | Traces a `Admin.listGroups`, `Admin.describeGroups`, `Admin.deleteGroups` or `Admin.removeMembersFromConsumerGroup` request. |
+| `plt:kafka:admin:clientQuotas`      | `Admin`          | Traces a `Admin.describeClientQuotas` or `Admin.alterClientQuotas` request.                                                  |
+| `plt:kafka:admin:logDirs`           | `Admin`          | Traces a `Admin.describeLogDirs` request.                                                                                    |
+| `plt:kafka:producer:initIdempotent` | `Producer`       | Traces a `Producer.initIdempotentProducer` request.                                                                          |
+| `plt:kafka:producer:sends`          | `Producer`       | Traces a `Producer.send` request.                                                                                            |
+| `plt:kafka:consumer:group`          | `Consumer`       | Traces a `Consumer.findGroupCoordinator`, `Consumer.joinGroup` or `Consumer.leaveGroup` requests.                            |
+| `plt:kafka:consumer:heartbeat`      | `Consumer`       | Traces the `Consumer` heartbeat requests.                                                                                    |
+| `plt:kafka:consumer:receives`       | `Consumer`       | Traces processing of every message.                                                                                          |
+| `plt:kafka:consumer:fetches`        | `Consumer`       | Traces a `Consumer.fetch` request.                                                                                           |
+| `plt:kafka:consumer:consumes`       | `Consumer`       | Traces a `Consumer.consume` request.                                                                                         |
+| `plt:kafka:consumer:commits`        | `Consumer`       | Traces a `Consumer.commit` request.                                                                                          |
+| `plt:kafka:consumer:offsets`        | `Consumer`       | Traces a `Consumer.listOffsets` or `Consumer.listCommittedOffsets` request.                                                  |

--- a/src/clients/admin/admin.ts
+++ b/src/clients/admin/admin.ts
@@ -24,6 +24,11 @@ import { type DescribeGroupsRequest, type DescribeGroupsResponse } from '../../a
 import { type DescribeLogDirsRequest, type DescribeLogDirsResponse } from '../../apis/admin/describe-log-dirs-v4.ts'
 import { type ListGroupsRequest as ListGroupsRequestV4 } from '../../apis/admin/list-groups-v4.ts'
 import {
+  type LeaveGroupRequest,
+  type LeaveGroupRequestMember,
+  type LeaveGroupResponse
+} from '../../apis/consumer/leave-group-v5.ts'
+import {
   type ListGroupsRequest as ListGroupsRequestV5,
   type ListGroupsResponse
 } from '../../apis/admin/list-groups-v5.ts'
@@ -70,7 +75,8 @@ import {
   describeGroupsOptionsValidator,
   describeLogDirsOptionsValidator,
   listGroupsOptionsValidator,
-  listTopicsOptionsValidator
+  listTopicsOptionsValidator,
+  removeMembersFromConsumerGroupOptionsValidator
 } from './options.ts'
 import {
   type AdminOptions,
@@ -87,7 +93,8 @@ import {
   type GroupBase,
   type GroupMember,
   type ListGroupsOptions,
-  type ListTopicsOptions
+  type ListTopicsOptions,
+  type RemoveMembersFromConsumerGroupOptions
 } from './types.ts'
 
 export class Admin extends Base<AdminOptions> {
@@ -281,6 +288,46 @@ export class Admin extends Base<AdminOptions> {
       this.#deleteGroups,
       1,
       createDiagnosticContext({ client: this, operation: 'deleteGroups', options }),
+      this,
+      options,
+      callback
+    )
+
+    return callback[kCallbackPromise]
+  }
+
+  removeMembersFromConsumerGroup (
+    options: RemoveMembersFromConsumerGroupOptions,
+    callback: CallbackWithPromise<void>
+  ): void
+  removeMembersFromConsumerGroup (options: RemoveMembersFromConsumerGroupOptions): Promise<void>
+  removeMembersFromConsumerGroup (
+    options: RemoveMembersFromConsumerGroupOptions,
+    callback?: CallbackWithPromise<void>
+  ): void | Promise<void> {
+    if (!callback) {
+      callback = createPromisifiedCallback()
+    }
+
+    if (this[kCheckNotClosed](callback)) {
+      return callback[kCallbackPromise]
+    }
+
+    const validationError = this[kValidateOptions](
+      options,
+      removeMembersFromConsumerGroupOptionsValidator,
+      '/options',
+      false
+    )
+    if (validationError) {
+      callback(validationError)
+      return callback[kCallbackPromise]
+    }
+
+    adminGroupsChannel.traceCallback(
+      this.#removeMembersFromConsumerGroup,
+      1,
+      createDiagnosticContext({ client: this, operation: 'removeMembersFromConsumerGroup', options }),
       this,
       options,
       callback
@@ -807,6 +854,108 @@ export class Admin extends Base<AdminOptions> {
           },
           error => callback(error)
         )
+      })
+    })
+  }
+
+  #removeMembersFromConsumerGroup (
+    options: RemoveMembersFromConsumerGroupOptions,
+    callback: CallbackWithPromise<void>
+  ): void {
+    if (!options.members || options.members.length === 0) {
+      this.#describeGroups({ groups: [options.groupId] }, (error, groupsMap) => {
+        if (error) {
+          callback(new MultipleErrors('Removing members from consumer group failed.', [error]))
+          return
+        }
+
+        const group = groupsMap.get(options.groupId)
+        if (!group) {
+          callback(new MultipleErrors('Removing members from consumer group failed.', []))
+          return
+        }
+
+        const allMemberIds = Array.from(group.members.keys())
+        if (allMemberIds.length === 0) {
+          callback(null)
+          return
+        }
+
+        this.#removeMembersFromConsumerGroup(
+          { ...options, members: allMemberIds.map(memberId => ({ memberId })) },
+          callback
+        )
+      })
+      return
+    }
+
+    this[kMetadata]({ topics: [] }, (error, metadata) => {
+      if (error) {
+        callback(error, undefined)
+        return
+      }
+
+      this.#findGroupCoordinator([options.groupId], (error, response) => {
+        if (error) {
+          callback(new MultipleErrors('Removing members from consumer group failed.', [error]))
+          return
+        }
+
+        const coordinator = response.coordinators.find(c => c.key === options.groupId)
+        if (!coordinator) {
+          callback(
+            new MultipleErrors('Removing members from consumer group failed.', [
+              new Error(`No coordinator found for group ${options.groupId}`)
+            ])
+          )
+          return
+        }
+
+        const broker = metadata.brokers.get(coordinator.nodeId)
+        if (!broker) {
+          callback(
+            new MultipleErrors('Removing members from consumer group failed.', [
+              new Error(`Broker ${coordinator.nodeId} not found`)
+            ])
+          )
+          return
+        }
+
+        this[kGetConnection](broker, (error, connection) => {
+          if (error) {
+            callback(new MultipleErrors('Removing members from consumer group failed.', [error]))
+            return
+          }
+
+          this[kPerformWithRetry]<LeaveGroupResponse>(
+            'removeMembersFromConsumerGroup',
+            retryCallback => {
+              this[kGetApi]<LeaveGroupRequest, LeaveGroupResponse>('LeaveGroup', (error, api) => {
+                if (error) {
+                  retryCallback(error, undefined as unknown as LeaveGroupResponse)
+                  return
+                }
+
+                const members: LeaveGroupRequestMember[] = options.members!.map(member => ({
+                  memberId: typeof member === 'string' ? member : member.memberId,
+                  groupInstanceId: null,
+                  reason: typeof member === 'string' ? 'Not specified' : member.reason
+                }))
+
+                api(connection, options.groupId, members, retryCallback as unknown as Callback<LeaveGroupResponse>)
+              })
+            },
+            (error: Error | null) => {
+              if (error) {
+                callback(new MultipleErrors('Removing members from consumer group failed.', [error]))
+                return
+              }
+
+              callback(null)
+            },
+            0
+          )
+        })
       })
     })
   }

--- a/src/clients/admin/options.ts
+++ b/src/clients/admin/options.ts
@@ -91,6 +91,28 @@ export const deleteGroupsOptionsSchema = {
   additionalProperties: false
 }
 
+export const removeMembersFromConsumerGroupOptionsSchema = {
+  type: 'object',
+  properties: {
+    groupId: idProperty,
+    members: {
+      type: ['array', 'null'],
+      items: {
+        type: 'object',
+        properties: {
+          memberId: idProperty,
+          reason: { type: 'string', minLength: 1 }
+        },
+        required: ['memberId'],
+        additionalProperties: false
+      },
+      default: null
+    }
+  },
+  required: ['groupId'],
+  additionalProperties: false
+}
+
 export const describeClientQuotasOptionsSchema = {
   type: 'object',
   properties: {
@@ -205,6 +227,7 @@ export const deleteTopicsOptionsValidator = ajv.compile(deleteTopicOptionsSchema
 export const listGroupsOptionsValidator = ajv.compile(listGroupsOptionsSchema)
 export const describeGroupsOptionsValidator = ajv.compile(describeGroupsOptionsSchema)
 export const deleteGroupsOptionsValidator = ajv.compile(deleteGroupsOptionsSchema)
+export const removeMembersFromConsumerGroupOptionsValidator = ajv.compile(removeMembersFromConsumerGroupOptionsSchema)
 export const describeClientQuotasOptionsValidator = ajv.compile(describeClientQuotasOptionsSchema)
 export const alterClientQuotasOptionsValidator = ajv.compile(alterClientQuotasOptionsSchema)
 export const describeLogDirsOptionsValidator = ajv.compile(describeLogDirsOptionsSchema)

--- a/src/clients/admin/types.ts
+++ b/src/clients/admin/types.ts
@@ -7,7 +7,7 @@ import {
   type DescribeLogDirsResponseResult
 } from '../../apis/admin/describe-log-dirs-v4.ts'
 import { type ConsumerGroupState } from '../../apis/enumerations.ts'
-import { type NullableString } from '../../protocol/definitions.ts'
+import { type Nullable, type NullableString } from '../../protocol/definitions.ts'
 import { type BaseOptions } from '../base/types.ts'
 import { type ExtendedGroupProtocolSubscription, type GroupAssignment } from '../consumer/types.ts'
 
@@ -77,6 +77,16 @@ export interface DescribeGroupsOptions {
 
 export interface DeleteGroupsOptions {
   groups: string[]
+}
+
+interface MemberRemoval {
+  memberId: string
+  reason?: string
+}
+
+export interface RemoveMembersFromConsumerGroupOptions {
+  groupId: string
+  members?: Nullable<MemberRemoval[]>
 }
 
 export interface DescribeClientQuotasOptions {

--- a/src/protocol/definitions.ts
+++ b/src/protocol/definitions.ts
@@ -17,4 +17,5 @@ export const EMPTY_TAGGED_FIELDS_BUFFER = Buffer.from([0])
 
 export type Collection = string | Buffer | DynamicBuffer | Array<unknown> | Map<unknown, unknown> | Set<unknown>
 
-export type NullableString = string | undefined | null
+export type Nullable<T> = T | null | undefined
+export type NullableString = Nullable<string>


### PR DESCRIPTION
This change implements `removeMembersFromConsumerGroup` on the admin client.

on-behalf-of: @SAP ospo@sap.com
Signed-off-by: Peter Lehnhardt <peter.lehnhardt@sap.com>