### PR TITLE
fix: commit offset+1 instead of offset (#101)

### DIFF
--- a/src/clients/consumer/consumer.ts
+++ b/src/clients/consumer/consumer.ts
@@ -631,8 +631,8 @@ export class Consumer<Key = Buffer, Value = Buffer, HeaderKey = Buffer, HeaderVa
           const committed = committeds.get(`${topic}:${i}`)
 
           // If the consumer is not assigned to this partition, we return -1n.
-          // Otherwise we compute the lag as latest - committed - 1. The -1 is because latest is the offset of the next message to be produced.
-          partitionLags.push(typeof committed === 'undefined' ? -1n : latest - committed - 1n)
+          // Otherwise we compute the lag as latest - committed.
+          partitionLags.push(typeof committed === 'undefined' ? -1n : latest - committed)
         }
 
         lag.set(topic, partitionLags)

--- a/src/clients/consumer/messages-stream.ts
+++ b/src/clients/consumer/messages-stream.ts
@@ -559,7 +559,7 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
 
             consumerReceivesChannel.start.publish(diagnosticContext)
 
-            const commit = autocommit ? noopCallback : this.#commit.bind(this, topic, partition, offset, leaderEpoch)
+            const commit = autocommit ? noopCallback : this.#commit.bind(this, topic, partition, offset + 1n, leaderEpoch)
 
             try {
               const headers = new Map()
@@ -617,7 +617,7 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
 
             // Autocommit if needed
             if (autocommit) {
-              this.#offsetsToCommit.set(`${topic}:${partition}`, { topic, partition, offset: lastOffset, leaderEpoch })
+              this.#offsetsToCommit.set(`${topic}:${partition}`, { topic, partition, offset: lastOffset + 1n, leaderEpoch })
             }
           }
         }
@@ -785,7 +785,7 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
         const offset = partitions[i]
 
         if (offset >= 0n) {
-          this.#offsetsToFetch.set(`${topic}:${i}`, offset + 1n)
+          this.#offsetsToFetch.set(`${topic}:${i}`, offset)
         } else if (this.#fallbackMode === MessagesStreamFallbackModes.FAIL) {
           callback(
             new UserError(
@@ -811,7 +811,7 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
 
       for (const partition of partitions) {
         const committed = this.#offsetsToFetch.get(`${topic}:${partition}`)!
-        this.#offsetsCommitted.set(`${topic}:${partition}`, committed - 1n)
+        this.#offsetsCommitted.set(`${topic}:${partition}`, committed)
       }
     }
 

--- a/test/clients/consumer/messages-stream.test.ts
+++ b/test/clients/consumer/messages-stream.test.ts
@@ -357,7 +357,7 @@ test('should support timed autocommits', async t => {
   // Get committed offsets again
   {
     const committedOffsets = await consumer.listCommittedOffsets({ topics: [{ topic, partitions: [0] }] })
-    deepStrictEqual(committedOffsets.get(topic), [messages.at(-1)!.offset])
+    deepStrictEqual(committedOffsets.get(topic), [messages.at(-1)!.offset + 1n])
   }
 })
 
@@ -400,6 +400,10 @@ test('should support manual commits', async t => {
   strictEqual(firstBatch.length, 3, 'Should consume 3 messages in first batch')
   // Manually commit the first message
   await firstBatch[0].commit()
+
+  // Verify committed offset is offset + 1 (next offset to consume)
+  const offsets = await firstConsumer.listCommittedOffsets({ topics: [{ topic, partitions: [0] }] })
+  deepStrictEqual(offsets.get(topic), [1n], 'Committed offset should be 1n (offset 0 + 1)')
 
   // Have the first consumer leave the group so that we are sure assignments are sent to the second consumer
   await firstStream.close()


### PR DESCRIPTION
Fixes #101.

Commit `offset + 1` (next offset to consume) instead of `offset` (last consumed offset).

According to [Apache Kafka KafkaConsumer](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java#L285), the committed offset should always be the offset of the next message to read. [Apache Kafka's VerifiableConsumer](https://github.com/apache/kafka/blob/trunk/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java#L161) and [KafkaJS](https://github.com/tulios/kafkajs/blob/master/src/consumer/offsetManager/index.js#L103-L110) both commit `offset + 1`.

`message.commit()` and autocommit now internally commit `offset + 1n`. `consumer.commit({ offsets })` commits the offset as-is for manual offset control.

This fixes:

- Consumer lag always showing 1 when checked with `kaf` cli tool (reproduction: [plt-kafka-test](https://github.com/CarlosGamero/plt-kafka-test))
- Potential `OFFSET_OUT_OF_RANGE` errors when migrating from kafka.js
