### PR TITLE
Improve typings for runConcurrentCallbacks

### DIFF
--- a/src/apis/callbacks.ts
+++ b/src/apis/callbacks.ts
@@ -29,9 +29,21 @@ export function createPromisifiedCallback<ReturnType> (): CallbackWithPromise<Re
   return callback
 }
 
+export function runConcurrentCallbacks<ReturnType, K, V> (
+  errorMessage: string,
+  collection: Map<K, V>,
+  operation: (item: [K, V], cb: Callback<ReturnType>) => void,
+  callback: Callback<ReturnType[]>
+): void
+export function runConcurrentCallbacks<ReturnType, V> (
+  errorMessage: string,
+  collection: Set<V> | V[],
+  operation: (item: V, cb: Callback<ReturnType>) => void,
+  callback: Callback<ReturnType[]>
+): void
 export function runConcurrentCallbacks<ReturnType> (
   errorMessage: string,
-  collection: unknown[] | Set<unknown> | Map<unknown, unknown>,
+  collection: Map<any, any> | Set<any> | any[],
   operation: (item: any, cb: Callback<ReturnType>) => void,
   callback: Callback<ReturnType[]>
 ): void {

--- a/src/clients/admin/admin.ts
+++ b/src/clients/admin/admin.ts
@@ -1107,10 +1107,10 @@ export class Admin extends Base<AdminOptions> {
         return
       }
 
-      runConcurrentCallbacks<ListGroupsResponse>(
+      runConcurrentCallbacks(
         'Listing groups failed.',
         metadata.brokers,
-        ([, broker], concurrentCallback) => {
+        ([, broker], concurrentCallback: Callback<ListGroupsResponse>) => {
           this[kGetConnection](broker, (error, connection) => {
             if (error) {
               concurrentCallback(error, undefined as unknown as ListGroupsResponse)
@@ -1191,10 +1191,10 @@ export class Admin extends Base<AdminOptions> {
           coordinator.push(group)
         }
 
-        runConcurrentCallbacks<DescribeGroupsResponse>(
+        runConcurrentCallbacks(
           'Describing groups failed.',
           coordinators,
-          ([node, groups], concurrentCallback) => {
+          ([node, groups], concurrentCallback: Callback<DescribeGroupsResponse>) => {
             this[kGetConnection](metadata.brokers.get(node)!, (error, connection) => {
               if (error) {
                 concurrentCallback(error, undefined as unknown as DescribeGroupsResponse)
@@ -1314,19 +1314,19 @@ export class Admin extends Base<AdminOptions> {
         runConcurrentCallbacks(
           'Deleting groups failed.',
           coordinators,
-          ([node, groups], concurrentCallback) => {
+          ([node, groups], concurrentCallback: Callback<DeleteGroupsResponse>) => {
             this[kGetConnection](metadata.brokers.get(node)!, (error, connection) => {
               if (error) {
-                concurrentCallback(error, undefined)
+                concurrentCallback(error, undefined as unknown as DeleteGroupsResponse)
                 return
               }
 
-              this[kPerformWithRetry](
+              this[kPerformWithRetry]<DeleteGroupsResponse>(
                 'deleteGroups',
                 retryCallback => {
                   this[kGetApi]<DeleteGroupsRequest, DeleteGroupsResponse>('DeleteGroups', (error, api) => {
                     if (error) {
-                      retryCallback(error, undefined as unknown as CreateTopicsResponse)
+                      retryCallback(error, undefined as unknown as DeleteGroupsResponse)
                       return
                     }
 
@@ -1575,10 +1575,10 @@ export class Admin extends Base<AdminOptions> {
         return
       }
 
-      runConcurrentCallbacks<BrokerLogDirDescription>(
+      runConcurrentCallbacks(
         'Describing log dirs failed.',
         metadata.brokers,
-        ([id, broker], concurrentCallback) => {
+        ([id, broker], concurrentCallback: Callback<BrokerLogDirDescription>) => {
           this[kGetConnection](broker, (error, connection) => {
             if (error) {
               concurrentCallback(error, undefined as unknown as BrokerLogDirDescription)
@@ -1594,7 +1594,7 @@ export class Admin extends Base<AdminOptions> {
                     return
                   }
 
-                  api(connection, options.topics, retryCallback as unknown as Callback<DescribeLogDirsResponse>)
+                  api(connection, options.topics, retryCallback)
                 })
               },
               (error, response) => {
@@ -1668,10 +1668,10 @@ export class Admin extends Base<AdminOptions> {
           coordinator.push(groupRequest)
         }
 
-        runConcurrentCallbacks<OffsetFetchResponse>(
+        runConcurrentCallbacks(
           'Listing consumer group offsets failed.',
           coordinators,
-          ([node, groups], concurrentCallback) => {
+          ([node, groups], concurrentCallback: Callback<OffsetFetchResponse>) => {
             this[kGetConnection](metadata.brokers.get(node)!, (error, connection) => {
               if (error) {
                 concurrentCallback(error, undefined as unknown as OffsetFetchResponse)
@@ -1948,10 +1948,10 @@ export class Admin extends Base<AdminOptions> {
   }
 
   #describeConfigs (options: DescribeConfigsOptions, callback: CallbackWithPromise<ConfigDescription[]>): void {
-    runConcurrentCallbacks<ConfigDescription[]>(
+    runConcurrentCallbacks(
       'Describing configs failed.',
       this.#getConfigRequestsDistributedToBrokers(options.resources),
-      ([brokerId, resources], concurrentCallback) => {
+      ([brokerId, resources], concurrentCallback: Callback<ConfigDescription[]>) => {
         this.#describeConfigsOnBroker({ ...options, resources }, brokerId, (error, response) => {
           if (error) {
             concurrentCallback(error, undefined as unknown as ConfigDescription[])
@@ -2018,11 +2018,11 @@ export class Admin extends Base<AdminOptions> {
     )
   }
 
-  #alterConfigs (options: DescribeConfigsOptions, callback: CallbackWithPromise<void>): void {
-    runConcurrentCallbacks<void>(
+  #alterConfigs (options: AlterConfigsOptions, callback: CallbackWithPromise<void>): void {
+    runConcurrentCallbacks(
       'Altering configs failed.',
       this.#getConfigRequestsDistributedToBrokers(options.resources),
-      ([brokerId, resources], concurrentCallback) => {
+      ([brokerId, resources], concurrentCallback: Callback<void>) => {
         this.#alterConfigsOnBroker({ ...options, resources }, brokerId, concurrentCallback)
       },
       error => {
@@ -2070,10 +2070,10 @@ export class Admin extends Base<AdminOptions> {
   }
 
   #incrementalAlterConfigs (options: IncrementalAlterConfigsOptions, callback: CallbackWithPromise<void>): void {
-    runConcurrentCallbacks<void>(
+    runConcurrentCallbacks(
       'Incrementally altering configs failed.',
       this.#getConfigRequestsDistributedToBrokers(options.resources),
-      ([brokerId, resources], concurrentCallback) => {
+      ([brokerId, resources], concurrentCallback: Callback<void>) => {
         this.#incrementalAlterConfigsOnBroker({ ...options, resources }, brokerId, concurrentCallback)
       },
       error => {
@@ -2268,10 +2268,10 @@ export class Admin extends Base<AdminOptions> {
         }
       }
 
-      runConcurrentCallbacks<ListOffsetsResponse>(
+      runConcurrentCallbacks(
         'Listing offsets failed.',
         requests,
-        ([leader, requests], concurrentCallback) => {
+        ([leader, requests], concurrentCallback: Callback<ListOffsetsResponse>) => {
           this[kGetConnection](metadata.brokers.get(leader)!, (error, connection) => {
             if (error) {
               concurrentCallback(error, undefined as unknown as ListOffsetsResponse)

--- a/src/clients/base/base.ts
+++ b/src/clients/base/base.ts
@@ -223,10 +223,10 @@ export class Base<OptionsType extends BaseOptions = BaseOptions> extends EventEm
         nodes = Array.from(metadata.brokers.keys())
       }
 
-      runConcurrentCallbacks<[number, Connection]>(
+      runConcurrentCallbacks(
         'Connecting to brokers failed.',
         nodes,
-        (nodeId: number, concurrentCallback) => {
+        (nodeId, concurrentCallback: Callback<[number, Connection]>) => {
           this[kGetConnection](metadata.brokers.get(nodeId)!, (error, connection) => {
             if (error) {
               concurrentCallback(error, undefined as unknown as [number, Connection])

--- a/src/clients/consumer/consumer.ts
+++ b/src/clients/consumer/consumer.ts
@@ -114,6 +114,7 @@ import {
   type Offsets,
   type OffsetsWithTimestamps
 } from './types.ts'
+import { type Callback } from '../../apis/definitions.ts'
 
 interface TopicPartition {
   topicId: string
@@ -939,10 +940,10 @@ export class Consumer<Key = Buffer, Value = Buffer, HeaderKey = Buffer, HeaderVa
         }
       }
 
-      runConcurrentCallbacks<ListOffsetsResponse>(
+      runConcurrentCallbacks(
         'Listing offsets failed.',
         requests,
-        ([leader, requests], concurrentCallback) => {
+        ([leader, requests], concurrentCallback: Callback<ListOffsetsResponse>) => {
           this[kPerformWithRetry]<ListOffsetsResponse>(
             'listOffsets',
             retryCallback => {
@@ -1667,10 +1668,10 @@ export class Consumer<Key = Buffer, Value = Buffer, HeaderKey = Buffer, HeaderVa
         return
       }
 
-      runConcurrentCallbacks<void>(
+      runConcurrentCallbacks(
         'Closing streams failed.',
         this.#streams,
-        (stream, concurrentCallback) => {
+        (stream, concurrentCallback: Callback<void>) => {
           stream.close(concurrentCallback)
         },
         error => {

--- a/src/clients/producer/producer.ts
+++ b/src/clients/producer/producer.ts
@@ -4,6 +4,7 @@ import {
   kCallbackPromise,
   runConcurrentCallbacks
 } from '../../apis/callbacks.ts'
+import { type Callback } from '../../apis/definitions.ts'
 import { ProduceAcks } from '../../apis/enumerations.ts'
 import { type InitProducerIdRequest, type InitProducerIdResponse } from '../../apis/producer/init-producer-id-v5.ts'
 import { type ProduceRequest, type ProduceResponse } from '../../apis/producer/produce-v11.ts'
@@ -405,10 +406,10 @@ export class Producer<Key = Buffer, Value = Buffer, HeaderKey = Buffer, HeaderVa
       // Track nodes so that we can get their ID for delayed write reporting
       const nodes: number[] = []
 
-      runConcurrentCallbacks<ProduceResponse | boolean>(
+      runConcurrentCallbacks(
         'Producing messages failed.',
         messagesByDestination,
-        ([destination, destinationMessages], concurrentCallback) => {
+        ([destination, destinationMessages], concurrentCallback: Callback<ProduceResponse | boolean>) => {
           nodes.push(destination)
 
           this.#performSingleDestinationSend(

--- a/src/network/connection-pool.ts
+++ b/src/network/connection-pool.ts
@@ -92,10 +92,10 @@ export class ConnectionPool extends EventEmitter {
 
     this.#closed = true
 
-    runConcurrentCallbacks<void>(
+    runConcurrentCallbacks(
       'Closing connections failed.',
       this.#connections,
-      ([key, connection]: [string, Connection], cb: Callback<void>) => {
+      ([key, connection], cb: Callback<void>) => {
         connection.close(cb)
         this.#connections.delete(key)
       },


### PR DESCRIPTION
I already tried to add these changes in another PR in similar form (https://github.com/platformatic/kafka/commit/7f7b1377fdf2713c9eaff20cb946a36c7dbccc65#diff-f4883ea5e1b2eeb55f414a143b9aaafefd297b2f97b3f4cc450e93e67e1b786e) but was requested to be reverted. As the PR was quite big I think it was not good to include these changes there and I assume the value of it was not completely apparent.I think these changes would improve things a bit and I want to discuss it here in its own scope again. I'll happily close this PR if it was really rejected for specific reasons.

---

This change improves typings of function `runConcurrentCallbacks` so
that the type of the first argument of the `operation` callback (`item`)
is inferred from the type of the `collection` parameter. Previously,
the type was not inferred and the `item` needed to be typed manually
or was inferred as any if not.

To not need to specify the collection type manually all type parameters
need to be inferrable (TypeScript type parameter inference is all or
nothing). This means, ReturnType of `runConcurrentCallback` needs to be
removed from the type parameter list, too, and be specified inside
the callback parameter of the `operation` callback function so that the
ReturnType can be inferred successfully.

This change also found an issue with types inside Admin.#alterConfigs.
