### PR TITLE
Add load and stress tests

### DIFF
--- a/load-tests/package-lock.json
+++ b/load-tests/package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "@platformatic/kafka-load-tests",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@platformatic/kafka-load-tests",
+      "version": "0.0.0",
+      "dependencies": {
+        "zod": "^3.24.0"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/load-tests/package.json
+++ b/load-tests/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@platformatic/kafka-load-tests",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "load:direct": "node src/run-direct.ts",
+    "load:direct:light": "node src/run-direct.ts --rate 100 --duration 30",
+    "load:direct:medium": "node src/run-direct.ts --rate 1000 --duration 60",
+    "load:direct:heavy": "node src/run-direct.ts --rate 5000 --duration 120",
+    "load:direct:batch": "node src/run-direct-batch.ts",
+    "load:direct:batch:light": "node src/run-direct-batch.ts --rate 100 --duration 30",
+    "load:direct:batch:medium": "node src/run-direct-batch.ts --rate 1000 --duration 60",
+    "load:direct:batch:heavy": "node src/run-direct-batch.ts --rate 5000 --duration 120",
+    "load:stress": "node src/run-stress.ts",
+    "load:stress:light": "node src/run-stress.ts --rate 1000 --duration 60 --handler-delay 5 --cpu-work 1 --retry-rate 0.05 --partitions 3 --payload-kb 1 --topics 2",
+    "load:stress:heavy": "node src/run-stress.ts --rate 10000 --duration 180 --handler-delay 20 --cpu-work 5 --retry-rate 0.2 --partitions 12 --payload-kb 5 --topics 4",
+    "load:stress:batch": "node src/run-stress-batch.ts",
+    "load:stress:batch:light": "node src/run-stress-batch.ts --rate 1000 --duration 60 --handler-delay 5 --cpu-work 1 --retry-rate 0.05 --partitions 3 --payload-kb 1 --topics 2",
+    "load:stress:batch:heavy": "node src/run-stress-batch.ts --rate 10000 --duration 180 --handler-delay 20 --cpu-work 5 --retry-rate 0.2 --partitions 12 --payload-kb 5 --topics 4"
+  },
+  "engines": {
+    "node": ">=22.18.0"
+  },
+  "dependencies": {
+    "zod": "^4.3.5"
+  }
+}

--- a/load-tests/src/config.ts
+++ b/load-tests/src/config.ts
@@ -1,0 +1,8 @@
+export const config = {
+  kafka: {
+    bootstrapBrokers: (process.env.KAFKA_BROKERS ?? 'localhost:9001').split(','),
+    clientId: 'load-test',
+  },
+  reportIntervalMs: 5_000,
+  drainTimeoutMs: 30_000,
+} as const

--- a/load-tests/src/direct-batch-load-generator.ts
+++ b/load-tests/src/direct-batch-load-generator.ts
@@ -1,0 +1,277 @@
+import { randomUUID } from 'node:crypto'
+import { pipeline } from 'node:stream/promises'
+import { setTimeout } from 'node:timers/promises'
+import type { z } from 'zod/v4'
+import {
+  Admin,
+  Consumer,
+  MessagesStreamModes,
+  Producer,
+  jsonDeserializer,
+  jsonSerializer,
+  stringDeserializer,
+  stringSerializer,
+  type Message,
+} from '../../src/index.ts'
+import { config } from './config.ts'
+import { MessageBatchStream } from './message-batch-stream.ts'
+import { MetricsCollector } from './metrics-collector.ts'
+import {
+  DIRECT_EVENT_SCHEMA,
+  DIRECT_ORDER_SCHEMA,
+  TOPICS,
+  type DirectEvent,
+  type DirectOrder,
+} from './schemas.ts'
+
+export interface BatchLoadTestOptions {
+  rate: number
+  duration: number
+  batchSize: number
+  consumerBatchSize: number
+  consumerBatchTimeoutMs: number
+}
+
+type DeserializedMessage = Message<string, Record<string, unknown>, string, string>
+
+// Replicates MQT's handler config: schema + handler function per topic
+interface HandlerConfig {
+  schema: z.ZodType
+  handler: (messages: DeserializedMessage[], metrics: MetricsCollector) => void
+}
+
+const handlers: Record<string, HandlerConfig> = {
+  [TOPICS.EVENTS]: {
+    schema: DIRECT_EVENT_SCHEMA,
+    handler: (messages, metrics) => {
+      console.log(
+        `[${new Date().toISOString()}] [batch-handler] direct-events batch received: ${messages.length} messages`
+      )
+      for (const message of messages) {
+        const value = message.value as unknown as DirectEvent
+        const loadtestTs =
+          typeof value.payload?.loadtest_ts === 'number' ? value.payload.loadtest_ts : undefined
+        metrics.recordConsumed(TOPICS.EVENTS, loadtestTs)
+      }
+    },
+  },
+  [TOPICS.ORDERS]: {
+    schema: DIRECT_ORDER_SCHEMA,
+    handler: (messages, metrics) => {
+      console.log(
+        `[${new Date().toISOString()}] [batch-handler] direct-orders batch received: ${messages.length} messages`
+      )
+      for (let i = 0; i < messages.length; i++) {
+        metrics.recordConsumed(TOPICS.ORDERS)
+      }
+    },
+  },
+}
+
+function generateEvent (index: number): DirectEvent {
+  return {
+    id: randomUUID(),
+    event_type: `load_test_${index % 5}`,
+    payload: { loadtest_ts: Date.now(), index, data: `event-payload-${index}` },
+    created_at: new Date().toISOString(),
+  }
+}
+
+function generateOrder (index: number): DirectOrder {
+  return {
+    id: randomUUID(),
+    customer_id: `customer-${(index % 100).toString().padStart(3, '0')}`,
+    amount: (Math.random() * 1000).toFixed(2),
+    status: ['pending', 'confirmed', 'shipped', 'delivered'][index % 4]!,
+    created_at: new Date().toISOString(),
+  }
+}
+
+async function ensureTopics (): Promise<void> {
+  const admin = new Admin({
+    clientId: 'load-test-admin',
+    bootstrapBrokers: config.kafka.bootstrapBrokers,
+  })
+
+  for (const topic of [TOPICS.EVENTS, TOPICS.ORDERS]) {
+    try {
+      await admin.createTopics({ topics: [topic], partitions: 3, replicas: 1 })
+    } catch {
+      // Topic may already exist
+    }
+  }
+
+  await admin.close()
+}
+
+// Replicates MQT's handleSyncStreamBatch + consume + parseMessages flow
+async function handleSyncStreamBatch (
+  batchStream: MessageBatchStream<DeserializedMessage>,
+  metrics: MetricsCollector
+): Promise<void> {
+  for await (const messageBatch of batchStream) {
+    const batch = messageBatch as DeserializedMessage[]
+    const topic = batch[0]!.topic
+
+    const handlerConfig = handlers[topic]
+    if (!handlerConfig) {
+      const lastMessage = batch[batch.length - 1]!
+      await lastMessage.commit()
+      continue
+    }
+
+    // Zod validation per message (replicates MQT's parseMessages with safeParse)
+    const validMessages: DeserializedMessage[] = []
+    for (const message of batch) {
+      if (!message.value) continue
+
+      const parseResult = handlerConfig.schema.safeParse(message.value)
+      if (!parseResult.success) {
+        console.error(`[validation] Invalid message on ${topic}:`, parseResult.error.message)
+        continue
+      }
+      validMessages.push(message)
+    }
+
+    if (validMessages.length > 0) {
+      // Call batch handler with validated messages (replicates MQT's tryToConsume)
+      handlerConfig.handler(validMessages, metrics)
+    }
+
+    // Commit last message in batch (replicates MQT's commit for batch)
+    const lastMessage = batch[batch.length - 1]!
+    await lastMessage.commit()
+  }
+}
+
+export async function runDirectBatchLoadTest (options: BatchLoadTestOptions): Promise<void> {
+  const { rate, duration, batchSize, consumerBatchSize, consumerBatchTimeoutMs } = options
+
+  console.log(
+    `Starting direct Kafka batch load test: ${rate} msgs/sec, ${duration}s duration, publish batch=${batchSize}, consumer batch=${consumerBatchSize}, timeout=${consumerBatchTimeoutMs}ms`
+  )
+
+  await ensureTopics()
+
+  const metrics = new MetricsCollector()
+  const groupId = `direct-batch-load-test-${randomUUID()}`
+
+  const producer = new Producer({
+    clientId: `direct-producer-${randomUUID()}`,
+    bootstrapBrokers: config.kafka.bootstrapBrokers,
+    serializers: {
+      key: stringSerializer,
+      value: jsonSerializer,
+      headerKey: stringSerializer,
+      headerValue: stringSerializer,
+    },
+  })
+
+  const consumer = new Consumer<string, Record<string, unknown>, string, string>({
+    clientId: `direct-batch-consumer-${randomUUID()}`,
+    groupId,
+    bootstrapBrokers: config.kafka.bootstrapBrokers,
+    deserializers: {
+      key: stringDeserializer,
+      value: jsonDeserializer,
+      headerKey: stringDeserializer,
+      headerValue: stringDeserializer,
+    },
+    autocommit: false,
+    maxWaitTime: 5,
+  })
+
+  console.log('Initializing Kafka batch consumer and producer...')
+
+  const consumerStream = await consumer.consume({
+    topics: [TOPICS.EVENTS, TOPICS.ORDERS],
+    mode: MessagesStreamModes.LATEST,
+  })
+
+  // Create batch stream and pipe consumer stream through it (replicates MQT pattern)
+  const messageBatchStream = new MessageBatchStream<DeserializedMessage>({
+    batchSize: consumerBatchSize,
+    timeoutMilliseconds: consumerBatchTimeoutMs,
+  })
+
+  // Use pipeline for backpressure management (same as MQT)
+  pipeline(consumerStream, messageBatchStream).catch((error) => {
+    console.error('Pipeline error:', error)
+  })
+
+  // Start batch consumption loop in background (replicates MQT's handleSyncStreamBatch)
+  handleSyncStreamBatch(messageBatchStream, metrics).catch((error) => {
+    console.error('Batch consumer stream error:', error)
+  })
+
+  console.log('Batch consumer and producer ready.')
+
+  const reportInterval = setInterval(() => metrics.report(), config.reportIntervalMs)
+
+  const totalMessages = rate * duration
+  console.log(`Publishing ${totalMessages.toLocaleString()} total messages at ${rate}/sec`)
+
+  const loadStartTime = Date.now()
+  let totalPublished = 0
+
+  while (totalPublished < totalMessages) {
+    const remaining = totalMessages - totalPublished
+    const currentBatch = Math.min(batchSize, remaining)
+    const eventCount = Math.ceil(currentBatch / 2)
+    const orderCount = currentBatch - eventCount
+
+    try {
+      const messages: Array<{
+        topic: string
+        key: string
+        value: DirectEvent | DirectOrder
+      }> = []
+
+      for (let i = 0; i < eventCount; i++) {
+        messages.push({
+          topic: TOPICS.EVENTS,
+          key: randomUUID(),
+          value: generateEvent(totalPublished + i),
+        })
+      }
+      for (let i = 0; i < orderCount; i++) {
+        messages.push({
+          topic: TOPICS.ORDERS,
+          key: randomUUID(),
+          value: generateOrder(totalPublished + eventCount + i),
+        })
+      }
+
+      await producer.send({ messages })
+      totalPublished += currentBatch
+      metrics.recordProduced(currentBatch)
+    } catch (err) {
+      console.error('Publish error:', err)
+    }
+
+    if (rate > 0) {
+      const elapsed = Date.now() - loadStartTime
+      const expectedElapsed = (totalPublished / rate) * 1000
+      const sleepMs = expectedElapsed - elapsed
+      if (sleepMs > 0) {
+        await setTimeout(sleepMs)
+      }
+    }
+  }
+
+  console.log(`\nPublishing complete. ${totalPublished.toLocaleString()} messages published.`)
+  console.log(`Waiting up to ${config.drainTimeoutMs / 1000}s for consumer to drain...`)
+
+  const drainStart = Date.now()
+  while (metrics.backlog > 0 && Date.now() - drainStart < config.drainTimeoutMs) {
+    await setTimeout(500)
+  }
+
+  clearInterval(reportInterval)
+  metrics.printFinalReport()
+
+  console.log('Shutting down...')
+  await new Promise((resolve) => messageBatchStream.end(resolve))
+  await Promise.all([consumer.close(), producer.close()])
+  console.log('Done.')
+}

--- a/load-tests/src/direct-load-generator.ts
+++ b/load-tests/src/direct-load-generator.ts
@@ -1,0 +1,243 @@
+import { randomUUID } from 'node:crypto'
+import { setTimeout } from 'node:timers/promises'
+import type { z } from 'zod/v4'
+import {
+  Admin,
+  Consumer,
+  MessagesStreamModes,
+  Producer,
+  jsonDeserializer,
+  jsonSerializer,
+  stringDeserializer,
+  stringSerializer,
+  type Message,
+  type MessagesStream,
+} from '../../src/index.ts'
+import { config } from './config.ts'
+import { MetricsCollector } from './metrics-collector.ts'
+import {
+  DIRECT_EVENT_SCHEMA,
+  DIRECT_ORDER_SCHEMA,
+  TOPICS,
+  type DirectEvent,
+  type DirectOrder,
+} from './schemas.ts'
+
+export interface LoadTestOptions {
+  rate: number
+  duration: number
+  batchSize: number
+}
+
+type DeserializedMessage = Message<string, Record<string, unknown>, string, string>
+
+// Replicates MQT's handler config: schema + handler function per topic
+interface HandlerConfig {
+  schema: z.ZodType
+  handler: (message: DeserializedMessage, metrics: MetricsCollector) => void
+}
+
+const handlers: Record<string, HandlerConfig> = {
+  [TOPICS.EVENTS]: {
+    schema: DIRECT_EVENT_SCHEMA,
+    handler: (message, metrics) => {
+      const value = message.value as unknown as DirectEvent
+      const loadtestTs =
+        typeof value.payload?.loadtest_ts === 'number' ? value.payload.loadtest_ts : undefined
+      metrics.recordConsumed(TOPICS.EVENTS, loadtestTs)
+    },
+  },
+  [TOPICS.ORDERS]: {
+    schema: DIRECT_ORDER_SCHEMA,
+    handler: (_message, metrics) => {
+      metrics.recordConsumed(TOPICS.ORDERS)
+    },
+  },
+}
+
+function generateEvent (index: number): DirectEvent {
+  return {
+    id: randomUUID(),
+    event_type: `load_test_${index % 5}`,
+    payload: { loadtest_ts: Date.now(), index, data: `event-payload-${index}` },
+    created_at: new Date().toISOString(),
+  }
+}
+
+function generateOrder (index: number): DirectOrder {
+  return {
+    id: randomUUID(),
+    customer_id: `customer-${(index % 100).toString().padStart(3, '0')}`,
+    amount: (Math.random() * 1000).toFixed(2),
+    status: ['pending', 'confirmed', 'shipped', 'delivered'][index % 4]!,
+    created_at: new Date().toISOString(),
+  }
+}
+
+async function ensureTopics (): Promise<void> {
+  const admin = new Admin({
+    clientId: 'load-test-admin',
+    bootstrapBrokers: config.kafka.bootstrapBrokers,
+  })
+
+  for (const topic of [TOPICS.EVENTS, TOPICS.ORDERS]) {
+    try {
+      await admin.createTopics({ topics: [topic], partitions: 3, replicas: 1 })
+    } catch {
+      // Topic may already exist
+    }
+  }
+
+  await admin.close()
+}
+
+// Replicates MQT's handleSyncStream + consume + parseMessages flow
+async function handleSyncStream (
+  stream: MessagesStream<string, Record<string, unknown>, string, string>,
+  metrics: MetricsCollector
+): Promise<void> {
+  for await (const message of stream) {
+    const handlerConfig = handlers[message.topic]
+    if (!handlerConfig) {
+      await message.commit()
+      continue
+    }
+
+    // Zod validation (replicates MQT's parseMessages with safeParse)
+    if (!message.value) {
+      await message.commit()
+      continue
+    }
+
+    const parseResult = handlerConfig.schema.safeParse(message.value)
+    if (!parseResult.success) {
+      console.error(`[validation] Invalid message on ${message.topic}:`, parseResult.error.message)
+      await message.commit()
+      continue
+    }
+
+    // Call handler with validated message (replicates MQT's tryToConsume)
+    handlerConfig.handler(message, metrics)
+
+    // Manual commit (replicates MQT's commitMessage)
+    await message.commit()
+  }
+}
+
+export async function runDirectLoadTest (options: LoadTestOptions): Promise<void> {
+  const { rate, duration, batchSize } = options
+
+  console.log(
+    `Starting direct Kafka load test: ${rate} msgs/sec, ${duration}s duration, batch=${batchSize}`
+  )
+
+  await ensureTopics()
+
+  const metrics = new MetricsCollector()
+  const groupId = `direct-load-test-${randomUUID()}`
+
+  const producer = new Producer({
+    clientId: `direct-producer-${randomUUID()}`,
+    bootstrapBrokers: config.kafka.bootstrapBrokers,
+    serializers: {
+      key: stringSerializer,
+      value: jsonSerializer,
+      headerKey: stringSerializer,
+      headerValue: stringSerializer,
+    },
+  })
+
+  const consumer = new Consumer<string, Record<string, unknown>, string, string>({
+    clientId: `direct-consumer-${randomUUID()}`,
+    groupId,
+    bootstrapBrokers: config.kafka.bootstrapBrokers,
+    deserializers: {
+      key: stringDeserializer,
+      value: jsonDeserializer,
+      headerKey: stringDeserializer,
+      headerValue: stringDeserializer,
+    },
+    autocommit: false,
+    maxWaitTime: 5,
+  })
+
+  console.log('Initializing Kafka consumer and producer...')
+
+  const stream = await consumer.consume({
+    topics: [TOPICS.EVENTS, TOPICS.ORDERS],
+    mode: MessagesStreamModes.LATEST,
+  })
+
+  // Start consumption loop in background (replicates MQT's handleSyncStream)
+  handleSyncStream(stream, metrics).catch((error) => {
+    console.error('Consumer stream error:', error)
+  })
+
+  console.log('Consumer and producer ready.')
+
+  const reportInterval = setInterval(() => metrics.report(), config.reportIntervalMs)
+
+  const totalMessages = rate * duration
+  console.log(`Publishing ${totalMessages.toLocaleString()} total messages at ${rate}/sec`)
+
+  const loadStartTime = Date.now()
+  let totalPublished = 0
+
+  while (totalPublished < totalMessages) {
+    const remaining = totalMessages - totalPublished
+    const currentBatch = Math.min(batchSize, remaining)
+    const eventCount = Math.ceil(currentBatch / 2)
+    const orderCount = currentBatch - eventCount
+
+    try {
+      const messages: Array<{
+        topic: string
+        key: string
+        value: DirectEvent | DirectOrder
+      }> = []
+
+      for (let i = 0; i < eventCount; i++) {
+        messages.push({
+          topic: TOPICS.EVENTS,
+          key: randomUUID(),
+          value: generateEvent(totalPublished + i),
+        })
+      }
+      for (let i = 0; i < orderCount; i++) {
+        messages.push({
+          topic: TOPICS.ORDERS,
+          key: randomUUID(),
+          value: generateOrder(totalPublished + eventCount + i),
+        })
+      }
+
+      await producer.send({ messages })
+      totalPublished += currentBatch
+      metrics.recordProduced(currentBatch)
+    } catch (err) {
+      console.error('Publish error:', err)
+    }
+
+    const elapsed = Date.now() - loadStartTime
+    const expectedElapsed = (totalPublished / rate) * 1000
+    const sleepMs = expectedElapsed - elapsed
+    if (sleepMs > 0) {
+      await setTimeout(sleepMs)
+    }
+  }
+
+  console.log(`\nPublishing complete. ${totalPublished.toLocaleString()} messages published.`)
+  console.log(`Waiting up to ${config.drainTimeoutMs / 1000}s for consumer to drain...`)
+
+  const drainStart = Date.now()
+  while (metrics.backlog > 0 && Date.now() - drainStart < config.drainTimeoutMs) {
+    await setTimeout(500)
+  }
+
+  clearInterval(reportInterval)
+  metrics.printFinalReport()
+
+  console.log('Shutting down...')
+  await Promise.all([consumer.close(), producer.close()])
+  console.log('Done.')
+}

--- a/load-tests/src/message-batch-stream.ts
+++ b/load-tests/src/message-batch-stream.ts
@@ -1,0 +1,102 @@
+import { Duplex } from 'node:stream'
+
+type CallbackFunction = (error?: Error | null) => void
+type MessageWithTopicAndPartition = { topic: string; partition: number }
+
+export interface MessageBatchOptions {
+  /** Maximum number of messages to accumulate before flushing */
+  batchSize: number
+  /** Time in milliseconds to wait before flushing incomplete batches */
+  timeoutMilliseconds: number
+}
+
+/**
+ * Replicates MQT's KafkaMessageBatchStream: a Duplex stream that batches Kafka messages
+ * based on size and timeout constraints.
+ *
+ * - Accumulates messages across all partitions up to batchSize
+ * - Groups messages by topic:partition when flushing
+ * - Implements backpressure
+ * - Auto-flushes on timeout for partial batches
+ */
+export class MessageBatchStream<TMessage extends MessageWithTopicAndPartition> extends Duplex {
+  private readonly batchSize: number
+  private readonly timeout: number
+
+  private messages: TMessage[]
+  private existingTimeout: NodeJS.Timeout | undefined
+  private pendingCallback: CallbackFunction | undefined
+  private isBackPressured: boolean
+
+  constructor (options: MessageBatchOptions) {
+    super({ objectMode: true })
+    this.batchSize = options.batchSize
+    this.timeout = options.timeoutMilliseconds
+    this.messages = []
+    this.isBackPressured = false
+  }
+
+  override _read (): void {
+    this.isBackPressured = false
+    if (!this.pendingCallback) return
+
+    const cb = this.pendingCallback
+    this.pendingCallback = undefined
+    cb()
+  }
+
+  override _write (message: TMessage, _encoding: BufferEncoding, callback: CallbackFunction): void {
+    let canContinue = true
+
+    try {
+      this.messages.push(message)
+
+      if (this.messages.length >= this.batchSize) {
+        canContinue = this.flushMessages()
+      } else {
+        this.existingTimeout ??= setTimeout(() => this.flushMessages(), this.timeout)
+      }
+    } finally {
+      if (!canContinue) this.pendingCallback = callback
+      else callback()
+    }
+  }
+
+  override _final (callback: CallbackFunction): void {
+    clearTimeout(this.existingTimeout)
+    this.existingTimeout = undefined
+    // Remaining messages are not committed, next consumer will process them
+    this.messages = []
+    this.push(null)
+    callback()
+  }
+
+  private flushMessages (): boolean {
+    clearTimeout(this.existingTimeout)
+    this.existingTimeout = undefined
+
+    if (this.isBackPressured) {
+      this.existingTimeout = setTimeout(() => this.flushMessages(), this.timeout)
+      return false
+    }
+
+    const messageBatch = this.messages.splice(0, this.messages.length)
+
+    // Group by topic:partition
+    const messagesByTopicPartition: Record<string, TMessage[]> = {}
+    for (const message of messageBatch) {
+      const key = `${message.topic}:${message.partition}`
+      if (!messagesByTopicPartition[key]) messagesByTopicPartition[key] = []
+      messagesByTopicPartition[key].push(message)
+    }
+
+    let canContinue = true
+    for (const messagesForKey of Object.values(messagesByTopicPartition)) {
+      canContinue = this.push(messagesForKey)
+    }
+
+    if (!canContinue) this.isBackPressured = true
+
+    return canContinue
+  }
+}

--- a/load-tests/src/metrics-collector.ts
+++ b/load-tests/src/metrics-collector.ts
@@ -1,0 +1,107 @@
+export class MetricsCollector {
+  private producedTotal = 0
+  private consumedTotal = 0
+  private windowProduced = 0
+  private windowConsumed = 0
+  private readonly perTopicConsumed = new Map<string, number>()
+  private readonly latencies: number[] = []
+
+  private readonly startTime = Date.now()
+  private lastReportTime = Date.now()
+
+  recordProduced (count: number): void {
+    this.producedTotal += count
+    this.windowProduced += count
+  }
+
+  recordConsumed (topic: string, loadtestTs?: number): void {
+    this.consumedTotal++
+    this.windowConsumed++
+    this.perTopicConsumed.set(topic, (this.perTopicConsumed.get(topic) ?? 0) + 1)
+
+    if (loadtestTs) {
+      this.latencies.push(Date.now() - loadtestTs)
+    }
+  }
+
+  get backlog (): number {
+    return this.producedTotal - this.consumedTotal
+  }
+
+  get totalConsumed (): number {
+    return this.consumedTotal
+  }
+
+  get totalProduced (): number {
+    return this.producedTotal
+  }
+
+  report (): void {
+    const now = Date.now()
+    const windowSec = (now - this.lastReportTime) / 1000
+    const elapsedSec = Math.round((now - this.startTime) / 1000)
+
+    const producedRate = windowSec > 0 ? Math.round(this.windowProduced / windowSec) : 0
+    const consumedRate = windowSec > 0 ? Math.round(this.windowConsumed / windowSec) : 0
+
+    const latencyStats = this.computeLatencyStats()
+
+    const topicBreakdown = [...this.perTopicConsumed.entries()]
+      .map(([t, c]) => `${t}=${c.toLocaleString()}`)
+      .join(' | ')
+
+    console.log(`
+=== Load Test Report (t=${elapsedSec}s) ===
+  Produced:   ${this.producedTotal.toLocaleString()} total | ${producedRate}/sec
+  Consumed:   ${this.consumedTotal.toLocaleString()} total | ${consumedRate}/sec
+  Backlog:    ${this.backlog.toLocaleString()} messages
+  Latency:    avg=${latencyStats.avg}ms | p50=${latencyStats.p50}ms | p95=${latencyStats.p95}ms | p99=${latencyStats.p99}ms
+  Per Topic:  ${topicBreakdown || 'n/a'}
+================================
+`)
+
+    this.windowProduced = 0
+    this.windowConsumed = 0
+    this.lastReportTime = now
+  }
+
+  printFinalReport (): void {
+    const elapsedSec = (Date.now() - this.startTime) / 1000
+
+    const latencyStats = this.computeLatencyStats()
+
+    const topicBreakdown = [...this.perTopicConsumed.entries()]
+      .map(([t, c]) => `${t}=${c.toLocaleString()}`)
+      .join(' | ')
+
+    console.log(`
+╔══════════════════════════════════════╗
+║        FINAL LOAD TEST REPORT        ║
+╠══════════════════════════════════════╣
+  Duration:   ${elapsedSec.toFixed(1)}s
+  Produced:   ${this.producedTotal.toLocaleString()} total | ${Math.round(this.producedTotal / elapsedSec)}/sec avg
+  Consumed:   ${this.consumedTotal.toLocaleString()} total | ${Math.round(this.consumedTotal / elapsedSec)}/sec avg
+  Backlog:    ${this.backlog.toLocaleString()} messages
+  Latency:    avg=${latencyStats.avg}ms | p50=${latencyStats.p50}ms | p95=${latencyStats.p95}ms | p99=${latencyStats.p99}ms
+  Per Topic:  ${topicBreakdown || 'n/a'}
+  Samples:    ${this.latencies.length.toLocaleString()} latency measurements
+╚══════════════════════════════════════╝
+`)
+  }
+
+  private computeLatencyStats (): { avg: number; p50: number; p95: number; p99: number } {
+    if (this.latencies.length === 0) {
+      return { avg: 0, p50: 0, p95: 0, p99: 0 }
+    }
+
+    const sorted = [...this.latencies].sort((a, b) => a - b)
+    const sum = sorted.reduce((s, v) => s + v, 0)
+
+    return {
+      avg: Math.round(sum / sorted.length),
+      p50: sorted[Math.floor(sorted.length * 0.5)]!,
+      p95: sorted[Math.floor(sorted.length * 0.95)]!,
+      p99: sorted[Math.floor(sorted.length * 0.99)]!,
+    }
+  }
+}

--- a/load-tests/src/run-direct-batch.ts
+++ b/load-tests/src/run-direct-batch.ts
@@ -1,0 +1,21 @@
+import { parseArgs } from 'node:util'
+import { runDirectBatchLoadTest } from './direct-batch-load-generator.ts'
+
+const { values } = parseArgs({
+  options: {
+    rate: { type: 'string', short: 'r', default: '1000' },
+    duration: { type: 'string', short: 'd', default: '60' },
+    batch: { type: 'string', short: 'b', default: '100' },
+    'consumer-batch': { type: 'string', default: '50' },
+    'consumer-timeout': { type: 'string', default: '200' },
+  },
+  strict: true,
+})
+
+await runDirectBatchLoadTest({
+  rate: Number.parseInt(values.rate!, 10),
+  duration: Number.parseInt(values.duration!, 10),
+  batchSize: Number.parseInt(values.batch!, 10),
+  consumerBatchSize: Number.parseInt(values['consumer-batch']!, 10),
+  consumerBatchTimeoutMs: Number.parseInt(values['consumer-timeout']!, 10),
+})

--- a/load-tests/src/run-direct.ts
+++ b/load-tests/src/run-direct.ts
@@ -1,0 +1,17 @@
+import { parseArgs } from 'node:util'
+import { runDirectLoadTest } from './direct-load-generator.ts'
+
+const { values } = parseArgs({
+  options: {
+    rate: { type: 'string', short: 'r', default: '1000' },
+    duration: { type: 'string', short: 'd', default: '60' },
+    batch: { type: 'string', short: 'b', default: '100' },
+  },
+  strict: true,
+})
+
+await runDirectLoadTest({
+  rate: Number.parseInt(values.rate!, 10),
+  duration: Number.parseInt(values.duration!, 10),
+  batchSize: Number.parseInt(values.batch!, 10),
+})

--- a/load-tests/src/run-stress-batch.ts
+++ b/load-tests/src/run-stress-batch.ts
@@ -1,0 +1,37 @@
+import { parseArgs } from 'node:util'
+import { runStressBatchLoadTest } from './stress-batch-load-generator.ts'
+
+const { values } = parseArgs({
+  options: {
+    rate: { type: 'string', short: 'r', default: '5000' },
+    duration: { type: 'string', short: 'd', default: '120' },
+    batch: { type: 'string', short: 'b', default: '100' },
+    'consumer-batch': { type: 'string', default: '50' },
+    'consumer-timeout': { type: 'string', default: '200' },
+    'handler-delay': { type: 'string', default: '10' },
+    'cpu-work': { type: 'string', default: '2' },
+    'retry-rate': { type: 'string', default: '0.1' },
+    partitions: { type: 'string', default: '6' },
+    'payload-kb': { type: 'string', default: '2' },
+    topics: { type: 'string', default: '4' },
+    'max-wait-time': { type: 'string', default: '5000' },
+    'max-bytes': { type: 'string', default: '10485760' },
+  },
+  strict: true,
+})
+
+await runStressBatchLoadTest({
+  rate: Number.parseInt(values.rate!, 10),
+  duration: Number.parseInt(values.duration!, 10),
+  batchSize: Number.parseInt(values.batch!, 10),
+  consumerBatchSize: Number.parseInt(values['consumer-batch']!, 10),
+  consumerBatchTimeoutMs: Number.parseInt(values['consumer-timeout']!, 10),
+  handlerDelayMs: Number.parseInt(values['handler-delay']!, 10),
+  cpuWorkMs: Number.parseInt(values['cpu-work']!, 10),
+  retryRate: Number.parseFloat(values['retry-rate']!),
+  partitions: Number.parseInt(values.partitions!, 10),
+  payloadKb: Number.parseInt(values['payload-kb']!, 10),
+  topics: Number.parseInt(values.topics!, 10),
+  maxWaitTime: Number.parseInt(values['max-wait-time']!, 10),
+  maxBytes: Number.parseInt(values['max-bytes']!, 10),
+})

--- a/load-tests/src/run-stress.ts
+++ b/load-tests/src/run-stress.ts
@@ -1,0 +1,33 @@
+import { parseArgs } from 'node:util'
+import { runStressLoadTest } from './stress-load-generator.ts'
+
+const { values } = parseArgs({
+  options: {
+    rate: { type: 'string', short: 'r', default: '5000' },
+    duration: { type: 'string', short: 'd', default: '120' },
+    batch: { type: 'string', short: 'b', default: '100' },
+    'handler-delay': { type: 'string', default: '10' },
+    'cpu-work': { type: 'string', default: '2' },
+    'retry-rate': { type: 'string', default: '0.1' },
+    partitions: { type: 'string', default: '6' },
+    'payload-kb': { type: 'string', default: '2' },
+    topics: { type: 'string', default: '4' },
+    'max-wait-time': { type: 'string', default: '5000' },
+    'max-bytes': { type: 'string', default: '10485760' },
+  },
+  strict: true,
+})
+
+await runStressLoadTest({
+  rate: Number.parseInt(values.rate!, 10),
+  duration: Number.parseInt(values.duration!, 10),
+  batchSize: Number.parseInt(values.batch!, 10),
+  handlerDelayMs: Number.parseInt(values['handler-delay']!, 10),
+  cpuWorkMs: Number.parseInt(values['cpu-work']!, 10),
+  retryRate: Number.parseFloat(values['retry-rate']!),
+  partitions: Number.parseInt(values.partitions!, 10),
+  payloadKb: Number.parseInt(values['payload-kb']!, 10),
+  topics: Number.parseInt(values.topics!, 10),
+  maxWaitTime: Number.parseInt(values['max-wait-time']!, 10),
+  maxBytes: Number.parseInt(values['max-bytes']!, 10),
+})

--- a/load-tests/src/schemas.ts
+++ b/load-tests/src/schemas.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod/v4'
+
+export const DIRECT_EVENT_SCHEMA = z.object({
+  id: z.string(),
+  event_type: z.string(),
+  payload: z.record(z.string(), z.unknown()),
+  created_at: z.string(),
+})
+export type DirectEvent = z.output<typeof DIRECT_EVENT_SCHEMA>
+
+export const DIRECT_ORDER_SCHEMA = z.object({
+  id: z.string(),
+  customer_id: z.string(),
+  amount: z.string(),
+  status: z.string(),
+  created_at: z.string(),
+})
+export type DirectOrder = z.output<typeof DIRECT_ORDER_SCHEMA>
+
+export const TOPICS = {
+  EVENTS: 'direct-events',
+  ORDERS: 'direct-orders',
+} as const
+
+// Stress test schemas — same validation as direct but with larger payload fields
+
+export const STRESS_EVENT_SCHEMA = z.object({
+  id: z.string(),
+  event_type: z.string(),
+  payload: z.record(z.string(), z.unknown()),
+  created_at: z.string(),
+})
+export type StressEvent = z.output<typeof STRESS_EVENT_SCHEMA>
+
+export const STRESS_ORDER_SCHEMA = z.object({
+  id: z.string(),
+  customer_id: z.string(),
+  amount: z.string(),
+  status: z.string(),
+  created_at: z.string(),
+})
+export type StressOrder = z.output<typeof STRESS_ORDER_SCHEMA>
+
+export const STRESS_METRIC_SCHEMA = z.object({
+  id: z.string(),
+  metric_name: z.string(),
+  value: z.number(),
+  tags: z.record(z.string(), z.unknown()),
+  created_at: z.string(),
+})
+export type StressMetric = z.output<typeof STRESS_METRIC_SCHEMA>
+
+export const STRESS_LOG_SCHEMA = z.object({
+  id: z.string(),
+  level: z.string(),
+  message: z.string(),
+  context: z.record(z.string(), z.unknown()),
+  created_at: z.string(),
+})
+export type StressLog = z.output<typeof STRESS_LOG_SCHEMA>
+
+export const STRESS_TOPICS = {
+  EVENTS: 'stress-events',
+  ORDERS: 'stress-orders',
+  METRICS: 'stress-metrics',
+  LOGS: 'stress-logs',
+} as const

--- a/load-tests/src/stress-batch-load-generator.ts
+++ b/load-tests/src/stress-batch-load-generator.ts
@@ -1,0 +1,423 @@
+import { randomUUID } from 'node:crypto'
+import { pipeline } from 'node:stream/promises'
+import { setTimeout } from 'node:timers/promises'
+import type { z } from 'zod/v4'
+import {
+  Admin,
+  Consumer,
+  MessagesStreamModes,
+  Producer,
+  jsonSerializer,
+  stringDeserializer,
+  stringSerializer,
+  type Message,
+} from '../../src/index.ts'
+import { config } from './config.ts'
+import { MessageBatchStream } from './message-batch-stream.ts'
+import { MetricsCollector } from './metrics-collector.ts'
+import {
+  STRESS_EVENT_SCHEMA,
+  STRESS_LOG_SCHEMA,
+  STRESS_METRIC_SCHEMA,
+  STRESS_ORDER_SCHEMA,
+  STRESS_TOPICS,
+  type StressEvent,
+  type StressLog,
+  type StressMetric,
+  type StressOrder,
+} from './schemas.ts'
+import { simulateWork, type WorkSimulatorOptions } from './work-simulator.ts'
+
+// Replicates MQT's safeJsonDeserializer: returns undefined for invalid JSON instead of throwing
+const safeJsonDeserializer = (data?: string | Buffer): object | undefined => {
+  if (!data) return undefined
+  if (!Buffer.isBuffer(data) && typeof data !== 'string') return undefined
+  try {
+    return JSON.parse(Buffer.isBuffer(data) ? data.toString('utf-8') : data)
+  } catch {
+    return undefined
+  }
+}
+
+export interface StressBatchLoadTestOptions {
+  rate: number
+  duration: number
+  batchSize: number
+  consumerBatchSize: number
+  consumerBatchTimeoutMs: number
+  handlerDelayMs: number
+  cpuWorkMs: number
+  retryRate: number
+  partitions: number
+  payloadKb: number
+  topics: number
+  maxWaitTime: number
+  maxBytes: number
+}
+
+type DeserializedMessage = Message<string, Record<string, unknown>, string, string>
+
+interface HandlerConfig {
+  schema: z.ZodType
+  handler: (messages: DeserializedMessage[], metrics: MetricsCollector) => Promise<void>
+}
+
+function buildHandlers (workOptions: WorkSimulatorOptions): Record<string, HandlerConfig> {
+  return {
+    [STRESS_TOPICS.EVENTS]: {
+      schema: STRESS_EVENT_SCHEMA,
+      handler: async (messages, metrics) => {
+        for (const message of messages) {
+          const value = message.value as unknown as StressEvent
+          await simulateWork(value as unknown as Record<string, unknown>, workOptions)
+          const loadtestTs =
+            typeof value.payload?.loadtest_ts === 'number' ? value.payload.loadtest_ts : undefined
+          metrics.recordConsumed(STRESS_TOPICS.EVENTS, loadtestTs)
+        }
+      },
+    },
+    [STRESS_TOPICS.ORDERS]: {
+      schema: STRESS_ORDER_SCHEMA,
+      handler: async (messages, metrics) => {
+        for (const message of messages) {
+          const value = message.value as unknown as StressOrder
+          await simulateWork(value as unknown as Record<string, unknown>, workOptions)
+          metrics.recordConsumed(STRESS_TOPICS.ORDERS)
+        }
+      },
+    },
+    [STRESS_TOPICS.METRICS]: {
+      schema: STRESS_METRIC_SCHEMA,
+      handler: async (messages, metrics) => {
+        for (const message of messages) {
+          const value = message.value as unknown as StressMetric
+          await simulateWork(value as unknown as Record<string, unknown>, workOptions)
+          const loadtestTs =
+            typeof value.tags?.loadtest_ts === 'number' ? value.tags.loadtest_ts : undefined
+          metrics.recordConsumed(STRESS_TOPICS.METRICS, loadtestTs)
+        }
+      },
+    },
+    [STRESS_TOPICS.LOGS]: {
+      schema: STRESS_LOG_SCHEMA,
+      handler: async (messages, metrics) => {
+        for (const message of messages) {
+          const value = message.value as unknown as StressLog
+          await simulateWork(value as unknown as Record<string, unknown>, workOptions)
+          const loadtestTs =
+            typeof value.context?.loadtest_ts === 'number' ? value.context.loadtest_ts : undefined
+          metrics.recordConsumed(STRESS_TOPICS.LOGS, loadtestTs)
+        }
+      },
+    },
+  }
+}
+
+function generatePaddedPayload (sizeKb: number): string {
+  const targetBytes = sizeKb * 1024
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+  let result = ''
+  for (let i = 0; i < targetBytes; i++) {
+    result += chars[i % chars.length]
+  }
+  return result
+}
+
+function generateStressEvent (index: number, padding: string): StressEvent {
+  return {
+    id: randomUUID(),
+    event_type: `stress_test_${index % 5}`,
+    payload: { loadtest_ts: Date.now(), index, data: padding },
+    created_at: new Date().toISOString(),
+  }
+}
+
+function generateStressOrder (index: number, padding: string): StressOrder {
+  return {
+    id: randomUUID(),
+    customer_id: `customer-${(index % 100).toString().padStart(3, '0')}`,
+    amount: (Math.random() * 1000).toFixed(2),
+    status: ['pending', 'confirmed', 'shipped', 'delivered'][index % 4]!,
+    created_at: new Date().toISOString() + padding.slice(0, 1),
+  }
+}
+
+function generateStressMetric (index: number, padding: string): StressMetric {
+  return {
+    id: randomUUID(),
+    metric_name: `stress_metric_${index % 10}`,
+    value: Math.random() * 1000,
+    tags: { loadtest_ts: Date.now(), index, data: padding },
+    created_at: new Date().toISOString(),
+  }
+}
+
+function generateStressLog (index: number, padding: string): StressLog {
+  return {
+    id: randomUUID(),
+    level: ['debug', 'info', 'warn', 'error'][index % 4]!,
+    message: `Stress log message ${index} ${padding.slice(0, 100)}`,
+    context: { loadtest_ts: Date.now(), index, data: padding },
+    created_at: new Date().toISOString(),
+  }
+}
+
+function getActiveTopics (topicCount: number): string[] {
+  const allTopics = [
+    STRESS_TOPICS.EVENTS,
+    STRESS_TOPICS.ORDERS,
+    STRESS_TOPICS.METRICS,
+    STRESS_TOPICS.LOGS,
+  ]
+  return allTopics.slice(0, Math.min(topicCount, allTopics.length))
+}
+
+async function ensureTopics (topics: string[], partitions: number): Promise<void> {
+  const admin = new Admin({
+    clientId: 'stress-batch-test-admin',
+    bootstrapBrokers: config.kafka.bootstrapBrokers,
+  })
+
+  for (const topic of topics) {
+    try {
+      await admin.createTopics({ topics: [topic], partitions, replicas: 1 })
+    } catch {
+      // Topic may already exist
+    }
+  }
+
+  await admin.close()
+}
+
+async function handleSyncStreamBatch (
+  batchStream: MessageBatchStream<DeserializedMessage>,
+  handlers: Record<string, HandlerConfig>,
+  metrics: MetricsCollector,
+  errorCount: { value: number }
+): Promise<void> {
+  for await (const messageBatch of batchStream) {
+    const batch = messageBatch as DeserializedMessage[]
+    const topic = batch[0]!.topic
+
+    const handlerConfig = handlers[topic]
+    if (!handlerConfig) {
+      const lastMessage = batch[batch.length - 1]!
+      await lastMessage.commit()
+      continue
+    }
+
+    const validMessages: DeserializedMessage[] = []
+    for (const message of batch) {
+      if (!message.value) continue
+
+      const parseResult = handlerConfig.schema.safeParse(message.value)
+      if (!parseResult.success) {
+        console.error(`[validation] Invalid message on ${topic}:`, parseResult.error.message)
+        continue
+      }
+      validMessages.push(message)
+    }
+
+    if (validMessages.length > 0) {
+      try {
+        await handlerConfig.handler(validMessages, metrics)
+      } catch (err) {
+        errorCount.value++
+        console.error(`[handler-error] #${errorCount.value} on ${topic}:`, err)
+      }
+    }
+
+    const lastMessage = batch[batch.length - 1]!
+    await lastMessage.commit()
+  }
+}
+
+export async function runStressBatchLoadTest (options: StressBatchLoadTestOptions): Promise<void> {
+  const {
+    rate,
+    duration,
+    batchSize,
+    consumerBatchSize,
+    consumerBatchTimeoutMs,
+    handlerDelayMs,
+    cpuWorkMs,
+    retryRate,
+    partitions,
+    payloadKb,
+    topics: topicCount,
+    maxWaitTime,
+    maxBytes,
+  } = options
+
+  const activeTopics = getActiveTopics(topicCount)
+
+  console.log(
+    `Starting stress batch load test: ${rate} msgs/sec, ${duration}s, batch=${batchSize}, ` +
+    `consumer-batch=${consumerBatchSize}, timeout=${consumerBatchTimeoutMs}ms, ` +
+    `delay=${handlerDelayMs}ms, cpu=${cpuWorkMs}ms, retry=${(retryRate * 100).toFixed(0)}%, ` +
+    `partitions=${partitions}, payload=${payloadKb}KB, topics=${activeTopics.length}, ` +
+    `maxWaitTime=${maxWaitTime}ms, maxBytes=${(maxBytes / 1024 / 1024).toFixed(1)}MB`
+  )
+
+  await ensureTopics(activeTopics, partitions)
+
+  const metrics = new MetricsCollector()
+  const errorCount = { value: 0 }
+  const groupId = `stress-batch-load-test-${randomUUID()}`
+  const padding = generatePaddedPayload(payloadKb)
+
+  const workOptions: WorkSimulatorOptions = {
+    handlerDelayMs,
+    cpuWorkMs,
+    retryRate,
+  }
+  const handlers = buildHandlers(workOptions)
+
+  const producer = new Producer({
+    clientId: `stress-batch-producer-${randomUUID()}`,
+    bootstrapBrokers: config.kafka.bootstrapBrokers,
+    serializers: {
+      key: stringSerializer,
+      value: jsonSerializer,
+      headerKey: stringSerializer,
+      headerValue: stringSerializer,
+    },
+  })
+
+  // Use realistic fetch parameters matching MQT defaults:
+  // - maxWaitTime: 5000ms (broker accumulates data before responding → large multi-chunk DynamicBuffers)
+  // - maxBytes: 10MB (allows large fetch responses that arrive in many TCP packets)
+  const consumer = new Consumer<string, Record<string, unknown>, string, string>({
+    clientId: `stress-batch-consumer-${randomUUID()}`,
+    groupId,
+    bootstrapBrokers: config.kafka.bootstrapBrokers,
+    deserializers: {
+      key: stringDeserializer,
+      value: safeJsonDeserializer,
+      headerKey: stringDeserializer,
+      headerValue: stringDeserializer,
+    },
+    autocommit: false,
+    maxWaitTime,
+    maxBytes,
+  })
+
+  console.log('Initializing Kafka batch consumer and producer...')
+
+  // Replicate MQT's init sequence: joinGroup() before consume()
+  await consumer.joinGroup()
+
+  const consumerStream = await consumer.consume({
+    topics: activeTopics,
+    mode: MessagesStreamModes.LATEST,
+  })
+
+  const messageBatchStream = new MessageBatchStream<DeserializedMessage>({
+    batchSize: consumerBatchSize,
+    timeoutMilliseconds: consumerBatchTimeoutMs,
+  })
+
+  // Listen for stream errors to detect DynamicBuffer bug
+  consumerStream.on('error', (error) => {
+    errorCount.value++
+    console.error(`[stream-error] #${errorCount.value}:`, error)
+    if (error.cause) {
+      console.error('[stream-error] cause:', error.cause)
+    }
+    if ('errors' in error && Array.isArray(error.errors)) {
+      for (const aggregateError of error.errors) {
+        console.error('[stream-error] aggregate:', aggregateError)
+      }
+    }
+  })
+
+  pipeline(consumerStream, messageBatchStream).catch((error) => {
+    errorCount.value++
+    console.error(`[pipeline-error] #${errorCount.value}:`, error)
+  })
+
+  handleSyncStreamBatch(messageBatchStream, handlers, metrics, errorCount).catch((error) => {
+    errorCount.value++
+    console.error(`[consumer-error] #${errorCount.value}:`, error)
+  })
+
+  console.log('Batch consumer and producer ready.')
+
+  const reportInterval = setInterval(() => {
+    metrics.report()
+    if (errorCount.value > 0) {
+      console.log(`  Stream errors: ${errorCount.value}`)
+    }
+  }, config.reportIntervalMs)
+
+  const totalMessages = rate * duration
+  console.log(`Publishing ${totalMessages.toLocaleString()} total messages at ${rate}/sec`)
+
+  const loadStartTime = Date.now()
+  let totalPublished = 0
+
+  const generators = [
+    (i: number) => ({ topic: STRESS_TOPICS.EVENTS, value: generateStressEvent(i, padding) }),
+    (i: number) => ({ topic: STRESS_TOPICS.ORDERS, value: generateStressOrder(i, padding) }),
+    (i: number) => ({ topic: STRESS_TOPICS.METRICS, value: generateStressMetric(i, padding) }),
+    (i: number) => ({ topic: STRESS_TOPICS.LOGS, value: generateStressLog(i, padding) }),
+  ].slice(0, activeTopics.length)
+
+  while (totalPublished < totalMessages) {
+    const remaining = totalMessages - totalPublished
+    const currentBatch = Math.min(batchSize, remaining)
+
+    try {
+      const messages: Array<{
+        topic: string
+        key: string
+        value: StressEvent | StressOrder | StressMetric | StressLog
+      }> = []
+
+      for (let i = 0; i < currentBatch; i++) {
+        const generatorIndex = i % generators.length
+        const generated = generators[generatorIndex]!(totalPublished + i)
+        messages.push({
+          topic: generated.topic,
+          key: randomUUID(),
+          value: generated.value,
+        })
+      }
+
+      await producer.send({ messages })
+      totalPublished += currentBatch
+      metrics.recordProduced(currentBatch)
+    } catch (err) {
+      console.error('Publish error:', err)
+    }
+
+    if (rate > 0) {
+      const elapsed = Date.now() - loadStartTime
+      const expectedElapsed = (totalPublished / rate) * 1000
+      const sleepMs = expectedElapsed - elapsed
+      if (sleepMs > 0) {
+        await setTimeout(sleepMs)
+      }
+    }
+  }
+
+  console.log(`\nPublishing complete. ${totalPublished.toLocaleString()} messages published.`)
+  console.log(`Waiting up to ${config.drainTimeoutMs / 1000}s for consumer to drain...`)
+
+  const drainStart = Date.now()
+  while (metrics.backlog > 0 && Date.now() - drainStart < config.drainTimeoutMs) {
+    await setTimeout(500)
+  }
+
+  clearInterval(reportInterval)
+  metrics.printFinalReport()
+
+  if (errorCount.value > 0) {
+    console.log(`\n*** ${errorCount.value} stream error(s) detected during test ***`)
+  }
+
+  console.log('Shutting down...')
+  await new Promise((resolve) => messageBatchStream.end(resolve))
+  await Promise.all([consumer.close(), producer.close()])
+  console.log('Done.')
+}

--- a/load-tests/src/stress-load-generator.ts
+++ b/load-tests/src/stress-load-generator.ts
@@ -1,0 +1,384 @@
+import { randomUUID } from 'node:crypto'
+import { setTimeout } from 'node:timers/promises'
+import type { z } from 'zod/v4'
+import {
+  Admin,
+  Consumer,
+  MessagesStreamModes,
+  Producer,
+  jsonSerializer,
+  stringDeserializer,
+  stringSerializer,
+  type Message,
+  type MessagesStream,
+} from '../../src/index.ts'
+import { config } from './config.ts'
+import { MetricsCollector } from './metrics-collector.ts'
+import {
+  STRESS_EVENT_SCHEMA,
+  STRESS_LOG_SCHEMA,
+  STRESS_METRIC_SCHEMA,
+  STRESS_ORDER_SCHEMA,
+  STRESS_TOPICS,
+  type StressEvent,
+  type StressLog,
+  type StressMetric,
+  type StressOrder,
+} from './schemas.ts'
+import { simulateWork, type WorkSimulatorOptions } from './work-simulator.ts'
+
+// Replicates MQT's safeJsonDeserializer: returns undefined for invalid JSON instead of throwing
+const safeJsonDeserializer = (data?: string | Buffer): object | undefined => {
+  if (!data) return undefined
+  if (!Buffer.isBuffer(data) && typeof data !== 'string') return undefined
+  try {
+    return JSON.parse(Buffer.isBuffer(data) ? data.toString('utf-8') : data)
+  } catch {
+    return undefined
+  }
+}
+
+export interface StressLoadTestOptions {
+  rate: number
+  duration: number
+  batchSize: number
+  handlerDelayMs: number
+  cpuWorkMs: number
+  retryRate: number
+  partitions: number
+  payloadKb: number
+  topics: number
+  maxWaitTime: number
+  maxBytes: number
+}
+
+type DeserializedMessage = Message<string, Record<string, unknown>, string, string>
+
+interface HandlerConfig {
+  schema: z.ZodType
+  handler: (message: DeserializedMessage, metrics: MetricsCollector) => Promise<void>
+}
+
+function buildHandlers (workOptions: WorkSimulatorOptions): Record<string, HandlerConfig> {
+  return {
+    [STRESS_TOPICS.EVENTS]: {
+      schema: STRESS_EVENT_SCHEMA,
+      handler: async (message, metrics) => {
+        const value = message.value as unknown as StressEvent
+        await simulateWork(value as unknown as Record<string, unknown>, workOptions)
+        const loadtestTs =
+          typeof value.payload?.loadtest_ts === 'number' ? value.payload.loadtest_ts : undefined
+        metrics.recordConsumed(STRESS_TOPICS.EVENTS, loadtestTs)
+      },
+    },
+    [STRESS_TOPICS.ORDERS]: {
+      schema: STRESS_ORDER_SCHEMA,
+      handler: async (message, metrics) => {
+        const value = message.value as unknown as StressOrder
+        await simulateWork(value as unknown as Record<string, unknown>, workOptions)
+        metrics.recordConsumed(STRESS_TOPICS.ORDERS)
+      },
+    },
+    [STRESS_TOPICS.METRICS]: {
+      schema: STRESS_METRIC_SCHEMA,
+      handler: async (message, metrics) => {
+        const value = message.value as unknown as StressMetric
+        await simulateWork(value as unknown as Record<string, unknown>, workOptions)
+        const loadtestTs =
+          typeof value.tags?.loadtest_ts === 'number' ? value.tags.loadtest_ts : undefined
+        metrics.recordConsumed(STRESS_TOPICS.METRICS, loadtestTs)
+      },
+    },
+    [STRESS_TOPICS.LOGS]: {
+      schema: STRESS_LOG_SCHEMA,
+      handler: async (message, metrics) => {
+        const value = message.value as unknown as StressLog
+        await simulateWork(value as unknown as Record<string, unknown>, workOptions)
+        const loadtestTs =
+          typeof value.context?.loadtest_ts === 'number' ? value.context.loadtest_ts : undefined
+        metrics.recordConsumed(STRESS_TOPICS.LOGS, loadtestTs)
+      },
+    },
+  }
+}
+
+function generatePaddedPayload (sizeKb: number): string {
+  const targetBytes = sizeKb * 1024
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+  let result = ''
+  for (let i = 0; i < targetBytes; i++) {
+    result += chars[i % chars.length]
+  }
+  return result
+}
+
+function generateStressEvent (index: number, padding: string): StressEvent {
+  return {
+    id: randomUUID(),
+    event_type: `stress_test_${index % 5}`,
+    payload: { loadtest_ts: Date.now(), index, data: padding },
+    created_at: new Date().toISOString(),
+  }
+}
+
+function generateStressOrder (index: number, padding: string): StressOrder {
+  return {
+    id: randomUUID(),
+    customer_id: `customer-${(index % 100).toString().padStart(3, '0')}`,
+    amount: (Math.random() * 1000).toFixed(2),
+    status: ['pending', 'confirmed', 'shipped', 'delivered'][index % 4]!,
+    created_at: new Date().toISOString() + padding.slice(0, 1),
+  }
+}
+
+function generateStressMetric (index: number, padding: string): StressMetric {
+  return {
+    id: randomUUID(),
+    metric_name: `stress_metric_${index % 10}`,
+    value: Math.random() * 1000,
+    tags: { loadtest_ts: Date.now(), index, data: padding },
+    created_at: new Date().toISOString(),
+  }
+}
+
+function generateStressLog (index: number, padding: string): StressLog {
+  return {
+    id: randomUUID(),
+    level: ['debug', 'info', 'warn', 'error'][index % 4]!,
+    message: `Stress log message ${index} ${padding.slice(0, 100)}`,
+    context: { loadtest_ts: Date.now(), index, data: padding },
+    created_at: new Date().toISOString(),
+  }
+}
+
+function getActiveTopics (topicCount: number): string[] {
+  const allTopics = [
+    STRESS_TOPICS.EVENTS,
+    STRESS_TOPICS.ORDERS,
+    STRESS_TOPICS.METRICS,
+    STRESS_TOPICS.LOGS,
+  ]
+  return allTopics.slice(0, Math.min(topicCount, allTopics.length))
+}
+
+async function ensureTopics (topics: string[], partitions: number): Promise<void> {
+  const admin = new Admin({
+    clientId: 'stress-test-admin',
+    bootstrapBrokers: config.kafka.bootstrapBrokers,
+  })
+
+  for (const topic of topics) {
+    try {
+      await admin.createTopics({ topics: [topic], partitions, replicas: 1 })
+    } catch {
+      // Topic may already exist
+    }
+  }
+
+  await admin.close()
+}
+
+async function handleSyncStream (
+  stream: MessagesStream<string, Record<string, unknown>, string, string>,
+  handlers: Record<string, HandlerConfig>,
+  metrics: MetricsCollector,
+  errorCount: { value: number }
+): Promise<void> {
+  for await (const message of stream) {
+    const handlerConfig = handlers[message.topic]
+    if (!handlerConfig) {
+      await message.commit()
+      continue
+    }
+
+    if (!message.value) {
+      await message.commit()
+      continue
+    }
+
+    const parseResult = handlerConfig.schema.safeParse(message.value)
+    if (!parseResult.success) {
+      console.error(`[validation] Invalid message on ${message.topic}:`, parseResult.error.message)
+      await message.commit()
+      continue
+    }
+
+    await handlerConfig.handler(message, metrics)
+    await message.commit()
+  }
+}
+
+export async function runStressLoadTest (options: StressLoadTestOptions): Promise<void> {
+  const {
+    rate,
+    duration,
+    batchSize,
+    handlerDelayMs,
+    cpuWorkMs,
+    retryRate,
+    partitions,
+    payloadKb,
+    topics: topicCount,
+    maxWaitTime,
+    maxBytes,
+  } = options
+
+  const activeTopics = getActiveTopics(topicCount)
+
+  console.log(
+    `Starting stress load test: ${rate} msgs/sec, ${duration}s, batch=${batchSize}, ` +
+    `delay=${handlerDelayMs}ms, cpu=${cpuWorkMs}ms, retry=${(retryRate * 100).toFixed(0)}%, ` +
+    `partitions=${partitions}, payload=${payloadKb}KB, topics=${activeTopics.length}, ` +
+    `maxWaitTime=${maxWaitTime}ms, maxBytes=${(maxBytes / 1024 / 1024).toFixed(1)}MB`
+  )
+
+  await ensureTopics(activeTopics, partitions)
+
+  const metrics = new MetricsCollector()
+  const errorCount = { value: 0 }
+  const groupId = `stress-load-test-${randomUUID()}`
+  const padding = generatePaddedPayload(payloadKb)
+
+  const workOptions: WorkSimulatorOptions = {
+    handlerDelayMs,
+    cpuWorkMs,
+    retryRate,
+  }
+  const handlers = buildHandlers(workOptions)
+
+  const producer = new Producer({
+    clientId: `stress-producer-${randomUUID()}`,
+    bootstrapBrokers: config.kafka.bootstrapBrokers,
+    serializers: {
+      key: stringSerializer,
+      value: jsonSerializer,
+      headerKey: stringSerializer,
+      headerValue: stringSerializer,
+    },
+  })
+
+  // Use realistic fetch parameters matching MQT defaults:
+  // - maxWaitTime: 5000ms (broker accumulates data before responding → large multi-chunk DynamicBuffers)
+  // - maxBytes: 10MB (allows large fetch responses that arrive in many TCP packets)
+  // Setting maxWaitTime: 5 (as in direct tests) creates tiny single-chunk responses that never stress DynamicBuffer
+  const consumer = new Consumer<string, Record<string, unknown>, string, string>({
+    clientId: `stress-consumer-${randomUUID()}`,
+    groupId,
+    bootstrapBrokers: config.kafka.bootstrapBrokers,
+    deserializers: {
+      key: stringDeserializer,
+      value: safeJsonDeserializer,
+      headerKey: stringDeserializer,
+      headerValue: stringDeserializer,
+    },
+    autocommit: false,
+    maxWaitTime,
+    maxBytes,
+  })
+
+  console.log('Initializing Kafka consumer and producer...')
+
+  // Replicate MQT's init sequence: joinGroup() before consume()
+  await consumer.joinGroup()
+
+  const stream = await consumer.consume({
+    topics: activeTopics,
+    mode: MessagesStreamModes.LATEST,
+  })
+
+  // Listen for stream errors to detect DynamicBuffer bug
+  stream.on('error', (error) => {
+    errorCount.value++
+    console.error(`[stream-error] #${errorCount.value}:`, error)
+    if (error.cause) {
+      console.error('[stream-error] cause:', error.cause)
+    }
+    if ('errors' in error && Array.isArray(error.errors)) {
+      for (const aggregateError of error.errors) {
+        console.error('[stream-error] aggregate:', aggregateError)
+      }
+    }
+  })
+
+  handleSyncStream(stream, handlers, metrics, errorCount).catch((error) => {
+    errorCount.value++
+    console.error(`[consumer-error] #${errorCount.value}:`, error)
+  })
+
+  console.log('Consumer and producer ready.')
+
+  const reportInterval = setInterval(() => {
+    metrics.report()
+    if (errorCount.value > 0) {
+      console.log(`  Stream errors: ${errorCount.value}`)
+    }
+  }, config.reportIntervalMs)
+
+  const totalMessages = rate * duration
+  console.log(`Publishing ${totalMessages.toLocaleString()} total messages at ${rate}/sec`)
+
+  const loadStartTime = Date.now()
+  let totalPublished = 0
+
+  const generators = [
+    (i: number) => ({ topic: STRESS_TOPICS.EVENTS, value: generateStressEvent(i, padding) }),
+    (i: number) => ({ topic: STRESS_TOPICS.ORDERS, value: generateStressOrder(i, padding) }),
+    (i: number) => ({ topic: STRESS_TOPICS.METRICS, value: generateStressMetric(i, padding) }),
+    (i: number) => ({ topic: STRESS_TOPICS.LOGS, value: generateStressLog(i, padding) }),
+  ].slice(0, activeTopics.length)
+
+  while (totalPublished < totalMessages) {
+    const remaining = totalMessages - totalPublished
+    const currentBatch = Math.min(batchSize, remaining)
+
+    try {
+      const messages: Array<{
+        topic: string
+        key: string
+        value: StressEvent | StressOrder | StressMetric | StressLog
+      }> = []
+
+      for (let i = 0; i < currentBatch; i++) {
+        const generatorIndex = i % generators.length
+        const generated = generators[generatorIndex]!(totalPublished + i)
+        messages.push({
+          topic: generated.topic,
+          key: randomUUID(),
+          value: generated.value,
+        })
+      }
+
+      await producer.send({ messages })
+      totalPublished += currentBatch
+      metrics.recordProduced(currentBatch)
+    } catch (err) {
+      console.error('Publish error:', err)
+    }
+
+    const elapsed = Date.now() - loadStartTime
+    const expectedElapsed = (totalPublished / rate) * 1000
+    const sleepMs = expectedElapsed - elapsed
+    if (sleepMs > 0) {
+      await setTimeout(sleepMs)
+    }
+  }
+
+  console.log(`\nPublishing complete. ${totalPublished.toLocaleString()} messages published.`)
+  console.log(`Waiting up to ${config.drainTimeoutMs / 1000}s for consumer to drain...`)
+
+  const drainStart = Date.now()
+  while (metrics.backlog > 0 && Date.now() - drainStart < config.drainTimeoutMs) {
+    await setTimeout(500)
+  }
+
+  clearInterval(reportInterval)
+  metrics.printFinalReport()
+
+  if (errorCount.value > 0) {
+    console.log(`\n*** ${errorCount.value} stream error(s) detected during test ***`)
+  }
+
+  console.log('Shutting down...')
+  await Promise.all([consumer.close(), producer.close()])
+  console.log('Done.')
+}

--- a/load-tests/src/work-simulator.ts
+++ b/load-tests/src/work-simulator.ts
@@ -1,0 +1,72 @@
+import { randomUUID } from 'node:crypto'
+import { setTimeout } from 'node:timers/promises'
+
+export interface WorkSimulatorOptions {
+  /** Async I/O delay per message in ms (simulates DB writes, API calls) */
+  handlerDelayMs: number
+  /** CPU-bound work per message in ms (simulates JSON serialization, schema validation) */
+  cpuWorkMs: number
+  /** Probability (0-1) that a handler "fails" and triggers retry logic */
+  retryRate: number
+}
+
+/**
+ * Simulates MQT's processing overhead per message:
+ * - randomUUID() + JSON.stringify() + object spread (transaction ID, error context, message cloning)
+ * - Configurable async I/O delay (DB writes, API calls)
+ * - Configurable CPU-bound work (tight loop for serialization overhead)
+ * - Handler retry logic with exponential backoff (1ms, 2ms, 4ms)
+ */
+export async function simulateWork (
+  message: Record<string, unknown>,
+  options: WorkSimulatorOptions
+): Promise<void> {
+  // MQT overhead: transaction ID, error context serialization, parsed message cloning
+  simulateMqtOverhead(message)
+
+  // Async I/O delay (DB writes, API calls)
+  if (options.handlerDelayMs > 0) {
+    await setTimeout(options.handlerDelayMs)
+  }
+
+  // CPU-bound work (JSON serialization, schema validation overhead, object cloning)
+  if (options.cpuWorkMs > 0) {
+    simulateCpuWork(options.cpuWorkMs)
+  }
+
+  // Handler retry logic with exponential backoff
+  if (options.retryRate > 0 && shouldRetry(options.retryRate)) {
+    for (let attempt = 0; attempt < 3; attempt++) {
+      await setTimeout(2 ** attempt)
+      if (!shouldRetry(options.retryRate)) break
+    }
+  }
+}
+
+/**
+ * Simulates MQT overhead per message:
+ * randomUUID() for transaction IDs, JSON.stringify() for error context,
+ * object spread for parsed message cloning
+ */
+function simulateMqtOverhead (message: Record<string, unknown>): void {
+  const _transactionId = randomUUID()
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const _serialized = JSON.stringify(message)
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const _clone = { ...message, _transactionId }
+}
+
+/**
+ * Burns CPU time with a tight loop to simulate synchronous processing overhead
+ * (JSON serialization, schema validation, object cloning in hot paths)
+ */
+function simulateCpuWork (ms: number): void {
+  const end = performance.now() + ms
+  while (performance.now() < end) {
+    // Tight loop to burn CPU
+  }
+}
+
+function shouldRetry (retryRate: number): boolean {
+  return Math.random() < retryRate
+}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "create:api": "node scripts/create-api.ts"
   },
   "dependencies": {
-    "@platformatic/dynamic-buffer": "^0.3.0",
+    "@platformatic/dynamic-buffer": "0.3.0",
     "@platformatic/wasm-utils": "^0.1.0",
     "ajv": "^8.17.1",
     "avsc": "^5.7.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       '@platformatic/dynamic-buffer':
-        specifier: ^0.3.0
+        specifier: 0.3.0
         version: 0.3.0
       '@platformatic/wasm-utils':
         specifier: ^0.1.0
@@ -189,28 +189,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@antoniomuso/lz4-napi-linux-arm64-musl@2.9.0':
     resolution: {integrity: sha512-eJtHp38zuLaYI0/cOV/BKcNQiXUBo4GPx53FTf0Y307yUjLsn48LNeN0vD28Ct9YrbUae3bQvMD5AD86She0ww==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@antoniomuso/lz4-napi-linux-x64-gnu@2.9.0':
     resolution: {integrity: sha512-mDjS4dyjRKaZQcAP71SphkYH5r3kufB30ih/VETVu/br2toCfBk6Zr1xhL1r+L7FaVAFzF62B7h30CiqrN0Awg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@antoniomuso/lz4-napi-linux-x64-musl@2.9.0':
     resolution: {integrity: sha512-pvU7Z7qjkjn17NkddBtBQ7C2iRqjtZ7WJ3Jqrjtj4XxolY3Q0HaYMvWjkWhzb9AKGZbj5y+EHYtbVoZJ2TSQhQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@antoniomuso/lz4-napi-win32-arm64-msvc@2.9.0':
     resolution: {integrity: sha512-aioLlbpJl0QPEXLXhh2bzyitc3T7Jot3f1ap6WdKiRa+CIjMHXw1nxJXy07MLXif10r+qVZr86ic8dvwErgqEQ==}
@@ -422,49 +418,42 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/snappy-linux-arm64-musl@7.3.3':
     resolution: {integrity: sha512-AAED4cQS74xPvktsyVmz5sy8vSxG/+3d7Rq2FDBZzj3Fv6v5vux6uZnECPCAqpALCdTtJ61unqpOyqO7hZCt1Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/snappy-linux-ppc64-gnu@7.3.3':
     resolution: {integrity: sha512-pofO5eSLg8ZTBwVae4WHHwJxJGZI8NEb4r5Mppvq12J/1/Hq1HecClXmfY3A7bdT2fsS2Td+Q7CI9VdBOj2sbA==}
     engines: {node: '>= 10'}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/snappy-linux-riscv64-gnu@7.3.3':
     resolution: {integrity: sha512-OiHYdeuwj0TVBXADUmmQDQ4lL1TB+8EwmXnFgOutoDVXHaUl0CJFyXLa6tYUXe+gRY8hs1v7eb0vyE97LKY06Q==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/snappy-linux-s390x-gnu@7.3.3':
     resolution: {integrity: sha512-66QdmuV9CTq/S/xifZXlMy3PsZTviAgkqqpZ+7vPCmLtuP+nqhaeupShOFf/sIDsS0gZePazPosPTeTBbhkLHg==}
     engines: {node: '>= 10'}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/snappy-linux-x64-gnu@7.3.3':
     resolution: {integrity: sha512-g6KURjOxrgb8yXDEZMuIcHkUr/7TKlDwSiydEQtMtP3n4iI4sNjkcE/WNKlR3+t9bZh1pFGAq7NFRBtouQGHpQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/snappy-linux-x64-musl@7.3.3':
     resolution: {integrity: sha512-6UvOyczHknpaKjrlKKSlX3rwpOrfJwiMG6qA0NRKJFgbcCAEUxmN9A8JvW4inP46DKdQ0bekdOxwRtAhFiTDfg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/snappy-openharmony-arm64@7.3.3':
     resolution: {integrity: sha512-I5mak/5rTprobf7wMCk0vFhClmWOL/QiIJM4XontysnadmP/R9hAcmuFmoMV2GaxC9MblqLA7Z++gy8ou5hJVw==}
@@ -545,28 +534,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@node-rs/crc32-linux-arm64-musl@1.10.6':
     resolution: {integrity: sha512-k8ra/bmg0hwRrIEE8JL1p32WfaN9gDlUUpQRWsbxd1WhjqvXea7kKO6K4DwVxyxlPhBS9Gkb5Urq7Y4mXANzaw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@node-rs/crc32-linux-x64-gnu@1.10.6':
     resolution: {integrity: sha512-IfjtqcuFK7JrSZ9mlAFhb83xgium30PguvRjIMI45C3FJwu18bnLk1oR619IYb/zetQT82MObgmqfKOtgemEKw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@node-rs/crc32-linux-x64-musl@1.10.6':
     resolution: {integrity: sha512-LbFYsA5M9pNunOweSt6uhxenYQF94v3bHDAQRPTQ3rnjn+mK6IC7YTAYoBjvoJP8lVzcvk9hRj8wp4Jyh6Y80g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@node-rs/crc32-wasm32-wasi@1.10.6':
     resolution: {integrity: sha512-KaejdLgHMPsRaxnM+OG9L9XdWL2TabNx80HLdsCOoX9BVhEkfh39OeahBo8lBmidylKbLGMQoGfIKDjq0YMStw==}
@@ -655,49 +640,41 @@ packages:
     resolution: {integrity: sha512-Cwm6A071ww60QouJ9LoHAwBgEoZzHQ0Qaqk2E7WLfBdiQN9mLXIDhnrpn04hlRElRPhLiu/dtg+o5PPLvaINXQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.17.1':
     resolution: {integrity: sha512-+hwlE2v3m0r3sk93SchJL1uyaKcPjf+NGO/TD2DZUDo+chXx7FfaEj0nUMewigSt7oZ2sQN9Z4NJOtUa75HE5Q==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.17.1':
     resolution: {integrity: sha512-bO+rsaE5Ox8cFyeL5Ct5tzot1TnQpFa/Wmu5k+hqBYSH2dNVDGoi0NizBN5QV8kOIC6O5MZr81UG4yW/2FyDTA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.17.1':
     resolution: {integrity: sha512-B/P+hxKQ1oX4YstI9Lyh4PGzqB87Ddqj/A4iyRBbPdXTcxa+WW3oRLx1CsJKLmHPdDk461Hmbghq1Bm3pl+8Aw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.17.1':
     resolution: {integrity: sha512-ulp2H3bFXzd/th2maH+QNKj5qgOhJ3v9Yspdf1svTw3CDOuuTl6sRKsWQ7MUw0vnkSNvQndtflBwVXgzZvURsQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.17.1':
     resolution: {integrity: sha512-LAXYVe3rKk09Zo9YKF2ZLBcH8sz8Oj+JIyiUxiHtq0hiYLMsN6dOpCf2hzQEjPAmsSEA/hdC1PVKeXo+oma8mQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.17.1':
     resolution: {integrity: sha512-3RAhxipMKE8RCSPn7O//sj440i+cYTgYbapLeOoDvQEt6R1QcJjTsFgI4iz99FhVj3YbPxlZmcLB5VW+ipyRTA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.17.1':
     resolution: {integrity: sha512-wpjMEubGU8r9VjZTLdZR3aPHaBqTl8Jl8F4DBbgNoZ+yhkhQD1/MGvY70v2TLnAI6kAHSvcqgfvaqKDa2iWsPQ==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.17.1':
     resolution: {integrity: sha512-XIE4w17RYAVIgx+9Gs3deTREq5tsmalbatYOOBGNdH7n0DfTE600c7wYXsp7ANc3BPDXsInnOzXDEPCvO1F6cg==}
@@ -815,28 +792,24 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.11':
     resolution: {integrity: sha512-PYftgsTaGnfDK4m6/dty9ryK1FbLk+LosDJ/RJR2nkXGc8rd+WenXIlvHjWULiBVnS1RsjHHOXmTS4nDhe0v0w==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.15.11':
     resolution: {integrity: sha512-DKtnJKIHiZdARyTKiX7zdRjiDS1KihkQWatQiCHMv+zc2sfwb4Glrodx2VLOX4rsa92NLR0Sw8WLcPEMFY1szQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.11':
     resolution: {integrity: sha512-mUjjntHj4+8WBaiDe5UwRNHuEzLjIWBTSGTw0JT9+C9/Yyuh4KQqlcEQ3ro6GkHmBGXBFpGIj/o5VMyRWfVfWw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.11':
     resolution: {integrity: sha512-ZkNNG5zL49YpaFzfl6fskNOSxtcZ5uOYmWBkY4wVAvgbSAQzLRVBp+xArGWh2oXlY/WgL99zQSGTv7RI5E6nzA==}
@@ -1002,49 +975,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}

--- a/test/clients/consumer/messages-stream-rebalance.test.ts
+++ b/test/clients/consumer/messages-stream-rebalance.test.ts
@@ -42,9 +42,7 @@ test('should not fetch while offsets are refreshing after a group rejoin', async
     consumer.metadataCalls++
 
     callback(null, {
-      topics: new Map([
-        ['test-topic', { id: 'test-topic-id', partitions: [{ leader: 1, leaderEpoch: 0 }] }]
-      ])
+      topics: new Map([['test-topic', { id: 'test-topic-id', partitions: [{ leader: 1, leaderEpoch: 0 }] }]])
     })
   }
 


### PR DESCRIPTION
This reproduces https://github.com/platformatic/kafka/issues/228

In order to do so, run `"load:stress:batch:light"` from load-tests/package.json

Note that in order to reproduce the issue you need to be using `"@platformatic/dynamic-buffer": "0.3.0"`. Updating to a newer version prevents the breakage in the first place, but it is highly likely that this only obscures the deeper issue in the code - even when a bug happens, consumption stream should not break or should be able to be recreated and continue.