### PR TITLE
fix: Fall back to discovered brokers when bootstrap brokers are unreachable.

### DIFF
--- a/src/clients/base/base.ts
+++ b/src/clients/base/base.ts
@@ -496,7 +496,7 @@ export class Base<
       return
     }
 
-    const discovered = Array.from(this.#metadata.brokers.values()).map(({ host, port }) => ({ host, port }))
+    const discovered = Array.from(this.#metadata.brokers.values())
     this[kConnections].getFirstAvailable([...this[kBootstrapBrokers], ...discovered], callback)
   }
 

--- a/src/clients/base/base.ts
+++ b/src/clients/base/base.ts
@@ -491,7 +491,13 @@ export class Base<
   }
 
   [kGetBootstrapConnection] (callback: Callback<Connection>): void {
-    this[kConnections].getFirstAvailable(this[kBootstrapBrokers], callback)
+    if (!this.#metadata) {
+      this[kConnections].getFirstAvailable(this[kBootstrapBrokers], callback)
+      return
+    }
+
+    const discovered = Array.from(this.#metadata.brokers.values()).map(({ host, port }) => ({ host, port }))
+    this[kConnections].getFirstAvailable([...this[kBootstrapBrokers], ...discovered], callback)
   }
 
   [kValidateOptions] (

--- a/test/clients/base/base.test.ts
+++ b/test/clients/base/base.test.ts
@@ -13,12 +13,15 @@ import {
   sleep,
   TimeoutError,
   UnsupportedApiError,
+  type Broker,
+  type CallbackWithPromise,
   type ClientDiagnosticEvent,
   type ClusterMetadata
 } from '../../../src/index.ts'
 import {
   createBase,
   createTracingChannelVerifier,
+  kafkaBootstrapServers,
   mockAPI,
   mockConnectionPoolGet,
   mockConnectionPoolGetFirstAvailable,
@@ -774,4 +777,72 @@ test('initialization should not fail when maxInflights is specifically set to un
   strictEqual(typeof metadata.id, 'string')
   strictEqual(metadata.brokers instanceof Map, true)
   strictEqual(metadata.topics instanceof Map, true)
+})
+
+test('metadata should fall back to discovered brokers when bootstrap broker is unreachable', async t => {
+  // Tests assume a single bootstrap broker; if kafkaBootstrapServers is extended the test is invalidated
+  strictEqual(kafkaBootstrapServers.length, 1, 'test assumes a single bootstrap broker')
+  const [bootstrapHost, bootstrapPortStr] = kafkaBootstrapServers[0].split(':')
+  const bootstrapPort = Number(bootstrapPortStr)
+
+  const client = createBase(t, { retries: 0 })
+
+  // Fetch initial metadata to populate the discovered brokers cache
+  const initialMetadata = await client.metadata({ topics: [] })
+  ok(initialMetadata.brokers.size > 1, 'test requires a multi-broker cluster')
+
+  // Simulate the bootstrap broker becoming unreachable
+  let bootstrapAttempted = false
+  const pool = client[kConnections]
+  const originalGet = pool.get.bind(pool)
+  pool.get = function (broker: Broker, callback: CallbackWithPromise<Connection>) {
+    if (broker.host === bootstrapHost && broker.port === bootstrapPort) {
+      bootstrapAttempted = true
+      callback(new Error('Simulated bootstrap broker unreachable'))
+      return
+    }
+    originalGet(broker, callback)
+  } as typeof originalGet
+
+  // Verify that a subsequent metadata request succeeds using a discovered broker
+  const metadata = await client.metadata({ topics: [], forceUpdate: true })
+  ok(bootstrapAttempted, 'bootstrap broker should have been attempted before falling back')
+  strictEqual(typeof metadata.id, 'string')
+  ok(metadata.brokers.size > 0)
+})
+
+test('metadata should use bootstrap brokers only after clearMetadata', async t => {
+  // Tests assume a single bootstrap broker; if kafkaBootstrapServers is extended the test is invalidated
+  strictEqual(kafkaBootstrapServers.length, 1, 'test assumes a single bootstrap broker')
+  const [bootstrapHost, bootstrapPortStr] = kafkaBootstrapServers[0].split(':')
+  const bootstrapPort = Number(bootstrapPortStr)
+
+  const client = createBase(t, { retries: 0 })
+
+  // Fetch initial metadata to populate the discovered brokers cache
+  const initialMetadata = await client.metadata({ topics: [] })
+  ok(initialMetadata.brokers.size > 1, 'test requires a multi-broker cluster')
+
+  // Clear the cache — subsequent fetches should revert to bootstrap-only discovery
+  client.clearMetadata()
+
+  // Simulate the bootstrap broker becoming unreachable
+  const pool = client[kConnections]
+  const originalGet = pool.get.bind(pool)
+  pool.get = function (broker: Broker, callback: CallbackWithPromise<Connection>) {
+    if (broker.host === bootstrapHost && broker.port === bootstrapPort) {
+      callback(new Error('Simulated bootstrap broker unreachable'))
+      return
+    }
+    originalGet(broker, callback)
+  } as typeof originalGet
+
+  // Should fail because clearMetadata reset the discovered broker cache
+  try {
+    await client.metadata({ topics: [] })
+    throw new Error('Expected metadata call to fail')
+  } catch (error) {
+    strictEqual(error instanceof MultipleErrors, true)
+    strictEqual(error.message, 'Cannot connect to any broker.')
+  }
 })


### PR DESCRIPTION
kGetBootstrapConnection currently only contacts the configured bootstrap brokers when fetching or refreshing metadata. If one or more bootstrap broker becomes permanently unavailable after initial connection, all subsequent metadata refreshes fail even though the client may know about additional brokers from its last successful fetch.

This change aligns @platformatic/kafka with kafkajs behaviour: once brokers are discovered, the client uses the full known broker list — not just the bootstrap entries — when it needs to re-establish a metadata connection. Bootstrap brokers are entry points, not a persistent dependency.

If cached metadata is available, we use it.  If the cache is empty (or cleared), we fall back to current behavior.