### PR TITLE
fix error accumulations memory leak

### DIFF
--- a/src/clients/base/base.ts
+++ b/src/clients/base/base.ts
@@ -372,7 +372,7 @@ export class Base<
     operation: (callback: Callback<ReturnType>) => void,
     callback: CallbackWithPromise<ReturnType>,
     attempt: number = 0,
-    errors: Error[] = [],
+    firstError?: Error,
     shouldSkipRetry?: (e: Error) => boolean
   ): void | Promise<ReturnType> {
     const retries = this[kOptions].retries! as number
@@ -383,13 +383,13 @@ export class Base<
         const genericError = error as GenericError
         // Only retry if all the errors in the chain are retriable
         const retriable = !genericError.findBy?.('canRetry', false)
-        errors.push(error)
+        // keeps only the first error ( root cause ) - avoid accumulating errors in case of multiple retries
+        const initialError = firstError ?? error
 
         if (attempt < retries && retriable && !shouldSkipRetry?.(error)) {
           function onClose () {
             clearTimeout(timeout)
-            errors.push(new UserError(`Client closed while retrying ${operationId}.`))
-            callback(new MultipleErrors(`${operationId} failed ${attempt + 1} times.`, errors))
+            callback(new MultipleErrors(`${operationId} failed ${attempt + 1} times.`, [initialError, new UserError(`Client was closed during retry ${operationId}.`)]))
           }
 
           let delay = this[kOptions].retryDelay
@@ -400,7 +400,7 @@ export class Base<
           this.emitWithDebug('client', 'performWithRetry:retry', operationId, attempt, retries, delay)
           const timeout = setTimeout(() => {
             this.removeListener('client:close', onClose)
-            this[kPerformWithRetry](operationId, operation, callback, attempt + 1, errors, shouldSkipRetry)
+            this[kPerformWithRetry](operationId, operation, callback, attempt + 1, initialError, shouldSkipRetry)
           }, delay)
 
           this.once('client:close', onClose)
@@ -410,7 +410,7 @@ export class Base<
             return
           }
 
-          callback(new MultipleErrors(`${operationId} failed ${attempt + 1} times.`, errors))
+          callback(new MultipleErrors(`${operationId} failed ${attempt + 1} times.`, [initialError, error]))
         }
 
         return

--- a/src/clients/producer/producer.ts
+++ b/src/clients/producer/producer.ts
@@ -1129,7 +1129,7 @@ export class Producer<Key = Buffer, Value = Buffer, HeaderKey = Buffer, HeaderVa
           callback(error, results)
         },
         0,
-        [],
+        undefined,
         error => {
           if (!repeatOnStaleMetadata || !GenericError.isGenericError(error)) {
             return false

--- a/test/clients/base/base.test.ts
+++ b/test/clients/base/base.test.ts
@@ -860,3 +860,15 @@ test('metadata should use bootstrap brokers only after clearMetadata', async t =
     strictEqual(error.message, 'Cannot connect to any broker.')
   }
 })
+
+test('kPerformWithRetry should only retain first and last error — not accumulate all', async t => {
+  const client = createBase(t, { retries: 3, retryDelay: 0 })
+
+  const error = await client.metadata({ topics: [`test-topic-${randomUUID()}`] }).catch(e => e)
+
+  await client.close()
+
+  // MultipleErrors must contain at most 2 errors: first (root cause) and last (final failure)
+  strictEqual(error instanceof MultipleErrors, true)
+  ok(error.errors.length <= 2, `expected at most 2 errors, got ${error.errors.length}`)
+})


### PR DESCRIPTION
performWithRetry accumulates all error objects across retries
Each retry call pushes an Error to a shared errors: Error[] array passed recursively through the closure chain. The array is captured by the onClose listener registered as consumer.once('client:close', onClose).
Key problem: 'client:close' is only emitted when consumer.close() is called — not when an individual MessagesStream is destroyed and recreated. During stream restarts (common in rebalance scenarios), each retry cycle creates a new chain with accumulated Error objects and CallSiteInfo stack frames that are never released.