### PR TITLE
fix: npm install -g npm@latest in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Push changes
         run: git push origin HEAD:${{ github.ref }}
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.11.1
       - name: Publish to NPM
         run: pnpm publish --access public --tag ${{ inputs.prerelease == true && 'next' || 'latest' }} --publish-branch ${{ github.ref_name }} --no-git-checks
       - name: 'Create release notes'


### PR DESCRIPTION
Potential fix for: https://github.com/platformatic/kafka/issues/273 

Temporary workaround pinning specific  last known working version of `npm`  to `11.1.1`. It will prevent further failures in `npm install -g npm@latest` which is causing issues in [Publish release](https://github.com/platformatic/kafka/actions/workflows/release.yml) workflow

Relevant issue in `npm`
https://github.com/npm/cli/issues/9151

More broad explanation can be found in the _Issues_: https://github.com/platformatic/kafka/issues/273#issuecomment-4320522888