### PR TITLE
Avoid parsing of group assignment user data

### DIFF
--- a/src/clients/admin/admin.ts
+++ b/src/clients/admin/admin.ts
@@ -1332,7 +1332,7 @@ export class Admin extends Base<AdminOptions> {
                       false
                     )
 
-                    reader.readBytes() // Ignore the user data
+                    // Ignore the user data
                   }
 
                   group.members.set(member.memberId, {

--- a/src/clients/consumer/consumer.ts
+++ b/src/clients/consumer/consumer.ts
@@ -1931,7 +1931,8 @@ export class Consumer<Key = Buffer, Value = Buffer, HeaderKey = Buffer, HeaderVa
     https://github.com/apache/kafka/blob/trunk/clients/src/main/resources/common/message/ConsumerProtocolAssignment.json
   */
   #encodeProtocolAssignment (assignments: GroupAssignment[]): Buffer {
-    return Writer.create()
+    const userData = this[kOptions].assignmentUserData
+    const writer = Writer.create()
       .appendInt16(0) // Version information
       .appendArray(
         assignments,
@@ -1941,7 +1942,12 @@ export class Consumer<Key = Buffer, Value = Buffer, HeaderKey = Buffer, HeaderVa
         false,
         false
       )
-      .appendInt32(0).buffer // No user data
+
+    if (userData) {
+      writer.append(userData)
+    }
+
+    return writer.buffer
   }
 
   #decodeProtocolAssignment (buffer: Buffer): GroupAssignment[] {

--- a/src/clients/consumer/types.ts
+++ b/src/clients/consumer/types.ts
@@ -79,6 +79,7 @@ export interface GroupOptions {
   heartbeatInterval?: number
   protocols?: GroupProtocolSubscription[]
   partitionAssigner?: GroupPartitionsAssigner
+  assignmentUserData?: Buffer
 }
 
 export interface ConsumerGroupOptions {
@@ -86,6 +87,7 @@ export interface ConsumerGroupOptions {
   groupInstanceId?: string
   groupRemoteAssignor?: string
   rebalanceTimeout?: number
+  assignmentUserData?: Buffer
 }
 
 export interface ConsumeBaseOptions<Key, Value, HeaderKey, HeaderValue> {

--- a/test/clients/admin/admin.test.ts
+++ b/test/clients/admin/admin.test.ts
@@ -1714,6 +1714,32 @@ test('describeGroups should handle includeAuthorizedOperations option', async t 
   strictEqual(typeof group2.authorizedOperations, 'number')
 })
 
+test('describeGroups should handle memberAssignment with single user data byte with high bit set', async t => {
+  const groupId = `test-group-${randomUUID()}`
+  const testTopic = `test-topic-${randomUUID()}`
+  const admin = createAdmin(t)
+  const assignmentUserData = Buffer.from([0x80])
+
+  await admin.createTopics({ topics: [testTopic], partitions: 1, replicas: 1 })
+
+  const consumer = new Consumer({
+    clientId: `test-client-${randomUUID()}`,
+    groupId,
+    bootstrapBrokers: kafkaBootstrapServers,
+    assignmentUserData
+  })
+  t.after(() => consumer.close())
+
+  await consumer.topics.trackAll(testTopic)
+  await consumer.joinGroup()
+
+  const groups = await admin.describeGroups({ groups: [groupId] })
+  const group = groups.get(groupId)!
+
+  strictEqual(group.state, 'STABLE')
+  strictEqual(group.members.size, 1)
+})
+
 test('describeGroups should validate options in strict mode', async t => {
   const admin = createAdmin(t, { strict: true })
 


### PR DESCRIPTION
User data is an arbitrary sequence of bytes, likely without any length prefix. The current code tries to parse these bytes, which will fail if there is only a single byte with the MSB set (which causes the varint parser to read beyond the buffer end). This change removes the parsing of this user data.

On-behalf-of: @SAP ospo@sap.com