### PR TITLE
fix: always write user data bytes field in ConsumerProtocolAssigment

### DIFF
--- a/src/clients/consumer/consumer.ts
+++ b/src/clients/consumer/consumer.ts
@@ -1964,9 +1964,7 @@ export class Consumer<Key = Buffer, Value = Buffer, HeaderKey = Buffer, HeaderVa
         false
       )
 
-    if (userData) {
-      writer.append(userData)
-    }
+    writer.appendBytes(userData ?? null, false)
 
     return writer.buffer
   }

--- a/test/clients/admin/admin.test.ts
+++ b/test/clients/admin/admin.test.ts
@@ -1748,6 +1748,12 @@ test('describeGroups memberAssignment should include user data field when no ass
 
   await admin.createTopics({ topics: [testTopic], partitions: 1, replicas: 1 })
 
+  const bootstrapConn = await new Promise<Connection>((resolve, reject) => {
+    admin[kGetBootstrapConnection]((error, conn) => (error ? reject(error) : resolve(conn!)))
+  })
+  const coordResponse = await findCoordinatorV6.api.async(bootstrapConn, FindCoordinatorKeyTypes.GROUP, [groupId])
+  const { host, port } = coordResponse.coordinators[0]
+
   const consumer = new Consumer({
     clientId: `test-client-${randomUUID()}`,
     groupId,
@@ -1758,23 +1764,17 @@ test('describeGroups memberAssignment should include user data field when no ass
   await consumer.topics.trackAll(testTopic)
   await consumer.joinGroup()
 
+  // Warm up the coordinator connection and assert stable state before the raw read.
   const groups = await admin.describeGroups({ groups: [groupId] })
   strictEqual(groups.get(groupId)!.state, 'STABLE')
   strictEqual(groups.get(groupId)!.members.size, 1)
 
-  const bootstrapConn = await new Promise<Connection>((resolve, reject) => {
-    admin[kGetBootstrapConnection]((error, conn) => (error ? reject(error) : resolve(conn!)))
-  })
-
-  // Route to the group coordinator so DescribeGroups returns members
-  const coordResponse = await findCoordinatorV6.api.async(bootstrapConn, FindCoordinatorKeyTypes.GROUP, [groupId])
-  const { host, port } = coordResponse.coordinators[0]
   const coordinatorConn = await new Promise<Connection>((resolve, reject) => {
     admin[kConnections].get({ host, port }, (error, conn) => (error ? reject(error) : resolve(conn!)))
   })
-
   const rawResponse = await describeGroupsV5.api.async(coordinatorConn, [groupId], false)
-  const rawMember = rawResponse.groups[0].members[0]
+  const rawMember = rawResponse.groups[0]?.members[0]
+  ok(rawMember, 'expected group member to be present')
 
   // Parse the raw memberAssignment bytes following Java ConsumerProtocolAssignment format:
   // int16 version | int32-prefixed topics array | int32 user data length

--- a/test/clients/admin/admin.test.ts
+++ b/test/clients/admin/admin.test.ts
@@ -22,7 +22,8 @@ import {
   type GroupBase,
   type ListConsumerGroupOffsetsGroup
 } from '../../../src/clients/admin/index.ts'
-import { kConnections, kGetBootstrapConnection } from '../../../src/clients/base/base.ts'
+import { kConnections, kGetApi, kGetBootstrapConnection } from '../../../src/clients/base/base.ts'
+import { type Connection } from '../../../src/network/connection.ts'
 import { Reader } from '../../../src/protocol/reader.ts'
 import {
   AclOperations,
@@ -43,7 +44,6 @@ import {
   type ClientDiagnosticEvent,
   ClientQuotaMatchTypes,
   type ClusterPartitionMetadata,
-  type Connection,
   Consumer,
   createAclsV3,
   createPartitionsV3,
@@ -1748,12 +1748,6 @@ test('describeGroups memberAssignment should include user data field when no ass
 
   await admin.createTopics({ topics: [testTopic], partitions: 1, replicas: 1 })
 
-  const bootstrapConn = await new Promise<Connection>((resolve, reject) => {
-    admin[kGetBootstrapConnection]((error, conn) => (error ? reject(error) : resolve(conn!)))
-  })
-  const coordResponse = await findCoordinatorV6.api.async(bootstrapConn, FindCoordinatorKeyTypes.GROUP, [groupId])
-  const { host, port } = coordResponse.coordinators[0]
-
   const consumer = new Consumer({
     clientId: `test-client-${randomUUID()}`,
     groupId,
@@ -1764,11 +1758,24 @@ test('describeGroups memberAssignment should include user data field when no ass
   await consumer.topics.trackAll(testTopic)
   await consumer.joinGroup()
 
-  // Warm up the coordinator connection and assert stable state before the raw read.
   const groups = await admin.describeGroups({ groups: [groupId] })
   strictEqual(groups.get(groupId)!.state, 'STABLE')
   strictEqual(groups.get(groupId)!.members.size, 1)
 
+  // Use kGetApi so FindCoordinator uses the broker-negotiated version.
+  // Hardcoded v6 causes Confluent Kafka 7.x to close the connection (version mismatch).
+  const bootstrapConn = await new Promise<Connection>((resolve, reject) => {
+    admin[kGetBootstrapConnection]((error, conn) => (error ? reject(error) : resolve(conn!)))
+  })
+  const coordResponse = await new Promise<{ coordinators: Array<{ host: string, port: number }> }>((resolve, reject) => {
+    admin[kGetApi]('FindCoordinator', (error: Error | null, api: any) => {
+      if (error) { reject(error); return }
+      api(bootstrapConn, FindCoordinatorKeyTypes.GROUP, [groupId], (err: Error | null, res: any) => {
+        err ? reject(err) : resolve(res)
+      })
+    })
+  })
+  const { host, port } = coordResponse.coordinators[0]
   const coordinatorConn = await new Promise<Connection>((resolve, reject) => {
     admin[kConnections].get({ host, port }, (error, conn) => (error ? reject(error) : resolve(conn!)))
   })

--- a/test/clients/admin/admin.test.ts
+++ b/test/clients/admin/admin.test.ts
@@ -22,7 +22,7 @@ import {
   type GroupBase,
   type ListConsumerGroupOffsetsGroup
 } from '../../../src/clients/admin/index.ts'
-import { kConnections, kGetBootstrapConnection, kGetConnection } from '../../../src/clients/base/base.ts'
+import { kConnections, kGetBootstrapConnection } from '../../../src/clients/base/base.ts'
 import { Reader } from '../../../src/protocol/reader.ts'
 import {
   AclOperations,

--- a/test/clients/admin/admin.test.ts
+++ b/test/clients/admin/admin.test.ts
@@ -22,7 +22,7 @@ import {
   type GroupBase,
   type ListConsumerGroupOffsetsGroup
 } from '../../../src/clients/admin/index.ts'
-import { kConnections, kGetBootstrapConnection } from '../../../src/clients/base/base.ts'
+import { kConnections, kGetBootstrapConnection, kGetConnection } from '../../../src/clients/base/base.ts'
 import { Reader } from '../../../src/protocol/reader.ts'
 import {
   AclOperations,
@@ -1758,11 +1758,18 @@ test('describeGroups memberAssignment should include user data field when no ass
   await consumer.topics.trackAll(testTopic)
   await consumer.joinGroup()
 
-  const connection = await new Promise<Connection>((resolve, reject) => {
+  const bootstrapConn = await new Promise<Connection>((resolve, reject) => {
     admin[kGetBootstrapConnection]((error, conn) => (error ? reject(error) : resolve(conn!)))
   })
 
-  const rawResponse = await describeGroupsV5.api.async(connection, [groupId], false)
+  // Route to the group coordinator so DescribeGroups returns members
+  const coordResponse = await findCoordinatorV6.api.async(bootstrapConn, FindCoordinatorKeyTypes.GROUP, [groupId])
+  const { host, port } = coordResponse.coordinators[0]
+  const coordinatorConn = await new Promise<Connection>((resolve, reject) => {
+    admin[kGetConnection]({ host, port }, (error, conn) => (error ? reject(error) : resolve(conn!)))
+  })
+
+  const rawResponse = await describeGroupsV5.api.async(coordinatorConn, [groupId], false)
   const rawMember = rawResponse.groups[0].members[0]
 
   // Parse the raw memberAssignment bytes following Java ConsumerProtocolAssignment format:

--- a/test/clients/admin/admin.test.ts
+++ b/test/clients/admin/admin.test.ts
@@ -22,7 +22,8 @@ import {
   type GroupBase,
   type ListConsumerGroupOffsetsGroup
 } from '../../../src/clients/admin/index.ts'
-import { kConnections } from '../../../src/clients/base/base.ts'
+import { kConnections, kGetBootstrapConnection } from '../../../src/clients/base/base.ts'
+import { Reader } from '../../../src/protocol/reader.ts'
 import {
   AclOperations,
   AclPermissionTypes,
@@ -1738,6 +1739,45 @@ test('describeGroups should handle memberAssignment with single user data byte w
 
   strictEqual(group.state, 'STABLE')
   strictEqual(group.members.size, 1)
+})
+
+test('describeGroups memberAssignment should include user data field when no assignmentUserData configured', async t => {
+  const groupId = `test-group-${randomUUID()}`
+  const testTopic = `test-topic-${randomUUID()}`
+  const admin = createAdmin(t)
+
+  await admin.createTopics({ topics: [testTopic], partitions: 1, replicas: 1 })
+
+  const consumer = new Consumer({
+    clientId: `test-client-${randomUUID()}`,
+    groupId,
+    bootstrapBrokers: kafkaBootstrapServers
+  })
+  t.after(() => consumer.close())
+
+  await consumer.topics.trackAll(testTopic)
+  await consumer.joinGroup()
+
+  const connection = await new Promise<Connection>((resolve, reject) => {
+    admin[kGetBootstrapConnection]((error, conn) => (error ? reject(error) : resolve(conn!)))
+  })
+
+  const rawResponse = await describeGroupsV5.api.async(connection, [groupId], false)
+  const rawMember = rawResponse.groups[0].members[0]
+
+  // Parse the raw memberAssignment bytes following Java ConsumerProtocolAssignment format:
+  // int16 version | int32-prefixed topics array | int32 user data length
+  const reader = Reader.from(rawMember.memberAssignment)
+  reader.readInt16() // version
+  reader.readArray(r => {
+    r.readString(false) // topic name
+    r.readArray(r => r.readInt32(), false, false) // partitions
+  }, false, false)
+
+  // Without the fix, readInt32() here throws BufferUnderflowException in Java
+  // because the user data length field is missing entirely
+  const userDataLength = reader.readInt32()
+  strictEqual(userDataLength, -1) // null bytes = int32(-1)
 })
 
 test('describeGroups should validate options in strict mode', async t => {

--- a/test/clients/admin/admin.test.ts
+++ b/test/clients/admin/admin.test.ts
@@ -1758,6 +1758,10 @@ test('describeGroups memberAssignment should include user data field when no ass
   await consumer.topics.trackAll(testTopic)
   await consumer.joinGroup()
 
+  const groups = await admin.describeGroups({ groups: [groupId] })
+  strictEqual(groups.get(groupId)!.state, 'STABLE')
+  strictEqual(groups.get(groupId)!.members.size, 1)
+
   const bootstrapConn = await new Promise<Connection>((resolve, reject) => {
     admin[kGetBootstrapConnection]((error, conn) => (error ? reject(error) : resolve(conn!)))
   })
@@ -1766,7 +1770,7 @@ test('describeGroups memberAssignment should include user data field when no ass
   const coordResponse = await findCoordinatorV6.api.async(bootstrapConn, FindCoordinatorKeyTypes.GROUP, [groupId])
   const { host, port } = coordResponse.coordinators[0]
   const coordinatorConn = await new Promise<Connection>((resolve, reject) => {
-    admin[kGetConnection]({ host, port }, (error, conn) => (error ? reject(error) : resolve(conn!)))
+    admin[kConnections].get({ host, port }, (error, conn) => (error ? reject(error) : resolve(conn!)))
   })
 
   const rawResponse = await describeGroupsV5.api.async(coordinatorConn, [groupId], false)


### PR DESCRIPTION
Problem
PR #281 removed .appendInt32(0) from #encodeProtocolAssignment, so when no assignmentUserData is set (the default), the trailing user data field is omitted entirely. The Kafka protocol requires this field to always be present. External Java clients (Kafka UI, KafkaAdminClient) fail with:


BufferUnderflowException at ConsumerProtocolAssignment.read(ConsumerProtocolAssignment.java:118)
Fix

// before
if (userData) { writer.append(userData) }

// after
writer.appendBytes(userData ?? null, false) // always writes int32(-1) or int32(length)+bytes