### PR TITLE
Several Fixes and Improvements to the Admin Client

### DIFF
--- a/src/apis/callbacks.ts
+++ b/src/apis/callbacks.ts
@@ -47,6 +47,7 @@ export function runConcurrentCallbacks<R, V> (
     if (e) {
       hasErrors = true
       errors.push([index, e])
+      results.push([index, undefined as unknown as R])
     } else {
       results.push([index, result!])
     }
@@ -65,11 +66,12 @@ export function runConcurrentCallbacks<R, V> (
     operation(item, operationCallback.bind(null, i++))
   }
 
-  allScheduled = true
-
-  if (allScheduled && i === 0) {
+  if (i === 0) {
     callback(null, [])
+    return
   }
+
+  allScheduled = true
 
   // If all operations were synchronous, allScheduled is not set to true in time for the operation
   // callback to pick it up. In that case, call the callback here.

--- a/src/apis/callbacks.ts
+++ b/src/apis/callbacks.ts
@@ -34,46 +34,48 @@ export function runConcurrentCallbacks<R, V> (
   operation: (item: V, cb: Callback<R>) => void,
   callback: Callback<R[]>
 ): void {
-  let scheduled = 0
   let allScheduled = false
   let completed = 0
   let callbackCalled = false
   let hasErrors = false
-  const errors: Error[] = []
-  const results: R[] = []
+  const errors: [number, Error][] = []
+  const results: [number, R][] = []
 
-  function operationCallback (e: Error | null, result?: R): void {
+  let i = 0
+
+  function operationCallback (index: number, e: Error | null, result?: R): void {
     if (e) {
       hasErrors = true
-      errors.push(e)
-      results.push(undefined as unknown as R)
+      errors.push([index, e])
     } else {
-      errors.push(undefined as unknown as Error)
-      results.push(result!)
+      results.push([index, result!])
     }
 
     completed++
 
-    if (allScheduled && completed === scheduled) {
+    if (allScheduled && completed === i) {
       callbackCalled = true
-      callback(hasErrors ? new MultipleErrors(errorMessage, errors.filter(Boolean)) : null, results.filter(Boolean) as R[])
+      const e = errors.sort((a, b) => a[0] - b[0]).map(([_, error]) => error)
+      const r = results.sort((a, b) => a[0] - b[0]).map(([_, result]) => result)
+      callback(hasErrors ? new MultipleErrors(errorMessage, e) : null, r)
     }
   }
 
   for (const item of collection) {
-    scheduled++
-    operation(item, operationCallback)
+    operation(item, operationCallback.bind(null, i++))
   }
 
   allScheduled = true
 
-  if (allScheduled && scheduled === 0) {
+  if (allScheduled && i === 0) {
     callback(null, [])
   }
 
   // If all operations were synchronous, allScheduled is not set to true in time for the operation
   // callback to pick it up. In that case, call the callback here.
-  if (completed === scheduled && !callbackCalled) {
-    callback(hasErrors ? new MultipleErrors(errorMessage, errors.filter(Boolean)) : null, results.filter(Boolean) as R[])
+  if (completed === i && !callbackCalled) {
+    const e = errors.sort((a, b) => a[0] - b[0]).map(([_, error]) => error)
+    const r = results.sort((a, b) => a[0] - b[0]).map(([_, result]) => result)
+    callback(hasErrors ? new MultipleErrors(errorMessage, e) : null, r)
   }
 }

--- a/src/apis/callbacks.ts
+++ b/src/apis/callbacks.ts
@@ -28,57 +28,52 @@ export function createPromisifiedCallback<ReturnType> (): CallbackWithPromise<Re
   return callback
 }
 
-export function runConcurrentCallbacks<ReturnType, K, V> (
+export function runConcurrentCallbacks<R, V> (
   errorMessage: string,
-  collection: Map<K, V>,
-  operation: (item: [K, V], cb: Callback<ReturnType>) => void,
-  callback: Callback<ReturnType[]>
-): void
-export function runConcurrentCallbacks<ReturnType, V> (
-  errorMessage: string,
-  collection: Set<V>,
-  operation: (item: V, cb: Callback<ReturnType>) => void,
-  callback: Callback<ReturnType[]>
-): void
-export function runConcurrentCallbacks<ReturnType, V> (
-  errorMessage: string,
-  collection: V[],
-  operation: (item: V, cb: Callback<ReturnType>) => void,
-  callback: Callback<ReturnType[]>
-): void
-export function runConcurrentCallbacks<ReturnType> (
-  errorMessage: string,
-  collection: Map<any, any> | Set<any> | any[],
-  operation: (item: any, cb: Callback<ReturnType>) => void,
-  callback: Callback<ReturnType[]>
+  collection: Iterable<V>,
+  operation: (item: V, cb: Callback<R>) => void,
+  callback: Callback<R[]>
 ): void {
-  let remaining = Array.isArray(collection) ? collection.length : collection.size
+  let scheduled = 0
+  let allScheduled = false
+  let completed = 0
+  let callbackCalled = false
   let hasErrors = false
-  const errors: Error[] = Array.from(Array(remaining))
-  const results: ReturnType[] = Array.from(Array(remaining))
+  const errors: Error[] = []
+  const results: R[] = []
 
-  let i = 0
-
-  function operationCallback (index: number, e: Error | null, result?: ReturnType): void {
+  function operationCallback (e: Error | null, result?: R): void {
     if (e) {
       hasErrors = true
-      errors[index] = e
+      errors.push(e)
+      results.push(undefined as unknown as R)
     } else {
-      results[index] = result!
+      errors.push(undefined as unknown as Error)
+      results.push(result!)
     }
 
-    remaining--
+    completed++
 
-    if (remaining === 0) {
-      callback(hasErrors ? new MultipleErrors(errorMessage, errors.filter(Boolean) as Error[]) : null, results)
+    if (allScheduled && completed === scheduled) {
+      callbackCalled = true
+      callback(hasErrors ? new MultipleErrors(errorMessage, errors.filter(Boolean)) : null, results.filter(Boolean) as R[])
     }
-  }
-
-  if (remaining === 0) {
-    callback(null, results)
   }
 
   for (const item of collection) {
-    operation(item, operationCallback.bind(null, i++))
+    scheduled++
+    operation(item, operationCallback)
+  }
+
+  allScheduled = true
+
+  if (allScheduled && scheduled === 0) {
+    callback(null, [])
+  }
+
+  // If all operations were synchronous, allScheduled is not set to true in time for the operation
+  // callback to pick it up. In that case, call the callback here.
+  if (completed === scheduled && !callbackCalled) {
+    callback(hasErrors ? new MultipleErrors(errorMessage, errors.filter(Boolean)) : null, results.filter(Boolean) as R[])
   }
 }

--- a/src/clients/admin/admin.ts
+++ b/src/clients/admin/admin.ts
@@ -952,7 +952,7 @@ export class Admin extends Base<AdminOptions> {
 
   #handleNotControllerError<T> (error: Error | null, value: T, callback: Callback<T>): void {
     if (error && (error as MultipleErrors)?.findBy?.('apiCode', 41)) {
-      this.metadata({ topics: [] }, (metadataError, metadata) => {
+      this[kMetadata]({ topics: [], forceUpdate: true }, (metadataError, metadata) => {
         /* c8 ignore next 4 - Hard to test */
         if (metadataError) {
           callback(metadataError)
@@ -994,7 +994,7 @@ export class Admin extends Base<AdminOptions> {
           },
           (error, metadata) => {
             if (error) {
-              deduplicateCallback(error)
+              deduplicateCallback(new MultipleErrors('Listing topics failed.', [error]))
               return
             }
 
@@ -1066,7 +1066,7 @@ export class Admin extends Base<AdminOptions> {
           },
           (error, response) => {
             if (error) {
-              deduplicateCallback(error)
+              deduplicateCallback(new MultipleErrors('Creating topics failed.', [error]))
               return
             }
 
@@ -1123,7 +1123,14 @@ export class Admin extends Base<AdminOptions> {
               })
             })
           },
-          deduplicateCallback,
+          (error, response) => {
+            if (error) {
+              callback(new MultipleErrors('Deleting topics failed.', [error]))
+              return
+            }
+
+            deduplicateCallback(null, response)
+          },
           0
         )
       },
@@ -1174,8 +1181,7 @@ export class Admin extends Base<AdminOptions> {
   }
 
   #listGroups (options: ListGroupsOptions, callback: CallbackWithPromise<Map<string, GroupBase>>): void {
-    // Find all the brokers in the cluster
-    this[kMetadata]({ topics: [] }, (error, metadata) => {
+    this[kMetadata]({ topics: [], forceUpdate: true }, (error, metadata) => {
       if (error) {
         callback(error)
         return
@@ -1183,6 +1189,7 @@ export class Admin extends Base<AdminOptions> {
 
       runConcurrentCallbacks(
         'Listing groups failed.',
+        // metadata must be defined as error was undefined
         metadata!.brokers,
         ([, broker], concurrentCallback) => {
           this[kGetConnection](broker, (error, connection) => {
@@ -1237,181 +1244,193 @@ export class Admin extends Base<AdminOptions> {
   }
 
   #describeGroups (options: DescribeGroupsOptions, callback: CallbackWithPromise<Map<string, Group>>): void {
-    this[kMetadata]({ topics: [] }, (error, metadata) => {
-      if (error) {
-        callback(error)
-        return
-      }
-
-      this.#findCoordinator({ keyType: FindCoordinatorKeyTypes.GROUP, keys: options.groups }, (error, coordinators) => {
-        if (error) {
-          callback(error)
-          return
-        }
-
-        // Group the groups by coordinator
-        const coordinatorsMap: Map<number, string[]> = new Map()
-        for (const { key: group, nodeId: node } of coordinators!) {
-          let coordinator = coordinatorsMap.get(node)
-          if (!coordinator) {
-            coordinator = []
-            coordinatorsMap.set(node, coordinator)
+    this[kPerformWithRetry](
+      'describeGroups',
+      retryCallback => {
+        this.#findCoordinator({ keyType: FindCoordinatorKeyTypes.GROUP, keys: options.groups }, (
+          error,
+          coordinators
+        ) => {
+          if (error) {
+            // FindCoordinator already retried some times so no retry again
+            callback(
+              new MultipleErrors('Describing groups failed.', error instanceof MultipleErrors ? error.errors : [error])
+            )
+            return
           }
 
-          coordinator.push(group)
-        }
+          const coordinatorsMap: Map<number, { host: string; port: number; groups: string[] }> = new Map()
+          // coordinators must be defined as error was undefined
+          for (const coordinator of coordinators!) {
+            let coordinatorAggregate = coordinatorsMap.get(coordinator.nodeId)
+            if (!coordinatorAggregate) {
+              coordinatorAggregate = { host: coordinator.host, port: coordinator.port, groups: [] }
+              coordinatorsMap.set(coordinator.nodeId, coordinatorAggregate)
+            }
 
-        runConcurrentCallbacks(
-          'Describing groups failed.',
-          coordinatorsMap,
-          ([node, groups], concurrentCallback) => {
-            this[kGetConnection](metadata!.brokers.get(node)!, (error, connection) => {
-              if (error) {
-                concurrentCallback(error)
-                return
-              }
+            coordinatorAggregate.groups.push(coordinator.key)
+          }
 
+          runConcurrentCallbacks(
+            'Describing groups failed.',
+            coordinatorsMap.values(),
+            (coordinator, concurrentCallback: Callback<DescribeGroupsResponse>) => {
               this[kPerformWithRetry]<DescribeGroupsResponse>(
-                'describeGroups',
+                'describeGroupsOnCoordinator',
                 retryCallback => {
-                  this[kGetApi]<DescribeGroupsRequest, DescribeGroupsResponse>('DescribeGroups', (error, api) => {
+                  this[kGetConnection](coordinator, (error, connection) => {
                     if (error) {
                       retryCallback(error)
                       return
                     }
 
-                    api!(connection!, groups, options.includeAuthorizedOperations ?? false, retryCallback)
+                    this[kGetApi]<DescribeGroupsRequest, DescribeGroupsResponse>('DescribeGroups', (error, api) => {
+                      if (error) {
+                        retryCallback(error)
+                        return
+                      }
+
+                      api!(connection!, coordinator.groups, options.includeAuthorizedOperations ?? false, retryCallback)
+                    })
                   })
                 },
                 concurrentCallback,
                 0
               )
-            })
-          },
-          (error, results) => {
-            if (error) {
-              callback(error)
-              return
-            }
+            },
+            (error, results) => {
+              if (error) {
+                retryCallback(error)
+                return
+              }
 
-            const groups: Map<string, Group> = new Map()
-            for (const result of results! as DescribeGroupsResponse[]) {
-              for (const raw of result.groups) {
-                const group: Group = {
-                  id: raw.groupId,
-                  state: raw.groupState.toUpperCase() as ConsumerGroupStateValue,
-                  protocolType: raw.protocolType,
-                  protocol: raw.protocolData,
-                  members: new Map(),
-                  authorizedOperations: raw.authorizedOperations
-                }
-
-                for (const member of raw.members) {
-                  const reader = Reader.from(member.memberMetadata)
-
-                  let memberMetadata: GroupMember['metadata'] | undefined
-                  let memberAssignments: Map<string, GroupAssignment> | undefined
-
-                  if (reader.remaining > 0) {
-                    memberMetadata = {
-                      version: reader.readInt16(),
-                      topics: reader.readArray(r => r.readString(false), false, false),
-                      metadata: reader.readBytes(false)
-                    }
-
-                    reader.reset(member.memberAssignment)
-                    reader.skip(2) // Ignore Version information
-
-                    memberAssignments = reader.readMap(
-                      r => {
-                        const topic = r.readString(false)
-
-                        return [topic, { topic, partitions: reader.readArray(r => r.readInt32(), false, false) }]
-                      },
-                      false,
-                      false
-                    )
-
-                    // Ignore the user data
+              const groups: Map<string, Group> = new Map()
+              for (const result of results! as DescribeGroupsResponse[]) {
+                for (const raw of result.groups) {
+                  const group: Group = {
+                    id: raw.groupId,
+                    state: raw.groupState.toUpperCase() as ConsumerGroupStateValue,
+                    protocolType: raw.protocolType,
+                    protocol: raw.protocolData,
+                    members: new Map(),
+                    authorizedOperations: raw.authorizedOperations
                   }
 
-                  group.members.set(member.memberId, {
-                    id: member.memberId,
-                    groupInstanceId: member.groupInstanceId,
-                    clientId: member.clientId,
-                    clientHost: member.clientHost,
-                    metadata: memberMetadata,
-                    assignments: memberAssignments
-                  })
+                  for (const member of raw.members) {
+                    const reader = Reader.from(member.memberMetadata)
+
+                    let memberMetadata: GroupMember['metadata'] | undefined
+                    let memberAssignments: Map<string, GroupAssignment> | undefined
+
+                    if (reader.remaining > 0) {
+                      memberMetadata = {
+                        version: reader.readInt16(),
+                        topics: reader.readArray(r => r.readString(false), false, false),
+                        metadata: reader.readBytes(false)
+                      }
+
+                      reader.reset(member.memberAssignment)
+                      reader.skip(2) // Ignore Version information
+
+                      memberAssignments = reader.readMap(
+                        r => {
+                          const topic = r.readString(false)
+
+                          return [topic, { topic, partitions: reader.readArray(r => r.readInt32(), false, false) }]
+                        },
+                        false,
+                        false
+                      )
+
+                      // Ignore the user data
+                    }
+
+                    group.members.set(member.memberId, {
+                      id: member.memberId,
+                      groupInstanceId: member.groupInstanceId,
+                      clientId: member.clientId,
+                      clientHost: member.clientHost,
+                      metadata: memberMetadata,
+                      assignments: memberAssignments
+                    })
+                  }
+
+                  groups.set(group.id, group)
                 }
-
-                groups.set(group.id, group)
               }
-            }
 
-            callback(null, groups)
-          }
-        )
-      })
-    })
+              retryCallback(null, groups)
+            }
+          )
+        })
+      },
+      callback,
+      0
+    )
   }
 
   #deleteGroups (options: DeleteGroupsOptions, callback: CallbackWithPromise<void>): void {
-    this[kMetadata]({ topics: [] }, (error, metadata) => {
-      if (error) {
-        callback(error)
-        return
-      }
-
-      this.#findCoordinator({ keyType: FindCoordinatorKeyTypes.GROUP, keys: options.groups }, (error, coordinators) => {
-        if (error) {
-          callback(error)
-          return
-        }
-
-        // Group the groups by coordinator
-        const coordinatorsMap: Map<number, string[]> = new Map()
-        for (const { key: group, nodeId: node } of coordinators!) {
-          let coordinator = coordinatorsMap.get(node)
-          if (!coordinator) {
-            coordinator = []
-            coordinatorsMap.set(node, coordinator)
+    this[kPerformWithRetry](
+      'deleteGroups',
+      retryCallback => {
+        this.#findCoordinator({ keyType: FindCoordinatorKeyTypes.GROUP, keys: options.groups }, (
+          error,
+          coordinators
+        ) => {
+          if (error) {
+            // FindCoordinator already retried some times so no retry again
+            callback(
+              new MultipleErrors('Deleting groups failed.', error instanceof MultipleErrors ? error.errors : [error])
+            )
+            return
           }
 
-          coordinator.push(group)
-        }
+          const coordinatorsMap: Map<number, { host: string; port: number; groups: string[] }> = new Map()
+          // coordinators must be defined as error was undefined
+          for (const coordinator of coordinators!) {
+            let coordinatorAggregate = coordinatorsMap.get(coordinator.nodeId)
+            if (!coordinatorAggregate) {
+              coordinatorAggregate = { host: coordinator.host, port: coordinator.port, groups: [] }
+              coordinatorsMap.set(coordinator.nodeId, coordinatorAggregate)
+            }
 
-        runConcurrentCallbacks(
-          'Deleting groups failed.',
-          coordinatorsMap,
-          ([node, groups], concurrentCallback) => {
-            this[kGetConnection](metadata!.brokers.get(node)!, (error, connection) => {
-              if (error) {
-                concurrentCallback(error)
-                return
-              }
+            coordinatorAggregate.groups.push(coordinator.key)
+          }
 
-              this[kPerformWithRetry]<DeleteGroupsResponse>(
-                'deleteGroups',
+          runConcurrentCallbacks(
+            'Deleting groups failed.',
+            coordinatorsMap.values(),
+            (coordinator, concurrentCallback: Callback<DeleteGroupsResponse>) => {
+              this[kPerformWithRetry](
+                'deleteGroupsOnCoordinator',
                 retryCallback => {
-                  this[kGetApi]<DeleteGroupsRequest, DeleteGroupsResponse>('DeleteGroups', (error, api) => {
+                  this[kGetConnection](coordinator, (error, connection) => {
                     if (error) {
                       retryCallback(error)
                       return
                     }
 
-                    api!(connection!, groups, retryCallback)
+                    this[kGetApi]<DeleteGroupsRequest, DeleteGroupsResponse>('DeleteGroups', (error, api) => {
+                      if (error) {
+                        retryCallback(error)
+                        return
+                      }
+
+                      api!(connection!, coordinator.groups, retryCallback)
+                    })
                   })
                 },
                 concurrentCallback,
                 0
               )
-            })
-          },
-          error => callback(error)
-        )
-      })
-    })
+            },
+            retryCallback as Callback<unknown> as Callback<DeleteGroupsResponse[]>
+          )
+        })
+      },
+      callback,
+      0
+    )
   }
 
   #removeMembersFromConsumerGroup (
@@ -1419,12 +1438,14 @@ export class Admin extends Base<AdminOptions> {
     callback: CallbackWithPromise<void>
   ): void {
     if (!options.members || options.members.length === 0) {
+      // Remove all members if none are specified
       this.#describeGroups({ groups: [options.groupId] }, (error, groupsMap) => {
         if (error) {
           callback(new MultipleErrors('Removing members from consumer group failed.', [error]))
           return
         }
 
+        // groupsMap must be defined as error was undefined
         const group = groupsMap!.get(options.groupId)
         /* c8 ignore next 4 - Hard to test */
         if (!group) {
@@ -1447,81 +1468,70 @@ export class Admin extends Base<AdminOptions> {
       return
     }
 
-    this[kMetadata]({ topics: [] }, (error, metadata) => {
-      if (error) {
-        callback(error, undefined)
-        return
-      }
+    this[kPerformWithRetry]<void>(
+      'removeMembersFromConsumerGroup',
+      retryCallback => {
+        this.#findCoordinator({ keyType: FindCoordinatorKeyTypes.GROUP, keys: [options.groupId] }, (
+          error,
+          coordinators
+        ) => {
+          if (error) {
+            // FindCoordinator already retried some times so no retry again
+            callback(
+              new MultipleErrors(
+                'Removing members from consumer group failed.',
+                error instanceof MultipleErrors ? error.errors : [error]
+              )
+            )
+            return
+          }
 
-      this.#findCoordinator({ keyType: FindCoordinatorKeyTypes.GROUP, keys: [options.groupId] }, (
-        error,
-        coordinators
-      ) => {
+          const coordinator = coordinators!.find(c => c.key === options.groupId)
+          /* c8 ignore next 8 - Hard to test */
+          if (!coordinator) {
+            retryCallback(new Error('Group coordinator not found'))
+            return
+          }
+
+          this[kGetConnection](coordinator, (error, connection) => {
+            if (error) {
+              retryCallback(error)
+              return
+            }
+
+            this[kGetApi]<LeaveGroupRequest, LeaveGroupResponse>('LeaveGroup', (error, api) => {
+              if (error) {
+                retryCallback(error)
+                return
+              }
+
+              /* c8 ignore next 5 - Hard to test */
+              const members: LeaveGroupRequestMember[] = options.members!.map(member => ({
+                memberId: typeof member === 'string' ? member : member.memberId,
+                groupInstanceId: null,
+                reason: typeof member === 'string' ? 'Not specified' : member.reason
+              }))
+
+              api!(
+                connection!,
+                options.groupId,
+                members,
+                retryCallback as Callback<unknown> as Callback<LeaveGroupResponse>
+              )
+            })
+          })
+        })
+      },
+      error => {
         if (error) {
           callback(new MultipleErrors('Removing members from consumer group failed.', [error]))
           return
         }
 
-        const coordinator = coordinators!.find(c => c.key === options.groupId)
-        /* c8 ignore next 8 - Hard to test */
-        if (!coordinator) {
-          callback(
-            new MultipleErrors('Removing members from consumer group failed.', [
-              new Error(`No coordinator found for group ${options.groupId}`)
-            ])
-          )
-          return
-        }
-
-        const broker = metadata!.brokers.get(coordinator.nodeId)
-        /* c8 ignore next 8 - Hard to test */
-        if (!broker) {
-          callback(
-            new MultipleErrors('Removing members from consumer group failed.', [
-              new Error(`Broker ${coordinator.nodeId} not found`)
-            ])
-          )
-          return
-        }
-
-        this[kGetConnection](broker, (error, connection) => {
-          if (error) {
-            callback(new MultipleErrors('Removing members from consumer group failed.', [error]))
-            return
-          }
-
-          this[kPerformWithRetry]<LeaveGroupResponse>(
-            'removeMembersFromConsumerGroup',
-            retryCallback => {
-              this[kGetApi]<LeaveGroupRequest, LeaveGroupResponse>('LeaveGroup', (error, api) => {
-                if (error) {
-                  retryCallback(error)
-                  return
-                }
-
-                /* c8 ignore next 5 - Hard to test */
-                const members: LeaveGroupRequestMember[] = options.members!.map(member => ({
-                  memberId: typeof member === 'string' ? member : member.memberId,
-                  groupInstanceId: null,
-                  reason: typeof member === 'string' ? 'Not specified' : member.reason
-                }))
-
-                api!(connection!, options.groupId, members, retryCallback)
-              })
-            },
-            error => {
-              if (error) {
-                callback(new MultipleErrors('Removing members from consumer group failed.', [error]))
-                return
-              }
-
-              callback(null)
-            },
-            0
-          )
-        })
-      })
-    })
+        callback(null)
+      },
+      0
+    )
   }
 
   #findCoordinator (options: FindCoordinatorOptions, callback: CallbackWithPromise<FindCoordinatorResult[]>): void {
@@ -1546,7 +1556,7 @@ export class Admin extends Base<AdminOptions> {
       },
       (error, response) => {
         if (error) {
-          callback(error)
+          callback(new MultipleErrors('Finding coordinator failed.', [error]))
           return
         }
 
@@ -1638,7 +1648,7 @@ export class Admin extends Base<AdminOptions> {
   }
 
   #describeLogDirs (options: DescribeLogDirsOptions, callback: CallbackWithPromise<BrokerLogDirDescription[]>): void {
-    this[kMetadata]({ topics: [] }, (error, metadata) => {
+    this[kMetadata]({ topics: [], forceUpdate: true }, (error, metadata) => {
       /* c8 ignore next 4 - Hard to test */
       if (error) {
         callback(error)
@@ -1647,17 +1657,18 @@ export class Admin extends Base<AdminOptions> {
 
       runConcurrentCallbacks(
         'Describing log dirs failed.',
+        // metadata must be defined as error was undefined
         metadata!.brokers,
         ([id, broker], concurrentCallback) => {
-          this[kGetConnection](broker, (error, connection) => {
-            if (error) {
-              concurrentCallback(error)
-              return
-            }
+          this[kPerformWithRetry]<DescribeLogDirsResponse>(
+            'describeLogDirs',
+            retryCallback => {
+              this[kGetConnection](broker, (error, connection) => {
+                if (error) {
+                  retryCallback(error)
+                  return
+                }
 
-            this[kPerformWithRetry]<DescribeLogDirsResponse>(
-              'describeLogDirs',
-              retryCallback => {
                 this[kGetApi]<DescribeLogDirsRequest, DescribeLogDirsResponse>('DescribeLogDirs', (error, api) => {
                   if (error) {
                     retryCallback(error)
@@ -1666,27 +1677,27 @@ export class Admin extends Base<AdminOptions> {
 
                   api!(connection!, options.topics, retryCallback)
                 })
-              },
-              (error, response) => {
-                if (error) {
-                  concurrentCallback(error)
-                  return
-                }
+              })
+            },
+            (error, response) => {
+              if (error) {
+                concurrentCallback(error)
+                return
+              }
 
-                concurrentCallback(null, {
-                  broker: id,
-                  throttleTimeMs: response!.throttleTimeMs,
-                  results: response!.results.map(result => ({
-                    logDir: result.logDir,
-                    topics: result.topics,
-                    totalBytes: result.totalBytes,
-                    usableBytes: result.usableBytes
-                  }))
-                })
-              },
-              0
-            )
-          })
+              concurrentCallback(null, {
+                broker: id,
+                throttleTimeMs: response!.throttleTimeMs,
+                results: response!.results.map(result => ({
+                  logDir: result.logDir,
+                  topics: result.topics,
+                  totalBytes: result.totalBytes,
+                  usableBytes: result.usableBytes
+                }))
+              })
+            },
+            0
+          )
         },
         callback
       )
@@ -1697,269 +1708,265 @@ export class Admin extends Base<AdminOptions> {
     options: ListConsumerGroupOffsetsOptions,
     callback: CallbackWithPromise<ListConsumerGroupOffsetsGroup[]>
   ): void {
-    this[kMetadata]({ topics: [] }, (error, metadata) => {
-      if (error) {
-        callback(error)
-        return
-      }
+    this[kPerformWithRetry](
+      'listConsumerGroupOffsets',
+      retryCallback => {
+        /* c8 ignore next - Hard to test */
+        const groupIds = options.groups.map(group => (typeof group === 'string' ? group : group.groupId))
 
-      /* c8 ignore next - Hard to test */
-      const groupIds = options.groups.map(group => (typeof group === 'string' ? group : group.groupId))
-
-      this.#findCoordinator({ keyType: FindCoordinatorKeyTypes.GROUP, keys: groupIds }, (error, coordinators) => {
-        if (error) {
-          callback(new MultipleErrors('Listing consumer group offsets failed.', [error]))
-          return
-        }
-
-        const coordinatorsMap: Map<number, OffsetFetchRequestGroup[]> = new Map()
-        for (const { key: groupId, nodeId: node } of coordinators!) {
-          const groupRequest: OffsetFetchRequestGroup = {
-            groupId,
-            memberId: null,
-            memberEpoch: -1
+        this.#findCoordinator({ keyType: FindCoordinatorKeyTypes.GROUP, keys: groupIds }, (error, coordinators) => {
+          if (error) {
+            // FindCoordinator already retried some times so no retry again
+            callback(
+              new MultipleErrors(
+                'Listing consumer group offsets failed.',
+                error instanceof MultipleErrors ? error.errors : [error]
+              )
+            )
+            return
           }
 
-          for (const group of options.groups) {
-            if (typeof group !== 'string' && group.groupId === groupId && !!group.topics && group.topics.length > 0) {
-              groupRequest.topics = group.topics
-              break
+          const coordinatorsMap: Map<number, { coordinator: Broker; groupRequests: OffsetFetchRequestGroup[] }> =
+            new Map()
+          for (const coordinator of coordinators!) {
+            const groupRequest: OffsetFetchRequestGroup = {
+              groupId: coordinator.key,
+              memberId: null,
+              memberEpoch: -1
             }
-          }
 
-          let coordinator = coordinatorsMap.get(node)
-          if (!coordinator) {
-            coordinator = []
-            coordinatorsMap.set(node, coordinator)
-          }
-
-          coordinator.push(groupRequest)
-        }
-
-        runConcurrentCallbacks(
-          'Listing consumer group offsets failed.',
-          coordinatorsMap,
-          ([node, groups], concurrentCallback) => {
-            this[kGetConnection](metadata!.brokers.get(node)!, (error, connection) => {
-              if (error) {
-                concurrentCallback(error)
-                return
+            for (const group of options.groups) {
+              if (
+                typeof group !== 'string' &&
+                group.groupId === coordinator.key &&
+                !!group.topics &&
+                group.topics.length > 0
+              ) {
+                groupRequest.topics = group.topics
+                break
               }
+            }
 
+            let offsetFetchRequestGroups = coordinatorsMap.get(coordinator.nodeId)
+            if (!offsetFetchRequestGroups) {
+              offsetFetchRequestGroups = { coordinator, groupRequests: [] }
+              coordinatorsMap.set(coordinator.nodeId, offsetFetchRequestGroups)
+            }
+
+            offsetFetchRequestGroups.groupRequests.push(groupRequest)
+          }
+
+          runConcurrentCallbacks(
+            'Listing consumer group offsets failed.',
+            coordinatorsMap.values(),
+            ({ coordinator, groupRequests }, concurrentCallback: Callback<OffsetFetchResponse>) => {
               this[kPerformWithRetry]<OffsetFetchResponse>(
                 'offsetFetch',
                 retryCallback => {
-                  this[kGetApi]<OffsetFetchRequest, OffsetFetchResponse>('OffsetFetch', (error, api) => {
+                  this[kGetConnection](coordinator, (error, connection) => {
                     if (error) {
                       retryCallback(error)
                       return
                     }
 
-                    /* c8 ignore next - Hard to test */
-                    api!(connection!, groups, options.requireStable ?? false, retryCallback)
+                    this[kGetApi]<OffsetFetchRequest, OffsetFetchResponse>('OffsetFetch', (error, api) => {
+                      if (error) {
+                        retryCallback(error)
+                        return
+                      }
+
+                      /* c8 ignore next - Hard to test */
+                      api!(connection!, groupRequests, options.requireStable ?? false, retryCallback)
+                    })
                   })
                 },
                 concurrentCallback,
                 0
               )
-            })
-          },
-          (error, responses) => {
-            if (error) {
-              callback(error)
-              return
-            }
+            },
+            (error, responses) => {
+              if (error) {
+                retryCallback(error)
+                return
+              }
 
-            callback(
-              null,
-              (responses as OffsetFetchResponse[]).flatMap(r =>
-                r.groups.map(group => ({
-                  groupId: group.groupId,
-                  topics: group.topics.map(topic => ({
-                    name: topic.name,
-                    partitions: topic.partitions.map(p => ({
-                      partitionIndex: p.partitionIndex,
-                      committedOffset: p.committedOffset,
-                      committedLeaderEpoch: p.committedLeaderEpoch,
-                      metadata: p.metadata
+              retryCallback(
+                null,
+                // responses must be defined as error was undefined
+                responses!.flatMap(r =>
+                  r.groups.map(group => ({
+                    groupId: group.groupId,
+                    topics: group.topics.map(topic => ({
+                      name: topic.name,
+                      partitions: topic.partitions.map(p => ({
+                        partitionIndex: p.partitionIndex,
+                        committedOffset: p.committedOffset,
+                        committedLeaderEpoch: p.committedLeaderEpoch,
+                        metadata: p.metadata
+                      }))
                     }))
-                  }))
-                })))
-            )
-          }
-        )
-      })
-    })
+                  })))
+              )
+            }
+          )
+        })
+      },
+      callback,
+      0
+    )
   }
 
   #alterConsumerGroupOffsets (options: AlterConsumerGroupOffsetsOptions, callback: CallbackWithPromise<void>): void {
-    this[kMetadata]({ topics: [] }, (error, metadata) => {
-      if (error) {
-        callback(error, undefined)
-        return
-      }
+    this[kPerformWithRetry](
+      'alterConsumerGroupOffsets',
+      retryCallback => {
+        this.#findCoordinator({ keyType: FindCoordinatorKeyTypes.GROUP, keys: [options.groupId] }, (
+          error,
+          coordinators
+        ) => {
+          if (error) {
+            // FindCoordinator already retried some times so no retry again
+            callback(
+              new MultipleErrors(
+                'Altering consumer group offsets failed.',
+                error instanceof MultipleErrors ? error.errors : [error]
+              )
+            )
+            return
+          }
 
-      this.#findCoordinator({ keyType: FindCoordinatorKeyTypes.GROUP, keys: [options.groupId] }, (
-        error,
-        coordinators
-      ) => {
+          const coordinator = coordinators!.find(c => c.key === options.groupId)
+          /* c8 ignore next 9 - Hard to test */
+          if (!coordinator) {
+            retryCallback(new Error('Group coordinator not found'))
+            return
+          }
+
+          this[kGetConnection](coordinator, (error, connection) => {
+            if (error) {
+              retryCallback(error)
+              return
+            }
+
+            this[kGetApi]<OffsetCommitRequest, OffsetCommitResponse>('OffsetCommit', (error, api) => {
+              if (error) {
+                retryCallback(error)
+                return
+              }
+
+              const topics: OffsetCommitRequestTopic[] = []
+              for (const topic of options.topics) {
+                const partitions = topic.partitionOffsets.map(p => ({
+                  partitionIndex: p.partition,
+                  committedOffset: p.offset,
+                  committedLeaderEpoch: -1,
+                  committedMetadata: null
+                }))
+                topics.push({ name: topic.name, partitions })
+              }
+
+              api!(
+                connection!,
+                options.groupId,
+                -1,
+                '',
+                null,
+                topics,
+                retryCallback as Callback<unknown> as Callback<OffsetCommitResponse>
+              )
+            })
+          })
+        })
+      },
+      error => {
         if (error) {
           callback(new MultipleErrors('Altering consumer group offsets failed.', [error]))
           return
         }
 
-        const coordinator = coordinators!.find(c => c.key === options.groupId)
-        /* c8 ignore next 9 - Hard to test */
-        if (!coordinator) {
-          callback(
-            new MultipleErrors('Altering consumer group offsets failed.', [
-              new Error(`No coordinator found for group ${options.groupId}`)
-            ])
-          )
-          return
-        }
-
-        const broker = metadata!.brokers.get(coordinator.nodeId)
-        /* c8 ignore next 9 - Hard to test */
-        if (!broker) {
-          callback(
-            new MultipleErrors('Altering consumer group offsets failed.', [
-              new Error(`Broker ${coordinator.nodeId} not found`)
-            ])
-          )
-          return
-        }
-
-        this[kGetConnection](broker, (error, connection) => {
-          if (error) {
-            callback(new MultipleErrors('Altering consumer group offsets failed.', [error]))
-            return
-          }
-
-          this[kPerformWithRetry]<OffsetCommitResponse>(
-            'alterConsumerGroupOffsets',
-            retryCallback => {
-              this[kGetApi]<OffsetCommitRequest, OffsetCommitResponse>('OffsetCommit', (error, api) => {
-                if (error) {
-                  retryCallback(error)
-                  return
-                }
-
-                const topics: OffsetCommitRequestTopic[] = []
-                for (const topic of options.topics) {
-                  const partitions = topic.partitionOffsets.map(p => ({
-                    partitionIndex: p.partition,
-                    committedOffset: p.offset,
-                    committedLeaderEpoch: -1,
-                    committedMetadata: null
-                  }))
-                  topics.push({ name: topic.name, partitions })
-                }
-
-                api!(connection!, options.groupId, -1, '', null, topics, retryCallback)
-              })
-            },
-            error => {
-              if (error) {
-                callback(new MultipleErrors('Altering consumer group offsets failed.', [error]))
-                return
-              }
-
-              callback(null)
-            },
-            0
-          )
-        })
-      })
-    })
+        callback(null)
+      },
+      0
+    )
   }
 
   #deleteConsumerGroupOffsets (
     options: DeleteConsumerGroupOffsetsOptions,
     callback: CallbackWithPromise<{ name: string; partitionIndexes: number[] }[]>
   ): void {
-    this[kMetadata]({ topics: [] }, (error, metadata) => {
-      if (error) {
-        callback(error)
-        return
-      }
+    this[kPerformWithRetry]<{ name: string; partitionIndexes: number[] }[]>(
+      'deleteConsumerGroupOffsets',
+      retryCallback => {
+        this.#findCoordinator({ keyType: FindCoordinatorKeyTypes.GROUP, keys: [options.groupId] }, (
+          error,
+          coordinators
+        ) => {
+          if (error) {
+            // FindCoordinator already retried some times so no retry again
+            callback(
+              new MultipleErrors(
+                'Deleting consumer group offsets failed.',
+                error instanceof MultipleErrors ? error.errors : [error]
+              )
+            )
+            return
+          }
 
-      this.#findCoordinator({ keyType: FindCoordinatorKeyTypes.GROUP, keys: [options.groupId] }, (
-        error,
-        coordinators
-      ) => {
+          const coordinator = coordinators!.find(c => c.key === options.groupId)
+          /* c8 ignore next 9 - Hard to test */
+          if (!coordinator) {
+            retryCallback(new Error('Group coordinator not found'))
+            return
+          }
+
+          this[kGetConnection](coordinator, (error, connection) => {
+            if (error) {
+              retryCallback(error)
+              return
+            }
+
+            this[kGetApi]<OffsetDeleteRequest, OffsetDeleteResponse>('OffsetDelete', (error, api) => {
+              if (error) {
+                retryCallback(error)
+                return
+              }
+
+              api!(
+                connection!,
+                options.groupId,
+                options.topics.map(t => ({
+                  name: t.name,
+                  partitions: t.partitionIndexes.map(p => ({ partitionIndex: p }))
+                })),
+                (error, response) => {
+                  if (error) {
+                    retryCallback(error)
+                    return
+                  }
+
+                  retryCallback(
+                    null,
+                    (response as OffsetDeleteResponse).topics.map(topic => ({
+                      name: topic.name,
+                      partitionIndexes: topic.partitions.map(p => p.partitionIndex)
+                    }))
+                  )
+                }
+              )
+            })
+          })
+        })
+      },
+      (error, results) => {
         if (error) {
           callback(new MultipleErrors('Deleting consumer group offsets failed.', [error]))
           return
         }
 
-        const coordinator = coordinators!.find(c => c.key === options.groupId)
-        /* c8 ignore next 9 - Hard to test */
-        if (!coordinator) {
-          callback(
-            new MultipleErrors('Deleting consumer group offsets failed.', [
-              new Error(`No coordinator found for group ${options.groupId}`)
-            ])
-          )
-          return
-        }
-
-        const broker = metadata!.brokers.get(coordinator.nodeId)
-        /* c8 ignore next 9 - Hard to test */
-        if (!broker) {
-          callback(
-            new MultipleErrors('Deleting consumer group offsets failed.', [
-              new Error(`Broker ${coordinator.nodeId} not found`)
-            ])
-          )
-          return
-        }
-
-        this[kGetConnection](broker, (error, connection) => {
-          if (error) {
-            callback(new MultipleErrors('Deleting consumer group offsets failed.', [error]))
-            return
-          }
-
-          this[kPerformWithRetry]<OffsetDeleteResponse>(
-            'deleteOffset',
-            retryCallback => {
-              this[kGetApi]<OffsetDeleteRequest, OffsetDeleteResponse>('OffsetDelete', (error, api) => {
-                if (error) {
-                  retryCallback(error)
-                  return
-                }
-
-                api!(
-                  connection!,
-                  options.groupId,
-                  options.topics.map(t => ({
-                    name: t.name,
-                    partitions: t.partitionIndexes.map(p => ({ partitionIndex: p }))
-                  })),
-                  retryCallback
-                )
-              })
-            },
-            (error, response) => {
-              if (error) {
-                callback(new MultipleErrors('Deleting consumer group offsets failed.', [error]))
-                return
-              }
-
-              callback(
-                null,
-                (response as OffsetDeleteResponse).topics.map(topic => ({
-                  name: topic.name,
-                  partitionIndexes: topic.partitions.map(p => p.partitionIndex)
-                }))
-              )
-            },
-            0
-          )
-        })
-      })
-    })
+        callback(null, results!)
+      },
+      0
+    )
   }
 
   #getConfigRequestsDistributedToBrokers<T extends { resourceType: ConfigResourceTypeValue; resourceName: string }> (
@@ -1991,7 +1998,7 @@ export class Admin extends Base<AdminOptions> {
       return
     }
 
-    this[kMetadata]({ topics: [] }, (error, metadata) => {
+    this[kMetadata]({ topics: [], forceUpdate: true }, (error, metadata) => {
       /* c8 ignore next 4 - Hard to test */
       if (error) {
         callback(error)
@@ -2013,18 +2020,11 @@ export class Admin extends Base<AdminOptions> {
     runConcurrentCallbacks(
       'Describing configs failed.',
       this.#getConfigRequestsDistributedToBrokers(options.resources),
-      ([brokerId, resources], concurrentCallback) => {
-        this.#describeConfigsOnBroker({ ...options, resources }, brokerId, (error, response) => {
-          if (error) {
-            concurrentCallback(error)
-            return
-          }
-
-          concurrentCallback(null, response)
-        })
+      ([brokerId, resources], concurrentCallback: Callback<ConfigDescription[]>) => {
+        this.#describeConfigsOnBroker({ ...options, resources }, brokerId, concurrentCallback)
       },
       (error, results) => {
-        callback(error, (results as ConfigDescription[])?.flat())
+        callback(error, results?.flat())
       }
     )
   }
@@ -2302,205 +2302,229 @@ export class Admin extends Base<AdminOptions> {
   }
 
   #deleteRecords (options: DeleteRecordsOptions, callback: CallbackWithPromise<DeletedRecordsTopic[]>): void {
-    this[kMetadata]({ topics: options.topics.map(topic => topic.name) }, (error, metadata) => {
-      if (error) {
-        callback(error)
-        return
-      }
-
-      const requestsByLeader = new Map<number, Map<string, DeleteRecordsRequestTopics>>()
-
-      for (const topic of options.topics) {
-        for (const partition of topic.partitions) {
-          const { leader } = metadata!.topics.get(topic.name)!.partitions[partition.partition]
-          let leaderRequests = requestsByLeader.get(leader)
-          if (!leaderRequests) {
-            leaderRequests = new Map()
-            requestsByLeader.set(leader, leaderRequests)
-          }
-
-          let topicRequest = leaderRequests.get(topic.name)
-          if (!topicRequest) {
-            topicRequest = { name: topic.name, partitions: [] }
-            leaderRequests.set(topic.name, topicRequest)
-          }
-
-          topicRequest.partitions.push({
-            partitionIndex: partition.partition,
-            offset: partition.offset
-          })
-        }
-      }
-
-      const requests = new Map<number, DeleteRecordsRequestTopics[]>()
-      for (const [leader, topics] of requestsByLeader) {
-        requests.set(leader, Array.from(topics.values()))
-      }
-
-      runConcurrentCallbacks(
-        'Deleting records failed.',
-        requests,
-        ([leader, requests], concurrentCallback) => {
-          this[kGetConnection](metadata!.brokers.get(leader)!, (error, connection) => {
-            if (error) {
-              concurrentCallback(error)
-              return
-            }
-
-            this[kPerformWithRetry](
-              'deleteRecords',
-              retryCallback => {
-                this[kGetApi]<DeleteRecordsRequest, DeleteRecordsResponse>('DeleteRecords', (error, api) => {
-                  if (error) {
-                    retryCallback(error)
-                    return
-                  }
-
-                  api!(connection!, Array.from(requests.values()), this[kOptions].timeout!, retryCallback)
-                })
-              },
-              concurrentCallback,
-              0
-            )
-          })
-        },
-        (error, responses) => {
+    this[kPerformWithRetry](
+      'deleteRecords',
+      retryCallback => {
+        this[kMetadata]({ topics: options.topics.map(topic => topic.name), forceUpdate: true }, (error, metadata) => {
           if (error) {
+            // Metadata request already retried some times so no retry again
             callback(error)
             return
           }
 
-          const deletedRecordsByTopic = new Map<string, DeletedRecordsTopic>()
+          const requests = new Map<Broker, DeleteRecordsRequestTopics[]>()
 
-          for (const response of responses as DeleteRecordsResponse[]) {
-            for (const topic of response.topics) {
-              let topicDeletedRecords = deletedRecordsByTopic.get(topic.name)
-              if (!topicDeletedRecords) {
-                topicDeletedRecords = { name: topic.name, partitions: [] }
-                deletedRecordsByTopic.set(topic.name, topicDeletedRecords)
+          for (const topic of options.topics) {
+            for (const partition of topic.partitions) {
+              // metadata!.topics.get(topic.name) must be defined as the metadata request was successful
+              const topicData = metadata!.topics.get(topic.name)!
+
+              const targetPartitionData = topicData.partitions[partition.partition]
+              /* c8 ignore next 4 - Hard to test */
+              if (!targetPartitionData) {
+                retryCallback(new UserError('Unknown partition.'))
+                return
               }
 
-              for (const partition of topic.partitions) {
-                topicDeletedRecords.partitions.push({
-                  partition: partition.partitionIndex,
-                  lowWatermark: partition.lowWatermark
-                })
+              const broker = metadata!.brokers.get(targetPartitionData.leader)!
+
+              let leaderRequests = requests.get(broker)
+              if (!leaderRequests) {
+                leaderRequests = []
+                requests.set(broker, leaderRequests)
               }
+
+              let topicRequest = leaderRequests.find(tr => tr.name === topic.name)
+              if (!topicRequest) {
+                topicRequest = { name: topic.name, partitions: [] }
+                leaderRequests.push(topicRequest)
+              }
+
+              topicRequest.partitions.push({
+                partitionIndex: partition.partition,
+                offset: partition.offset
+              })
             }
           }
 
-          callback(null, Array.from(deletedRecordsByTopic.values()))
-        }
-      )
-    })
+          runConcurrentCallbacks(
+            'Deleting records failed.',
+            requests,
+            ([leader, requests], concurrentCallback: Callback<DeleteRecordsResponse>) => {
+              this[kPerformWithRetry](
+                'deleteRecordsOnLeader',
+                retryCallback => {
+                  this[kGetConnection](leader, (error, connection) => {
+                    if (error) {
+                      retryCallback(error)
+                      return
+                    }
+                    this[kGetApi]<DeleteRecordsRequest, DeleteRecordsResponse>('DeleteRecords', (error, api) => {
+                      if (error) {
+                        retryCallback(error)
+                        return
+                      }
+
+                      api!(connection!, requests, this[kOptions].timeout!, retryCallback)
+                    })
+                  })
+                },
+                concurrentCallback,
+                0
+              )
+            },
+            (error, responses) => {
+              if (error) {
+                // Do not retry failed deletion requests
+                callback(error)
+                return
+              }
+
+              const deletedRecordsByTopic = new Map<string, DeletedRecordsTopic>()
+
+              for (const response of responses as DeleteRecordsResponse[]) {
+                for (const topic of response.topics) {
+                  let topicDeletedRecords = deletedRecordsByTopic.get(topic.name)
+                  if (!topicDeletedRecords) {
+                    topicDeletedRecords = { name: topic.name, partitions: [] }
+                    deletedRecordsByTopic.set(topic.name, topicDeletedRecords)
+                  }
+
+                  for (const partition of topic.partitions) {
+                    topicDeletedRecords.partitions.push({
+                      partition: partition.partitionIndex,
+                      lowWatermark: partition.lowWatermark
+                    })
+                  }
+                }
+              }
+
+              retryCallback(null, Array.from(deletedRecordsByTopic.values()))
+            }
+          )
+        })
+      },
+      callback,
+      0
+    )
   }
 
   #listOffsets (options: AdminListOffsetsOptions, callback: CallbackWithPromise<ListedOffsetsTopic[]>): void {
-    this[kMetadata]({ topics: options.topics.map(topic => topic.name) }, (error, metadata) => {
-      if (error) {
-        callback(error)
-        return
-      }
-
-      // metadata must be defined at this point
-      const { topics, brokers } = metadata!
-
-      const requests = new Map<number, ListOffsetsRequestTopic[]>()
-
-      for (const topic of options.topics) {
-        for (const partition of topic.partitions) {
-          // topics.get(topic.name) must be defined as the metadata request was successful
-          const topicData = topics.get(topic.name)!
-
-          const targetPartitionData = topicData.partitions[partition.partitionIndex]
-          /* c8 ignore next 4 - Hard to test */
-          if (!targetPartitionData) {
-            callback(new UserError(`Unknown partition ${partition.partitionIndex} for topic ${topic.name}.`))
-            return
-          }
-
-          let leaderRequests = requests.get(targetPartitionData.leader)
-          if (!leaderRequests) {
-            leaderRequests = []
-            requests.set(targetPartitionData.leader, leaderRequests)
-          }
-
-          let topicRequest = leaderRequests.find(t => t.name === topic.name)
-          if (!topicRequest) {
-            topicRequest = { name: topic.name, partitions: [] }
-            leaderRequests.push(topicRequest)
-          }
-
-          topicRequest.partitions.push({
-            partitionIndex: partition.partitionIndex,
-            currentLeaderEpoch: targetPartitionData.leaderEpoch,
-            /* c8 ignore next - Hard to test */
-            timestamp: partition.timestamp ?? -1n
-          })
-        }
-      }
-
-      runConcurrentCallbacks(
-        'Listing offsets failed.',
-        requests,
-        ([leader, requests], concurrentCallback) => {
-          this[kGetConnection](brokers.get(leader)!, (error, connection) => {
-            if (error) {
-              concurrentCallback(error)
-              return
-            }
-            this[kPerformWithRetry](
-              'listOffsets',
-              retryCallback => {
-                this[kGetApi]<ListOffsetsRequest, ListOffsetsResponse>('ListOffsets', (error, api) => {
-                  if (error) {
-                    retryCallback(error)
-                    return
-                  }
-
-                  api!(
-                    connection!,
-                    -1,
-                    options.isolationLevel ?? FetchIsolationLevels.READ_UNCOMMITTED,
-                    Array.from(requests.values()),
-                    retryCallback
-                  )
-                })
-              },
-              concurrentCallback,
-              0
-            )
-          })
-        },
-        (error, responses) => {
+    this[kPerformWithRetry](
+      'listOffsets',
+      retryCallback => {
+        this[kMetadata]({ topics: options.topics.map(topic => topic.name), forceUpdate: true }, (error, metadata) => {
           if (error) {
+            // Metadata request already retried some times so no retry again
             callback(error)
             return
           }
 
-          const ret: ListedOffsetsTopic[] = []
+          // metadata must be defined at this point
+          const { topics, brokers } = metadata!
 
-          for (const response of responses as ListOffsetsResponse[]) {
-            for (const topic of response.topics) {
-              let topicOffsets = ret.find(t => t.name === topic.name)
-              if (!topicOffsets) {
-                topicOffsets = { name: topic.name, partitions: [] }
-                ret.push(topicOffsets)
+          const requests = new Map<Broker, ListOffsetsRequestTopic[]>()
+
+          for (const topic of options.topics) {
+            for (const partition of topic.partitions) {
+              // topics.get(topic.name) must be defined as the metadata request was successful
+              const topicData = topics.get(topic.name)!
+
+              const targetPartitionData = topicData.partitions[partition.partitionIndex]
+              /* c8 ignore next 4 - Hard to test */
+              if (!targetPartitionData) {
+                retryCallback(new UserError('Unknown partition.'))
+                return
               }
-              for (const partition of topic.partitions) {
-                topicOffsets.partitions.push({
-                  offset: partition.offset,
-                  timestamp: partition.timestamp,
-                  partitionIndex: partition.partitionIndex,
-                  leaderEpoch: partition.leaderEpoch
-                })
+
+              const broker = brokers.get(targetPartitionData.leader)!
+
+              let leaderRequests = requests.get(broker)
+              if (!leaderRequests) {
+                leaderRequests = []
+                requests.set(broker, leaderRequests)
               }
+
+              let topicRequest = leaderRequests.find(t => t.name === topic.name)
+              if (!topicRequest) {
+                topicRequest = { name: topic.name, partitions: [] }
+                leaderRequests.push(topicRequest)
+              }
+
+              topicRequest.partitions.push({
+                partitionIndex: partition.partitionIndex,
+                currentLeaderEpoch: targetPartitionData.leaderEpoch,
+                /* c8 ignore next - Hard to test */
+                timestamp: partition.timestamp ?? -1n
+              })
             }
           }
 
-          callback(null, ret)
-        }
-      )
-    })
+          runConcurrentCallbacks(
+            'Listing offsets failed.',
+            requests,
+            ([leader, requests], concurrentCallback: Callback<ListOffsetsResponse>) => {
+              this[kPerformWithRetry](
+                'listOffsets',
+                retryCallback => {
+                  this[kGetConnection](leader, (error, connection) => {
+                    if (error) {
+                      retryCallback(error)
+                      return
+                    }
+                    this[kGetApi]<ListOffsetsRequest, ListOffsetsResponse>('ListOffsets', (error, api) => {
+                      if (error) {
+                        retryCallback(error)
+                        return
+                      }
+
+                      api!(
+                        connection!,
+                        -1,
+                        options.isolationLevel ?? FetchIsolationLevels.READ_UNCOMMITTED,
+                        requests,
+                        retryCallback
+                      )
+                    })
+                  })
+                },
+                concurrentCallback,
+                0
+              )
+            },
+            (error, responses) => {
+              if (error) {
+                retryCallback(error)
+                return
+              }
+
+              const ret: ListedOffsetsTopic[] = []
+
+              for (const response of responses as ListOffsetsResponse[]) {
+                for (const topic of response.topics) {
+                  let topicOffsets = ret.find(t => t.name === topic.name)
+                  if (!topicOffsets) {
+                    topicOffsets = { name: topic.name, partitions: [] }
+                    ret.push(topicOffsets)
+                  }
+                  for (const partition of topic.partitions) {
+                    topicOffsets.partitions.push({
+                      offset: partition.offset,
+                      timestamp: partition.timestamp,
+                      partitionIndex: partition.partitionIndex,
+                      leaderEpoch: partition.leaderEpoch
+                    })
+                  }
+                }
+              }
+
+              retryCallback(null, ret)
+            }
+          )
+        })
+      },
+      callback,
+      0
+    )
   }
 }

--- a/src/clients/base/base.ts
+++ b/src/clients/base/base.ts
@@ -657,6 +657,7 @@ export class Base<
               }
             } else {
               this.#metadata.lastUpdate = lastUpdate
+              this.#metadata.controllerId = metadata!.controllerId
             }
 
             const brokers: ClusterMetadata['brokers'] = new Map()

--- a/test/clients/admin/admin.test.ts
+++ b/test/clients/admin/admin.test.ts
@@ -434,7 +434,10 @@ test('listTopics should handle errors from Connection.getFirstAvailable', async 
   } catch (error) {
     // Error should contain our mock error message
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.message.includes(mockedErrorMessage), true)
+    strictEqual(error.message, 'Listing topics failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError.message, mockedErrorMessage)
   }
 })
 
@@ -448,9 +451,12 @@ test('listTopics should handle unavailable API errors', async t => {
     await admin.listTopics({})
     throw new Error('Expected error not thrown')
   } catch (error) {
-    // Error should contain our mock error message
-    strictEqual(error instanceof UnsupportedApiError, true)
-    strictEqual(error.message.includes('Unsupported API Metadata.'), true)
+    strictEqual(error instanceof MultipleErrors, true)
+    strictEqual(error.message, 'Listing topics failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError instanceof UnsupportedApiError, true)
+    strictEqual(subError.message, 'Unsupported API Metadata.')
   }
 })
 
@@ -835,7 +841,10 @@ test('createTopics should handle errors from Connection.getFirstAvailable', asyn
   } catch (error) {
     // Error should contain our mock error message
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.message.includes(mockedErrorMessage), true)
+    strictEqual(error.message, 'Creating topics failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError.message, mockedErrorMessage)
   }
 })
 
@@ -853,9 +862,12 @@ test('createTopics should handle unavailable API errors', async t => {
     })
     throw new Error('Expected error not thrown')
   } catch (error) {
-    // Error should contain our mock error message
-    strictEqual(error instanceof UnsupportedApiError, true)
-    strictEqual(error.message.includes('Unsupported API CreateTopics.'), true)
+    strictEqual(error instanceof MultipleErrors, true)
+    strictEqual(error.message, 'Creating topics failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError instanceof UnsupportedApiError, true)
+    strictEqual(subError.message, 'Unsupported API CreateTopics.')
   }
 })
 
@@ -1071,7 +1083,10 @@ test('deleteTopics should handle errors from Connection.getFirstAvailable', asyn
   } catch (error) {
     // Error should contain our mock error message
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.message.includes(mockedErrorMessage), true)
+    strictEqual(error.message, 'Deleting topics failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError.message, mockedErrorMessage)
   }
 })
 
@@ -1088,8 +1103,12 @@ test('deleteTopics should handle unavailable API errors', async t => {
     throw new Error('Expected error not thrown')
   } catch (error) {
     // Error should contain our mock error message
-    strictEqual(error instanceof UnsupportedApiError, true)
-    strictEqual(error.message.includes('Unsupported API DeleteTopics.'), true)
+    strictEqual(error instanceof MultipleErrors, true)
+    strictEqual(error.message, 'Deleting topics failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError instanceof UnsupportedApiError, true)
+    strictEqual(subError.message, 'Unsupported API DeleteTopics.')
   }
 })
 
@@ -1356,9 +1375,11 @@ test('createPartitions should handle errors from the API', async t => {
     })
     throw new Error('Expected error not thrown')
   } catch (error) {
-    // Error should be about connection failure
-    strictEqual(error instanceof Error, true)
+    strictEqual(error instanceof MultipleErrors, true)
     strictEqual(error.message, 'Creating partitions failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError.message, mockedErrorMessage)
   }
 })
 
@@ -1376,9 +1397,12 @@ test('listGroups should handle unavailable API errors', async t => {
     })
     throw new Error('Expected error not thrown')
   } catch (error) {
-    // Error should be about connection failure
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.errors[0].message.includes('Unsupported API CreatePartitions.'), true)
+    strictEqual(error.message, 'Creating partitions failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError instanceof UnsupportedApiError, true)
+    strictEqual(subError.message, 'Unsupported API CreatePartitions.')
   }
 })
 
@@ -1566,8 +1590,11 @@ test('listGroups should handle errors from the API', async t => {
     throw new Error('Expected error not thrown')
   } catch (error) {
     // Error should be about connection failure
-    strictEqual(error instanceof Error, true)
+    strictEqual(error instanceof MultipleErrors, true)
     strictEqual(error.message, 'Listing groups failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError.message, mockedErrorMessage)
   }
 })
 
@@ -1581,9 +1608,12 @@ test('listGroups should handle unavailable API errors', async t => {
     await admin.listGroups()
     throw new Error('Expected error not thrown')
   } catch (error) {
-    // Error should be about connection failure
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.errors[0].message.includes('Unsupported API ListGroups.'), true)
+    strictEqual(error.message, 'Listing groups failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError instanceof UnsupportedApiError, true)
+    strictEqual(subError.message, 'Unsupported API ListGroups.')
   }
 })
 
@@ -1767,9 +1797,15 @@ test('describeGroups memberAssignment should include user data field when no ass
   const bootstrapConn = await new Promise<Connection>((resolve, reject) => {
     admin[kGetBootstrapConnection]((error, conn) => (error ? reject(error) : resolve(conn!)))
   })
-  const coordResponse = await new Promise<{ coordinators: Array<{ host: string, port: number }> }>((resolve, reject) => {
+  const coordResponse = await new Promise<{ coordinators: Array<{ host: string; port: number }> }>((
+    resolve,
+    reject
+  ) => {
     admin[kGetApi]('FindCoordinator', (error: Error | null, api: any) => {
-      if (error) { reject(error); return }
+      if (error) {
+        reject(error)
+        return
+      }
       api(bootstrapConn, FindCoordinatorKeyTypes.GROUP, [groupId], (err: Error | null, res: any) => {
         err ? reject(err) : resolve(res)
       })
@@ -1787,10 +1823,14 @@ test('describeGroups memberAssignment should include user data field when no ass
   // int16 version | int32-prefixed topics array | int32 user data length
   const reader = Reader.from(rawMember.memberAssignment)
   reader.readInt16() // version
-  reader.readArray(r => {
-    r.readString(false) // topic name
-    r.readArray(r => r.readInt32(), false, false) // partitions
-  }, false, false)
+  reader.readArray(
+    r => {
+      r.readString(false) // topic name
+      r.readArray(r => r.readInt32(), false, false) // partitions
+    },
+    false,
+    false
+  )
 
   // Without the fix, readInt32() here throws BufferUnderflowException in Java
   // because the user data length field is missing entirely
@@ -1855,46 +1895,10 @@ test('describeGroups should validate options in strict mode', async t => {
   }
 })
 
-test('describeGroups should handle errors from Base.metadata', async t => {
-  const admin = createAdmin(t)
-
-  mockMetadata(admin)
-
-  try {
-    // Attempt to describe groups - should fail with connection error
-    await admin.describeGroups({
-      groups: ['test-group']
-    })
-    throw new Error('Expected error not thrown')
-  } catch (error) {
-    // Error should contain our mock error message
-    strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.message.includes(mockedErrorMessage), true)
-  }
-})
-
-test('describeGroups should handle errors from Connection.getFirstAvailable', async t => {
-  const admin = createAdmin(t)
-
-  mockConnectionPoolGetFirstAvailable(admin[kConnections], 3)
-
-  try {
-    // Attempt to describe groups - should fail with connection error
-    await admin.describeGroups({
-      groups: ['test-group']
-    })
-    throw new Error('Expected error not thrown')
-  } catch (error) {
-    // Error should contain our mock error message
-    strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.message.includes(mockedErrorMessage), true)
-  }
-})
-
 test('describeGroups should handle errors from Connection.get', async t => {
   const admin = createAdmin(t)
 
-  mockConnectionPoolGet(admin[kConnections], 4)
+  mockConnectionPoolGet(admin[kConnections], () => true)
 
   try {
     // Attempt to describe groups - should fail with connection error
@@ -1923,14 +1927,17 @@ test('describeGroups should handle errors from the API', async t => {
   } catch (error) {
     // Error should contain our mock error message
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.message.includes('Describing groups failed.'), true)
+    strictEqual(error.message, 'Describing groups failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError.message, mockedErrorMessage)
   }
 })
 
 test('describeGroups should handle unavailable API errors (FindCoordinator)', async t => {
   const admin = createAdmin(t)
 
-  mockUnavailableAPI(admin, 'FindCoordinator')
+  mockUnavailableAPI(admin, 'FindCoordinator', () => false)
 
   try {
     // Attempt to describe groups - should fail with connection error
@@ -1940,8 +1947,12 @@ test('describeGroups should handle unavailable API errors (FindCoordinator)', as
     throw new Error('Expected error not thrown')
   } catch (error) {
     // Error should contain our mock error message
-    strictEqual(error instanceof UnsupportedApiError, true)
-    strictEqual(error.message.includes('Unsupported API FindCoordinator.'), true)
+    strictEqual(error instanceof MultipleErrors, true)
+    strictEqual(error.message, 'Describing groups failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError instanceof UnsupportedApiError, true)
+    strictEqual(subError.message, 'Unsupported API FindCoordinator.')
   }
 })
 
@@ -1959,7 +1970,11 @@ test('describeGroups should handle unavailable API errors (DescribeGroups)', asy
   } catch (error) {
     // Error should contain our mock error message
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.errors[0].message.includes('Unsupported API DescribeGroups.'), true)
+    strictEqual(error.message, 'Describing groups failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError instanceof UnsupportedApiError, true)
+    strictEqual(subError.message, 'Unsupported API DescribeGroups.')
   }
 })
 
@@ -2066,40 +2081,6 @@ test('deleteGroups should validate options in strict mode', async t => {
   }
 })
 
-test('deleteGroups should handle errors from Base.metadata', async t => {
-  const admin = createAdmin(t)
-
-  mockMetadata(admin)
-
-  try {
-    // Attempt to delete groups - should fail with connection error
-    await admin.deleteGroups({ groups: ['non-existent'] })
-    throw new Error('Expected error not thrown')
-  } catch (error) {
-    // Error should contain our mock error message
-    strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.message.includes(mockedErrorMessage), true)
-  }
-})
-
-test('deleteGroups should handle errors from Connection.getFirstAvailable', async t => {
-  const admin = createAdmin(t)
-
-  mockConnectionPoolGetFirstAvailable(admin[kConnections], 2)
-
-  try {
-    // Attempt to delete groups - should fail with connection error
-    await admin.deleteGroups({
-      groups: ['test-group']
-    })
-    throw new Error('Expected error not thrown')
-  } catch (error) {
-    // Error should contain our mock error message
-    strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.message.includes(mockedErrorMessage), true)
-  }
-})
-
 test('deleteGroups should handle errors from Connection.get', async t => {
   const admin = createAdmin(t)
 
@@ -2126,25 +2107,31 @@ test('deleteGroups should handle unavailable API errors (DeleteGroups)', async t
     await admin.deleteGroups({ groups: ['non-existent'] })
     throw new Error('Expected error not thrown')
   } catch (error) {
-    // Error should contain our mock error message
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.errors[0].message.includes('Unsupported API DeleteGroups.'), true)
+    strictEqual(error.message, 'Deleting groups failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError instanceof UnsupportedApiError, true)
+    strictEqual(subError.message, 'Unsupported API DeleteGroups.')
   }
 })
 
 test('deleteGroups should handle unavailable API errors (FindCoordinator)', async t => {
   const admin = createAdmin(t)
 
-  mockUnavailableAPI(admin, 'FindCoordinator')
+  mockUnavailableAPI(admin, 'FindCoordinator', () => false)
 
   try {
     // Attempt to delete groups - should fail with connection error
     await admin.deleteGroups({ groups: ['non-existent'] })
     throw new Error('Expected error not thrown')
   } catch (error) {
-    // Error should contain our mock error message
-    strictEqual(error instanceof UnsupportedApiError, true)
-    strictEqual(error.message.includes('Unsupported API FindCoordinator.'), true)
+    strictEqual(error instanceof MultipleErrors, true)
+    strictEqual(error.message, 'Deleting groups failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError instanceof UnsupportedApiError, true)
+    strictEqual(subError.message, 'Unsupported API FindCoordinator.')
   }
 })
 
@@ -2355,41 +2342,10 @@ test('removeMembersFromConsumerGroup should validate options in strict mode', as
   }
 })
 
-test('removeMembersFromConsumerGroup should handle errors from Base.metadata', async t => {
-  const admin = createAdmin(t)
-
-  mockMetadata(admin)
-
-  try {
-    await admin.removeMembersFromConsumerGroup({ groupId: 'non-existent', members: [{ memberId: 'fake-member' }] })
-    throw new Error('Expected error not thrown')
-  } catch (error) {
-    strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.message.includes(mockedErrorMessage), true)
-  }
-})
-
-test('removeMembersFromConsumerGroup should handle errors from Connection.getFirstAvailable', async t => {
-  const admin = createAdmin(t)
-
-  mockConnectionPoolGetFirstAvailable(admin[kConnections], 2)
-
-  try {
-    await admin.removeMembersFromConsumerGroup({
-      groupId: 'test-group',
-      members: [{ memberId: 'fake-member' }]
-    })
-    throw new Error('Expected error not thrown')
-  } catch (error) {
-    strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.message.includes(mockedErrorMessage), true)
-  }
-})
-
 test('removeMembersFromConsumerGroup should handle errors from Connection.get', async t => {
   const admin = createAdmin(t)
 
-  mockConnectionPoolGet(admin[kConnections], 4)
+  mockConnectionPoolGet(admin[kConnections], () => true)
 
   try {
     await admin.removeMembersFromConsumerGroup({ groupId: 'non-existent', members: [{ memberId: 'fake-member' }] })
@@ -2403,14 +2359,18 @@ test('removeMembersFromConsumerGroup should handle errors from Connection.get', 
 test('removeMembersFromConsumerGroup should handle unavailable API errors (LeaveGroup)', async t => {
   const admin = createAdmin(t)
 
-  mockUnavailableAPI(admin, 'LeaveGroup')
+  mockUnavailableAPI(admin, 'LeaveGroup', () => false)
 
   try {
     await admin.removeMembersFromConsumerGroup({ groupId: 'non-existent', members: [{ memberId: 'fake-member' }] })
     throw new Error('Expected error not thrown')
   } catch (error) {
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.errors[0].message.includes('Unsupported API LeaveGroup.'), true)
+    strictEqual(error.message, 'Removing members from consumer group failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError instanceof UnsupportedApiError, true)
+    strictEqual(subError.message, 'Unsupported API LeaveGroup.')
   }
 })
 
@@ -2428,7 +2388,7 @@ test('removeMembersFromConsumerGroup should handle unavailable API errors (FindC
     const subError = error.errors[0]
     ok(subError)
     strictEqual(subError instanceof UnsupportedApiError, true)
-    strictEqual(subError.message.includes('Unsupported API FindCoordinator.'), true)
+    strictEqual(subError.message, 'Unsupported API FindCoordinator.')
   }
 })
 
@@ -2712,7 +2672,10 @@ test('alterClientQuotas should handle errors from Connection.getFirstAvailable',
     throw new Error('Expected error not thrown')
   } catch (error) {
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.message.includes('Altering client quotas failed.'), true)
+    strictEqual(error.message, 'Altering client quotas failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError.message, mockedErrorMessage)
   }
 })
 
@@ -2754,7 +2717,10 @@ test('alterClientQuotas should handle errors from the API', async t => {
     throw new Error('Expected error not thrown')
   } catch (error) {
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.message.includes('Altering client quotas failed.'), true)
+    strictEqual(error.message, 'Altering client quotas failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError.message, mockedErrorMessage)
   }
 })
 
@@ -2775,7 +2741,11 @@ test('alterClientQuotas should handle unavailable API errors (AlterClientQuotas)
     throw new Error('Expected error not thrown')
   } catch (error) {
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.errors[0].message.includes('Unsupported API AlterClientQuotas.'), true)
+    strictEqual(error.message, 'Altering client quotas failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError instanceof UnsupportedApiError, true)
+    strictEqual(subError.message, 'Unsupported API AlterClientQuotas.')
   }
 })
 
@@ -3144,7 +3114,10 @@ test('describeClientQuotas should handle errors from Connection.getFirstAvailabl
     throw new Error('Expected error not thrown')
   } catch (error) {
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.message.includes('Describing client quotas failed.'), true)
+    strictEqual(error.message, 'Describing client quotas failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError.message, mockedErrorMessage)
   }
 })
 
@@ -3180,7 +3153,10 @@ test('describeClientQuotas should handle errors from the API', async t => {
     throw new Error('Expected error not thrown')
   } catch (error) {
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.message.includes('Describing client quotas failed.'), true)
+    strictEqual(error.message, 'Describing client quotas failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError.message, mockedErrorMessage)
   }
 })
 
@@ -3198,7 +3174,10 @@ test('describeClientQuotas should handle unavailable API errors (DescribeClientQ
     throw new Error('Expected error not thrown')
   } catch (error) {
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.errors[0].message.includes('Unsupported API DescribeClientQuotas.'), true)
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError instanceof UnsupportedApiError, true)
+    strictEqual(subError.message, 'Unsupported API DescribeClientQuotas.')
   }
 })
 
@@ -3467,7 +3446,10 @@ test('describeLogDirs should handle errors from the API', async t => {
     throw new Error('Expected error not thrown')
   } catch (error) {
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.message.includes('Describing log dirs failed.'), true)
+    strictEqual(error.message, 'Describing log dirs failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError.message, mockedErrorMessage)
   }
 })
 
@@ -3483,7 +3465,10 @@ test('describeLogDirs should handle unavailable API errors', async t => {
     throw new Error('Expected error not thrown')
   } catch (error) {
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.errors[0].message.includes('Unsupported API DescribeLogDirs.'), true)
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError instanceof UnsupportedApiError, true)
+    strictEqual(subError.message, 'Unsupported API DescribeLogDirs.')
   }
 })
 
@@ -4536,112 +4521,10 @@ test('deleteConsumerGroupOffsets should validate options in strict mode', async 
   }
 })
 
-test('listConsumerGroupOffsets should handle errors from Base.metadata', async t => {
-  const admin = createAdmin(t)
-
-  mockMetadata(admin)
-
-  try {
-    await admin.listConsumerGroupOffsets({
-      groups: [{ groupId: 'test-group', topics: [{ name: 'test-topic', partitionIndexes: [0] }] }],
-      requireStable: false
-    })
-    throw new Error('Expected error not thrown')
-  } catch (error) {
-    strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.message.includes(mockedErrorMessage), true)
-  }
-})
-
-test('alterConsumerGroupOffsets should handle errors from Base.metadata', async t => {
-  const admin = createAdmin(t)
-
-  mockMetadata(admin)
-
-  try {
-    await admin.alterConsumerGroupOffsets({
-      groupId: 'test-group',
-      topics: [{ name: 'test-topic', partitionOffsets: [{ partition: 0, offset: BigInt(10) }] }]
-    })
-    throw new Error('Expected error not thrown')
-  } catch (error) {
-    strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.message.includes(mockedErrorMessage), true)
-  }
-})
-
-test('deleteConsumerGroupOffsets should handle errors from Base.metadata', async t => {
-  const admin = createAdmin(t)
-
-  mockMetadata(admin)
-
-  try {
-    await admin.deleteConsumerGroupOffsets({
-      groupId: 'test-group',
-      topics: [{ name: 'test-topic', partitionIndexes: [0] }]
-    })
-    throw new Error('Expected error not thrown')
-  } catch (error) {
-    strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.message.includes(mockedErrorMessage), true)
-  }
-})
-
-test('listConsumerGroupOffsets should handle errors from Connection.getFirstAvailable', async t => {
-  const admin = createAdmin(t)
-
-  mockConnectionPoolGetFirstAvailable(admin[kConnections], 3)
-
-  try {
-    await admin.listConsumerGroupOffsets({
-      groups: [{ groupId: 'test-group', topics: [{ name: 'test-topic', partitionIndexes: [0] }] }],
-      requireStable: false
-    })
-    throw new Error('Expected error not thrown')
-  } catch (error) {
-    strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.message.includes('Listing consumer group offsets failed.'), true)
-  }
-})
-
-test('alterConsumerGroupOffsets should handle errors from Connection.getFirstAvailable', async t => {
-  const admin = createAdmin(t)
-
-  mockConnectionPoolGetFirstAvailable(admin[kConnections], 3)
-
-  try {
-    await admin.alterConsumerGroupOffsets({
-      groupId: 'test-group',
-      topics: [{ name: 'test-topic', partitionOffsets: [{ partition: 0, offset: BigInt(10) }] }]
-    })
-    throw new Error('Expected error not thrown')
-  } catch (error) {
-    strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.message.includes('Altering consumer group offsets failed.'), true)
-  }
-})
-
-test('deleteConsumerGroupOffsets should handle errors from Connection.getFirstAvailable', async t => {
-  const admin = createAdmin(t)
-
-  mockConnectionPoolGetFirstAvailable(admin[kConnections], 3)
-
-  try {
-    await admin.deleteConsumerGroupOffsets({
-      groupId: 'test-group',
-      topics: [{ name: 'test-topic', partitionIndexes: [0] }]
-    })
-    throw new Error('Expected error not thrown')
-  } catch (error) {
-    strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.message.includes('Deleting consumer group offsets failed.'), true)
-  }
-})
-
 test('listConsumerGroupOffsets should handle errors from Connection.get', async t => {
   const admin = createAdmin(t)
 
-  mockConnectionPoolGet(admin[kConnections], 4)
+  mockConnectionPoolGet(admin[kConnections], () => true)
 
   try {
     await admin.listConsumerGroupOffsets({
@@ -4702,9 +4585,11 @@ test('listConsumerGroupOffsets should handle unavailable API errors (FindCoordin
     throw new Error('Expected error not thrown')
   } catch (error) {
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.errors[0] instanceof UnsupportedApiError, true)
-    strictEqual(error.message.includes('Listing consumer group offsets failed.'), true)
-    strictEqual(error.errors[0].message.includes('Unsupported API FindCoordinator.'), true)
+    strictEqual(error.message, 'Listing consumer group offsets failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError instanceof UnsupportedApiError, true)
+    strictEqual(subError.message, 'Unsupported API FindCoordinator.')
   }
 })
 
@@ -4721,9 +4606,11 @@ test('alterConsumerGroupOffsets should handle unavailable API errors (FindCoordi
     throw new Error('Expected error not thrown')
   } catch (error) {
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.errors[0] instanceof UnsupportedApiError, true)
-    strictEqual(error.message.includes('Altering consumer group offsets failed.'), true)
-    strictEqual(error.errors[0].message.includes('Unsupported API FindCoordinator.'), true)
+    strictEqual(error.message, 'Altering consumer group offsets failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError instanceof UnsupportedApiError, true)
+    strictEqual(subError.message, 'Unsupported API FindCoordinator.')
   }
 })
 
@@ -4740,9 +4627,11 @@ test('deleteConsumerGroupOffsets should handle unavailable API errors (FindCoord
     throw new Error('Expected error not thrown')
   } catch (error) {
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.errors[0] instanceof UnsupportedApiError, true)
-    strictEqual(error.message.includes('Deleting consumer group offsets failed.'), true)
-    strictEqual(error.errors[0].message.includes('Unsupported API FindCoordinator.'), true)
+    strictEqual(error.message, 'Deleting consumer group offsets failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError instanceof UnsupportedApiError, true)
+    strictEqual(subError.message, 'Unsupported API FindCoordinator.')
   }
 })
 
@@ -4759,9 +4648,11 @@ test('listConsumerGroupOffsets should handle unavailable API errors (OffsetFetch
     throw new Error('Expected error not thrown')
   } catch (error) {
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.errors[0] instanceof UnsupportedApiError, true)
-    strictEqual(error.message.includes('Listing consumer group offsets failed.'), true)
-    strictEqual(error.errors[0].message.includes('Unsupported API OffsetFetch.'), true)
+    strictEqual(error.message, 'Listing consumer group offsets failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError instanceof UnsupportedApiError, true)
+    strictEqual(subError.message, 'Unsupported API OffsetFetch.')
   }
 })
 
@@ -4778,9 +4669,11 @@ test('alterConsumerGroupOffsets should handle unavailable API errors (OffsetComm
     throw new Error('Expected error not thrown')
   } catch (error) {
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.errors[0] instanceof UnsupportedApiError, true)
-    strictEqual(error.message.includes('Altering consumer group offsets failed.'), true)
-    strictEqual(error.errors[0].message.includes('Unsupported API OffsetCommit.'), true)
+    strictEqual(error.message, 'Altering consumer group offsets failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError instanceof UnsupportedApiError, true)
+    strictEqual(subError.message, 'Unsupported API OffsetCommit.')
   }
 })
 
@@ -4797,9 +4690,11 @@ test('deleteConsumerGroupOffsets should handle unavailable API errors (OffsetDel
     throw new Error('Expected error not thrown')
   } catch (error) {
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.errors[0] instanceof UnsupportedApiError, true)
-    strictEqual(error.message.includes('Deleting consumer group offsets failed.'), true)
-    strictEqual(error.errors[0].message.includes('Unsupported API OffsetDelete.'), true)
+    strictEqual(error.message, 'Deleting consumer group offsets failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError instanceof UnsupportedApiError, true)
+    strictEqual(subError.message, 'Unsupported API OffsetDelete.')
   }
 })
 
@@ -4963,6 +4858,7 @@ test('describeConfigs should properly describe broker configs', async t => {
     result.every(r => r.resourceType === ConfigResourceTypes.BROKER),
     true
   )
+  result.sort((a, b) => a.resourceName.localeCompare(b.resourceName))
   strictEqual(result[0].resourceName, '1')
   strictEqual(Array.isArray(result[0].configs), true)
   strictEqual(result[1].resourceName, '2')
@@ -5256,7 +5152,10 @@ test('describeConfigs should handle errors from the API', async t => {
     throw new Error('Expected error not thrown')
   } catch (error) {
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.message.includes('Describing configs failed.'), true)
+    strictEqual(error.message, 'Describing configs failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError.message, mockedErrorMessage)
   }
 })
 
@@ -5276,7 +5175,11 @@ test('describeConfigs should handle unavailable API errors', async t => {
     throw new Error('Expected error not thrown')
   } catch (error) {
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.errors[0].message.includes('Unsupported API DescribeConfigs.'), true)
+    strictEqual(error.message, 'Describing configs failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError instanceof UnsupportedApiError, true)
+    strictEqual(error.errors[0].message, 'Unsupported API DescribeConfigs.')
   }
 })
 
@@ -5392,6 +5295,8 @@ test('alterConfigs should properly update broker configs', async t => {
     includeSynonyms: false,
     includeDocumentation: false
   })
+
+  result.sort((a, b) => a.resourceName.localeCompare(b.resourceName))
 
   deepStrictEqual(result, [
     {
@@ -5886,7 +5791,10 @@ test('alterConfigs should handle errors from the API', async t => {
     throw new Error('Expected error not thrown')
   } catch (error) {
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.message.includes('Altering configs failed.'), true)
+    strictEqual(error.message, 'Altering configs failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError.message, mockedErrorMessage)
   }
 })
 
@@ -5906,7 +5814,11 @@ test('alterConfigs should handle unavailable API errors', async t => {
     throw new Error('Expected error not thrown')
   } catch (error) {
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.errors[0].message.includes('Unsupported API AlterConfigs.'), true)
+    strictEqual(error.message, 'Altering configs failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError instanceof UnsupportedApiError, true)
+    strictEqual(subError.message, 'Unsupported API AlterConfigs.')
   }
 })
 
@@ -6167,6 +6079,8 @@ test('incrementalAlterConfigs should properly update broker configs', async t =>
     includeSynonyms: false,
     includeDocumentation: false
   })
+
+  result.sort((a, b) => a.resourceName.localeCompare(b.resourceName))
 
   deepStrictEqual(result, [
     {
@@ -6806,7 +6720,10 @@ test('incrementalAlterConfigs should handle errors from the API', async t => {
     throw new Error('Expected error not thrown')
   } catch (error) {
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.message.includes('Incrementally altering configs failed.'), true)
+    strictEqual(error.message, 'Incrementally altering configs failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError.message, mockedErrorMessage)
   }
 })
 
@@ -6832,7 +6749,11 @@ test('incrementalAlterConfigs should handle unavailable API errors', async t => 
     throw new Error('Expected error not thrown')
   } catch (error) {
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.errors[0].message.includes('Unsupported API IncrementalAlterConfigs.'), true)
+    strictEqual(error.message, 'Incrementally altering configs failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError instanceof UnsupportedApiError, true)
+    strictEqual(subError.message, 'Unsupported API IncrementalAlterConfigs.')
   }
 })
 
@@ -7483,7 +7404,10 @@ test('createAcls should handle errors from Connection.getFirstAvailable', async 
     throw new Error('Expected error not thrown')
   } catch (error) {
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.message.includes('Creating ACLs failed.'), true)
+    strictEqual(error.message, 'Creating ACLs failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError.message, mockedErrorMessage)
   }
 })
 
@@ -7507,7 +7431,10 @@ test('describeAcls should handle errors from Connection.getFirstAvailable', asyn
     throw new Error('Expected error not thrown')
   } catch (error) {
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.message.includes('Describing ACLs failed.'), true)
+    strictEqual(error.message, 'Describing ACLs failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError.message, mockedErrorMessage)
   }
 })
 
@@ -7533,7 +7460,10 @@ test('deleteAcls should handle errors from Connection.getFirstAvailable', async 
     throw new Error('Expected error not thrown')
   } catch (error) {
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.message.includes('Deleting ACLs failed.'), true)
+    strictEqual(error.message, 'Deleting ACLs failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError.message, mockedErrorMessage)
   }
 })
 
@@ -7635,7 +7565,10 @@ test('createAcls should handle errors from the API', async t => {
     throw new Error('Expected error not thrown')
   } catch (error) {
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.message.includes('Creating ACLs failed.'), true)
+    strictEqual(error.message, 'Creating ACLs failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError.message, mockedErrorMessage)
   }
 })
 
@@ -7659,7 +7592,10 @@ test('describeAcls should handle errors from the API', async t => {
     throw new Error('Expected error not thrown')
   } catch (error) {
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.message.includes('Describing ACLs failed.'), true)
+    strictEqual(error.message, 'Describing ACLs failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError.message, mockedErrorMessage)
   }
 })
 
@@ -7685,7 +7621,10 @@ test('deleteAcls should handle errors from the API', async t => {
     throw new Error('Expected error not thrown')
   } catch (error) {
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.message.includes('Deleting ACLs failed.'), true)
+    strictEqual(error.message, 'Deleting ACLs failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError.message, mockedErrorMessage)
   }
 })
 
@@ -7711,6 +7650,10 @@ test('createAcls should handle unavailable API errors (CreateAcls)', async t => 
     throw new Error('Expected error not thrown')
   } catch (error) {
     strictEqual(error instanceof MultipleErrors, true)
+    strictEqual(error.message, 'Creating ACLs failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError instanceof UnsupportedApiError, true)
     strictEqual(error.errors[0].message.includes('Unsupported API CreateAcls.'), true)
   }
 })
@@ -7735,7 +7678,11 @@ test('describeAcls should handle unavailable API errors (DescribeAcls)', async t
     throw new Error('Expected error not thrown')
   } catch (error) {
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.errors[0].message.includes('Unsupported API DescribeAcls.'), true)
+    strictEqual(error.message, 'Describing ACLs failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError instanceof UnsupportedApiError, true)
+    strictEqual(subError.message, 'Unsupported API DescribeAcls.')
   }
 })
 
@@ -7761,7 +7708,11 @@ test('deleteAcls should handle unavailable API errors (DeleteAcls)', async t => 
     throw new Error('Expected error not thrown')
   } catch (error) {
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.errors[0].message.includes('Unsupported API DeleteAcls.'), true)
+    strictEqual(error.message, 'Deleting ACLs failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError instanceof UnsupportedApiError, true)
+    strictEqual(subError.message, 'Unsupported API DeleteAcls.')
   }
 })
 
@@ -7801,6 +7752,11 @@ test('listOffsets should list offsets for topics and partitions', async t => {
         ]
       }
     ]
+  })
+
+  listOffsetsResult.sort((a, b) => a.name.localeCompare(b.name))
+  listOffsetsResult.forEach(topic => {
+    topic.partitions.sort((a, b) => a.partitionIndex - b.partitionIndex)
   })
 
   strictEqual(Array.isArray(listOffsetsResult), true)
@@ -8203,7 +8159,10 @@ test('listOffsets should handle errors from the API', async t => {
     throw new Error('Expected error not thrown')
   } catch (error) {
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.message.includes('Listing offsets failed.'), true)
+    strictEqual(error.message, 'Listing offsets failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError.message, mockedErrorMessage)
   }
 })
 
@@ -8233,7 +8192,11 @@ test('listOffsets should handle unavailable API errors', async t => {
     throw new Error('Expected error not thrown')
   } catch (error) {
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.errors[0].message.includes('Unsupported API ListOffsets.'), true)
+    strictEqual(error.message, 'Listing offsets failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError instanceof UnsupportedApiError, true)
+    strictEqual(subError.message, 'Unsupported API ListOffsets.')
   }
 })
 
@@ -8285,6 +8248,8 @@ test('deleteRecords should delete records for topic partitions', async t => {
       }
     ]
   })
+
+  deleted[0].partitions.sort((a, b) => a.partition - b.partition)
 
   deepStrictEqual(deleted, [
     {
@@ -8479,7 +8444,10 @@ test('deleteRecords should handle errors from the API', async t => {
     throw new Error('Expected error not thrown')
   } catch (error) {
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.message.includes('Deleting records failed.'), true)
+    strictEqual(error.message, 'Deleting records failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError.message, mockedErrorMessage)
   }
 })
 
@@ -8495,7 +8463,7 @@ test('deleteRecords should handle unavailable API errors', async t => {
 
   await scheduler.wait(1000)
 
-  mockUnavailableAPI(admin, 'DeleteRecords')
+  mockUnavailableAPI(admin, 'DeleteRecords', false)
 
   try {
     await admin.deleteRecords({
@@ -8509,7 +8477,11 @@ test('deleteRecords should handle unavailable API errors', async t => {
     throw new Error('Expected error not thrown')
   } catch (error) {
     strictEqual(error instanceof MultipleErrors, true)
-    strictEqual(error.errors[0].message.includes('Unsupported API DeleteRecords.'), true)
+    strictEqual(error.message, 'Deleting records failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError instanceof UnsupportedApiError, true)
+    strictEqual(subError.message, 'Unsupported API DeleteRecords.')
   }
 })
 
@@ -8636,7 +8608,11 @@ test('findCoordinator should handle errors from the API', async t => {
     })
     throw new Error('Expected error not thrown')
   } catch (error) {
-    strictEqual(error.message, mockedErrorMessage)
+    strictEqual(error instanceof MultipleErrors, true)
+    strictEqual(error.message, 'Finding coordinator failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError.message, mockedErrorMessage)
   }
 })
 
@@ -8652,7 +8628,11 @@ test('findCoordinator should handle unavailable API errors', async t => {
     })
     throw new Error('Expected error not thrown')
   } catch (error) {
-    strictEqual(error instanceof UnsupportedApiError, true)
-    strictEqual(error.message.includes('Unsupported API FindCoordinator.'), true)
+    strictEqual(error instanceof MultipleErrors, true)
+    strictEqual(error.message, 'Finding coordinator failed.')
+    const subError = error.errors[0]
+    ok(subError)
+    strictEqual(subError instanceof UnsupportedApiError, true)
+    strictEqual(subError.message, 'Unsupported API FindCoordinator.')
   }
 })


### PR DESCRIPTION
This change includes several adjustments.

Fixed issues:
- Always fetch fresh metadata because it is easily possible that either topic metadata or brokers change during the lifetime of an Admin client, and performance is not critical, unlike for producers or consumers.
- Also throw user error in #deleteRecords for the same reason as was introduced for #listOffsets.
- Controller IDs were not updated on metadata fetches.

Major improvements:
- Sending requests to group coordinators does not require looking up brokers in the cluster metadata; therefore, all unnecessary metadata calls in respective operations (e.g., describeGroups) have been removed.
- Introduction of retry-logic where it might be appropriate.
- Adjustment to `runConcurrentCallbacks` with an easier interface to allow working with Iterables, which enables iterating over e.g. `someMap.values()`; as Iterables do not expose a size value, the internal logic had to be changed.

Minor improvements:
- Unify error interface for all admin operations: top-most error is a MultipleErrors instance with a generic message 'operation X failed.' and owning a set of more specific errors.
- Add some comments where variables cannot be undefined or where retrying operations does not make sense.


On-behalf-of: @SAP ospo@sap.com