### PR TITLE
fix: Route synchronous exception on retry to callback

### DIFF
--- a/src/clients/base/base.ts
+++ b/src/clients/base/base.ts
@@ -413,7 +413,12 @@ export class Base<
           this.emitWithDebug('client', 'performWithRetry:retry', operationId, attempt, retries, delay)
           const timeout = setTimeout(() => {
             this.removeListener('client:close', onClose)
-            this[kPerformWithRetry](operationId, operation, callback, attempt + 1, errors, shouldSkipRetry)
+            try {
+              this[kPerformWithRetry](operationId, operation, callback, attempt + 1, errors, shouldSkipRetry)
+            } catch (error) {
+              errors.push(error)
+              callback(new MultipleErrors(`${operationId} failed ${attempt + 1} times.`, errors))
+            }
           }, delay)
 
           this.once('client:close', onClose)

--- a/test/clients/base/base.test.ts
+++ b/test/clients/base/base.test.ts
@@ -798,6 +798,32 @@ test('kPerformWithRetry should accept a custom function', async t => {
   deepStrictEqual(second, 2000)
 })
 
+test('kPerformWithRetry should route synchronous exceptions thrown on retry to callback', async t => {
+  const client = createBase(t, { retries: 1, retryDelay: 0 })
+  const callback = createPromisifiedCallback<string>()
+  let attempts = 0
+
+  const result = client[kPerformWithRetry]<string>(
+    'testOperation',
+    retryCallback => {
+      attempts++
+      if (attempts === 1) {
+        retryCallback(new Error('first attempt failed'))
+        return
+      }
+      throw new Error('synchronous throw on retry')
+    },
+    callback,
+    0,
+    []
+  )
+
+  const error = await (result as Promise<string>).catch(e => e)
+  strictEqual(attempts, 2)
+  strictEqual(error instanceof MultipleErrors, true)
+  strictEqual(error.errors.at(-1).message, 'synchronous throw on retry')
+})
+
 test('kPerformWithRetry should clear retry errors after eventual success', async t => {
   const client = createBase(t, { retries: 3, retryDelay: 0 })
   const errors: Error[] = []


### PR DESCRIPTION
A synchronous exception raised by an operation retried in a setTimeout call cannot be handled by the caller and ends up as uncaught exception. This fix wraps the operation in a try/catch block to route the error to the callback instead.

On-behalf-of: @SAP ospo@sap.com