### PR TITLE
fix(connection): constrain correlation ID to 32 bits

### DIFF
--- a/src/network/connection.ts
+++ b/src/network/connection.ts
@@ -423,7 +423,9 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
     hasResponseHeaderTaggedFields: boolean,
     callback: Callback<ReturnType>
   ) {
-    const correlationId = ++this.#correlationId
+    // Correlation ID is a 32-bit integer in the protocol, so we need to wrap around after 2^31 - 1
+    const correlationId = (this.#correlationId + 1) & 0x7FFFFFFF
+    this.#correlationId = correlationId
 
     const diagnostic = createDiagnosticContext({
       connection: this,


### PR DESCRIPTION
First of all thanks for this library :)

We had a long running process run into an `ERR_OUT_OF_RANGE` error, and after some digging I'm fairly sure the cause was the correlation ID overflowing.

I was unable to add a test that runs in reasonable time, given that the correlation ID counter is a private field. I verified it by modifying the constructor to assign `Number.MAX_SAFE_INTEGER` instead of `0` and running the connection tests. If there is a way to properly test this behaviour I would be grateful if you could provide some pointers.