### PR TITLE
Fix OFFSET_OUT_OF_RANGE recovery when Fetch omits reset offset

### DIFF
--- a/src/clients/consumer/messages-stream.ts
+++ b/src/clients/consumer/messages-stream.ts
@@ -613,12 +613,25 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
                 return
               }
 
-              if (
-                this.#fallbackMode !== MessagesStreamFallbackModes.FAIL &&
-                this.#handleOffsetOutOfRange(error as GenericError, topicIds)
-              ) {
-                process.nextTick(() => {
-                  this.#fetch()
+              if (this.#fallbackMode !== MessagesStreamFallbackModes.FAIL) {
+                this.#handleOffsetOutOfRange(error as GenericError, topicIds, (recoveryError, recovered) => {
+                  if (this.#closed || this.closed || this.destroyed) {
+                    return
+                  }
+
+                  if (recoveryError) {
+                    this.destroy(recoveryError)
+                    return
+                  }
+
+                  if (recovered) {
+                    process.nextTick(() => {
+                      this.#fetch()
+                    })
+                    return
+                  }
+
+                  this.destroy(error)
                 })
                 return
               }
@@ -644,22 +657,30 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
     })
   }
 
-  #handleOffsetOutOfRange (error: GenericError, topicIds: Map<string, string>): boolean {
+  #handleOffsetOutOfRange (
+    error: GenericError,
+    topicIds: Map<string, string>,
+    callback: Callback<boolean>
+  ): void {
     if (!error.findBy?.('apiId', 'OFFSET_OUT_OF_RANGE')) {
-      return false
+      callback(null, false)
+      return
     }
 
     const response = error.response as FetchResponse | undefined
     if (!response || response.errorCode !== 0) {
-      return false
+      callback(null, false)
+      return
     }
 
     const recoveredOffsets: [string, bigint][] = []
+    const partitionsToRefresh = new Map<string, number[]>()
 
     for (const topicResponse of response.responses) {
       const topic = topicIds.get(topicResponse.topicId)
       if (!topic) {
-        return false
+        callback(null, false)
+        return
       }
 
       for (const partitionResponse of topicResponse.partitions) {
@@ -668,18 +689,80 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
         }
 
         if (partitionResponse.errorCode !== protocolErrors.OFFSET_OUT_OF_RANGE.code) {
-          return false
+          callback(null, false)
+          return
         }
 
-        const key = `${topic}:${partitionResponse.partitionIndex}`
         const offset =
           this.#fallbackMode === MessagesStreamFallbackModes.EARLIEST
             ? partitionResponse.logStartOffset
             : partitionResponse.highWatermark
-        recoveredOffsets.push([key, offset])
+
+        if (offset >= 0n) {
+          recoveredOffsets.push([partitionKey(topic, partitionResponse.partitionIndex), offset])
+          continue
+        }
+
+        let partitions = partitionsToRefresh.get(topic)
+        if (!partitions) {
+          partitions = []
+          partitionsToRefresh.set(topic, partitions)
+        }
+        partitions.push(partitionResponse.partitionIndex)
       }
     }
 
+    if (partitionsToRefresh.size > 0) {
+      this.#refreshOutOfRangeOffsets(partitionsToRefresh, recoveredOffsets, callback)
+      return
+    }
+
+    callback(null, this.#applyRecoveredOffsets(recoveredOffsets))
+  }
+
+  #refreshOutOfRangeOffsets (
+    partitionsToRefresh: Map<string, number[]>,
+    recoveredOffsets: [string, bigint][],
+    callback: Callback<boolean>
+  ): void {
+    const partitions = Object.fromEntries(partitionsToRefresh)
+
+    this.#consumer.listOffsets(
+      {
+        topics: Array.from(partitionsToRefresh.keys()),
+        partitions,
+        timestamp:
+          this.#fallbackMode === MessagesStreamFallbackModes.EARLIEST
+            ? ListOffsetTimestamps.EARLIEST
+            : ListOffsetTimestamps.LATEST
+      },
+      (error, offsets) => {
+        if (error) {
+          callback(error)
+          return
+        }
+
+        for (const [topic, refreshedPartitions] of partitionsToRefresh) {
+          const topicOffsets = offsets!.get(topic)
+
+          for (const partition of refreshedPartitions) {
+            const offset = topicOffsets?.[partition]
+
+            if (typeof offset !== 'bigint' || offset < 0n) {
+              callback(new UserError(`Cannot recover offset out of range for topic ${topic} partition ${partition}.`))
+              return
+            }
+
+            recoveredOffsets.push([partitionKey(topic, partition), offset])
+          }
+        }
+
+        callback(null, this.#applyRecoveredOffsets(recoveredOffsets))
+      }
+    )
+  }
+
+  #applyRecoveredOffsets (recoveredOffsets: [string, bigint][]): boolean {
     for (const [key, offset] of recoveredOffsets) {
       this.#offsetsToFetch.set(key, offset)
       this.#offsetsCommitted.set(key, offset)

--- a/test/clients/consumer/messages-stream-rebalance.test.ts
+++ b/test/clients/consumer/messages-stream-rebalance.test.ts
@@ -4,7 +4,14 @@ import { test, type TestContext } from 'node:test'
 import type { CallbackWithPromise } from '../../../src/apis/callbacks.ts'
 import type { FetchRequestTopic, FetchResponse } from '../../../src/apis/consumer/fetch-v17.ts'
 import { kConnections, kCreateConnectionPool, kGetApi, kOptions, kPrometheus } from '../../../src/clients/base/base.ts'
-import { type Consumer, MessagesStream, MessagesStreamFallbackModes, MessagesStreamModes } from '../../../src/index.ts'
+import {
+  type Consumer,
+  ListOffsetTimestamps,
+  MessagesStream,
+  MessagesStreamFallbackModes,
+  MessagesStreamModes,
+  ResponseError
+} from '../../../src/index.ts'
 import { kGetFetchNode } from '../../../src/symbols.ts'
 import { createConsumer, mockConnectionPoolGet, mockMetadata, mockMethod } from '../../helpers.ts'
 
@@ -254,6 +261,66 @@ test('should not fetch while offsets are refreshing after a group rejoin', async
   await new Promise(resolve => setTimeout(resolve, 70))
 
   strictEqual(consumer.metadataCalls > baselineMetadataCalls, true)
+
+  stream.destroy()
+})
+
+test('should refresh fallback offsets when offset out of range fetch errors omit log start offset', async t => {
+  const recoveredOffsets: bigint[] = []
+  const listOffsetRequests: any[] = []
+  let resolveRecoveredFetch!: () => void
+  const recoveredFetch = new Promise<void>(resolve => {
+    resolveRecoveredFetch = resolve
+  })
+  let fetchCalls = 0
+
+  const consumer = createConsumerMock(t, (options, callback) => {
+    fetchCalls++
+
+    if (fetchCalls !== 1) {
+      recoveredOffsets.push(options.topics[0].partitions[0].fetchOffset)
+      resolveRecoveredFetch()
+      return
+    }
+
+    const response: FetchResponse = {
+      throttleTimeMs: 0,
+      errorCode: 0,
+      sessionId: 0,
+      responses: [
+        {
+          topicId,
+          partitions: [
+            {
+              partitionIndex: 0,
+              errorCode: 1,
+              highWatermark: 3n,
+              lastStableOffset: 3n,
+              logStartOffset: -1n,
+              abortedTransactions: [],
+              preferredReadReplica: -1
+            }
+          ]
+        }
+      ]
+    }
+
+    callback(new ResponseError(1, 17, { '/responses/0/partitions/0': [1, null] }, response), undefined)
+  })
+
+  consumer.listOffsets = ((options: object, callback: CallbackWithPromise<any>) => {
+    listOffsetRequests.push(options)
+    callback(null, new Map([[topic, [5n]]]))
+  }) as typeof consumer.listOffsets
+
+  const stream = createStream(consumer)
+
+  stream.resume()
+  await recoveredFetch
+
+  strictEqual(recoveredOffsets[0], 5n)
+  strictEqual(listOffsetRequests.at(-1).timestamp, ListOffsetTimestamps.EARLIEST)
+  strictEqual(listOffsetRequests.at(-1).partitions[topic][0], 0)
 
   stream.destroy()
 })


### PR DESCRIPTION
# Fix OFFSET_OUT_OF_RANGE recovery when Fetch omits a usable reset offset

## Summary

This PR fixes a `MessagesStream` recovery path that can wedge a consumer after an `OFFSET_OUT_OF_RANGE` Fetch response.

`MessagesStream` already attempts to recover from out-of-range offsets by reseeking to the configured fallback offset:

- `fallbackMode='earliest'` uses the Fetch partition response's `logStartOffset`
- `fallbackMode='latest'` uses the Fetch partition response's `highWatermark`

That works when the Fetch response contains a usable non-negative offset. In practice, the Fetch partition response can report `logStartOffset: -1n` for an errored partition. When that happens, the current code stores `-1n` as the next fetch offset, immediately fetches an invalid offset again, receives another `OFFSET_OUT_OF_RANGE`, and can repeat indefinitely without surfacing a terminal stream error.

## Root Cause

The previous recovery logic trusted the Fetch response fallback offset unconditionally:

```ts
const offset =
  this.#fallbackMode === MessagesStreamFallbackModes.EARLIEST
    ? partitionResponse.logStartOffset
    : partitionResponse.highWatermark
recoveredOffsets.push([key, offset])
```

For `fallbackMode='earliest'`, a Fetch response with `logStartOffset: -1n` caused the stream to reseek to `-1n`. Since `-1n` is not a valid fetch offset for the partition, the next fetch could hit the same `OFFSET_OUT_OF_RANGE` path again.

## Fix

The recovery path now keeps the existing fast path when Fetch provides a valid non-negative fallback offset.

If the selected fallback offset is negative, `MessagesStream` performs a targeted `Consumer.listOffsets()` call for the affected topic partitions:

- `fallbackMode='earliest'` asks for `ListOffsetTimestamps.EARLIEST`
- `fallbackMode='latest'` asks for `ListOffsetTimestamps.LATEST`

It then applies the returned broker offsets to both `offsetsToFetch` and `offsetsCommitted`, preserving the existing recovery behavior after obtaining a valid reset point.

If `listOffsets()` fails, or if the broker still does not return a non-negative offset for the affected partition, the stream is destroyed with the recovery error instead of silently looping.

## Behavioral Impact

- Existing successful OOR recovery remains unchanged when Fetch includes usable offsets.
- Recovery now handles Fetch responses where the selected reset offset is negative.
- The Fetch error path is now callback-based because recovery may require a broker round trip.
- Non-OOR Fetch errors and `fallbackMode='fail'` still destroy the stream as before.

## Tests

Added a mock-only regression test in `test/clients/consumer/messages-stream-rebalance.test.ts`.

The test simulates:

1. A Fetch response with a partition-level `OFFSET_OUT_OF_RANGE`
2. `fallbackMode='earliest'`
3. `logStartOffset: -1n`
4. A follow-up `listOffsets()` response returning a valid earliest offset

It asserts that the next Fetch uses the refreshed offset rather than `-1n`, and that the refresh request targets the affected partition with `ListOffsetTimestamps.EARLIEST`.

## Downstream Reproducer Sample

The downstream integration case that originally exposed the issue is equivalent to this TC-044 flow. It commits offset `5`, deletes records before offset `8`, then restarts the same consumer group. The fixed client must recover from the broker-generated `OFFSET_OUT_OF_RANGE` by resetting to the refreshed earliest offset (`8`) and consuming the surviving records.

```ts
it.failing(
  'TC-044: recovers from OFFSET_OUT_OF_RANGE after broker trims past the committed offset',
  async () => {
    const topics = createTopics(expect.getState().currentTestName ?? 'tc044')
    const betaGroup = `${env.runId}-beta-tc044-group`
    const betaState = new BetaState('beta-tc044')
    const PARTITION = 0

    const alpha = await trackAlpha(
      startAlphaApp({
        topics,
        kafka: kafkaConfig(env, `${env.runId}-alpha-tc044`, `${env.runId}-alpha-tc044-group`),
        health
      })
    )

    let beta = await trackBeta(
      startBetaApp({
        topics,
        kafka: kafkaConfig(env, `${env.runId}-beta-tc044-1`, betaGroup),
        health,
        state: betaState
      })
    )
    await beta.app.waitForAssignments(topics.commandTopic)

    // Beta-1 consumes and commits offsets 0..4 on partition 0.
    const initialIds = Array.from({ length: 5 }, (_v, i) => `tc044-initial-${i}`)
    for (const [index, id] of initialIds.entries()) {
      await alpha.publisher.publishCommand({ id, payload: { sequence: index } }, PARTITION)
    }
    await waitForResponses(alpha.state, initialIds)

    await waitFor(
      async () => {
        const committed = await beta.app.committedOffsets(topics.commandTopic, [PARTITION])
        return (committed[0] ?? -1n) >= 5n
      },
      {
        description: 'partition 0 committed offset reached 5',
        intervalMs: 100,
        timeoutMs: 15_000
      }
    )

    // Stop Beta, produce offsets 5..9, then trim the log before offset 8.
    await closeTracked(beta.app)
    const trailingIds = Array.from({ length: 5 }, (_v, i) => `tc044-trailing-${i}`)
    for (const [index, id] of trailingIds.entries()) {
      await alpha.publisher.publishCommand({ id, payload: { sequence: 5 + index } }, PARTITION)
    }

    const newLogStart = await env.deleteRecordsBefore(topics.commandTopic, PARTITION, 8n)
    expect(newLogStart).toBe(8n)

    const postDeleteOffsets = await env.listPartitionOffsets(topics.commandTopic, PARTITION)
    expect(postDeleteOffsets.earliest).toBe(8n)
    expect(postDeleteOffsets.latest).toBe(10n)

    // Beta-2 rejoins with committed offset 5, which is now below log_start_offset.
    // It should recover via fallbackMode='earliest' and consume only offsets 8..9.
    beta = await trackBeta(
      startBetaApp({
        topics,
        kafka: kafkaConfig(env, `${env.runId}-beta-tc044-2`, betaGroup),
        health,
        state: betaState
      })
    )
    await beta.app.waitForAssignments(topics.commandTopic)

    const survivingIds = ['tc044-trailing-3', 'tc044-trailing-4']
    await waitForResponses(alpha.state, [...initialIds, ...survivingIds], 45_000)

    for (const trimmedId of ['tc044-trailing-0', 'tc044-trailing-1', 'tc044-trailing-2']) {
      expect(betaState.commandCount(trimmedId)).toBe(0)
    }
    for (const id of survivingIds) {
      expect(betaState.commandCount(id)).toBeGreaterThanOrEqual(1)
    }

    expect(beta.app.latestStatus).toBe(PlatformaticKafkaStatus.CONNECTED)
    await waitFor(
      async () => {
        const committed = await beta.app.committedOffsets(topics.commandTopic, [PARTITION])
        return (committed[0] ?? -1n) >= 10n
      },
      {
        description: 'partition 0 committed offset advanced past log-end',
        intervalMs: 200,
        timeoutMs: 15_000
      }
    )
  },
  180_000
)
```

## Local Verification

Completed with Node `v24.15.0`, which satisfies the package `engines` constraint:

```bash
PATH=/Users/ewert/.nvm/versions/node/v24.15.0/bin:$PATH ./scripts/node --test --test-reporter=cleaner-spec-reporter test/clients/consumer/messages-stream-rebalance.test.ts --test-name-pattern "offset out of range"
PATH=/Users/ewert/.nvm/versions/node/v24.15.0/bin:$PATH pnpm typecheck
PATH=/Users/ewert/.nvm/versions/node/v24.15.0/bin:$PATH pnpm exec eslint src/clients/consumer/messages-stream.ts test/clients/consumer/messages-stream-rebalance.test.ts
PATH=/Users/ewert/.nvm/versions/node/v24.15.0/bin:$PATH pnpm build
```

Full `pnpm test` verification requires the repository's Kafka docker-compose test stack.

Full suite result:

```bash
PATH=/Users/ewert/.nvm/versions/node/v24.15.0/bin:$PATH pnpm run test:docker:up
PATH=/Users/ewert/.nvm/versions/node/v24.15.0/bin:$PATH pnpm test
```

`pnpm test` passed with exit code 0 against the healthy docker-compose test stack.

Cross-repo validation against the original failing application scenario also passed. In `hupx-id-adapter`, I temporarily overlaid the installed `@platformatic/kafka@2.1.0` package `dist/` with this fork's built `dist/`, temporarily changed TC-044 from `it.failing` to `it.only`, and ran:

```bash
pnpm --filter @alteo-artemis/kafka-strategy-integration test:integration -- --runTestsByPath src/__tests__/kafka-strategy.integration.spec.ts
```

Result: `1 passed, 24 skipped`. The app worktree and installed package overlay were restored afterward.
