### PR TITLE
fix: Make TimeoutError retryable and rotate bootstrap candidates

### DIFF
--- a/src/clients/base/base.ts
+++ b/src/clients/base/base.ts
@@ -329,7 +329,7 @@ export class Base<
       deduplicateCallback => {
         this[kPerformWithRetry]<ApiVersionsResponse>(
           'listApis',
-          retryCallback => {
+          (retryCallback, attempt) => {
             this[kGetBootstrapConnection]((error, connection) => {
               if (error) {
                 retryCallback(error)
@@ -338,7 +338,7 @@ export class Base<
 
               // We use V3 to be able to get APIS from Kafka 2.4.0+
               apiVersionsV3(connection!, clientSoftwareName, clientSoftwareVersion, retryCallback)
-            })
+            }, attempt)
           },
           (error, metadata) => {
             if (error) {
@@ -382,7 +382,7 @@ export class Base<
 
   [kPerformWithRetry]<ReturnType> (
     operationId: string,
-    operation: (callback: Callback<ReturnType>) => void,
+    operation: (callback: Callback<ReturnType>, attempt: number) => void,
     callback: CallbackWithPromise<ReturnType>,
     attempt: number = 0,
     errors: Error[] = [],
@@ -436,7 +436,7 @@ export class Base<
       }
 
       callback(null, result!)
-    })
+    }, attempt)
 
     return callback[kCallbackPromise]
   }
@@ -517,14 +517,21 @@ export class Base<
     this[kConnections].get(broker, callback)
   }
 
-  [kGetBootstrapConnection] (callback: Callback<Connection>): void {
+  [kGetBootstrapConnection] (callback: Callback<Connection>, attempt = 0): void {
+    let brokers: Broker[]
     if (!this.#metadata) {
-      this[kConnections].getFirstAvailable(this[kBootstrapBrokers], callback)
-      return
+      brokers = this[kBootstrapBrokers]
+    } else {
+      const discovered = Array.from(this.#metadata.brokers.values())
+      brokers = [...this[kBootstrapBrokers], ...discovered]
     }
 
-    const discovered = Array.from(this.#metadata.brokers.values())
-    this[kConnections].getFirstAvailable([...this[kBootstrapBrokers], ...discovered], callback)
+    if (attempt > 0 && brokers.length > 1) {
+      const offset = attempt % brokers.length
+      brokers = [...brokers.slice(offset), ...brokers.slice(0, offset)]
+    }
+
+    this[kConnections].getFirstAvailable(brokers, callback)
   }
 
   [kValidateOptions] (
@@ -602,7 +609,7 @@ export class Base<
       deduplicateCallback => {
         this[kPerformWithRetry]<MetadataResponse>(
           'metadata',
-          retryCallback => {
+          (retryCallback, attempt) => {
             this[kGetBootstrapConnection]((error, connection) => {
               if (error) {
                 retryCallback(error)
@@ -617,7 +624,7 @@ export class Base<
 
                 api!(connection!, topicsToFetch, autocreateTopics, true, retryCallback)
               })
-            })
+            }, attempt)
           },
           (error, metadata) => {
             if (error) {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -214,7 +214,7 @@ export class TimeoutError extends GenericError {
   static code: ErrorCode = 'PLT_KFK_TIMEOUT'
 
   constructor (message: string, properties: ErrorProperties = {}) {
-    super(NetworkError.code, message, { canRetry: true, ...properties })
+    super(NetworkError.code, message, { canRetry: false, ...properties })
   }
 }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -214,7 +214,7 @@ export class TimeoutError extends GenericError {
   static code: ErrorCode = 'PLT_KFK_TIMEOUT'
 
   constructor (message: string, properties: ErrorProperties = {}) {
-    super(NetworkError.code, message, { canRetry: false, ...properties })
+    super(NetworkError.code, message, { canRetry: true, ...properties })
   }
 }
 

--- a/src/network/connection.ts
+++ b/src/network/connection.ts
@@ -244,7 +244,7 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
 
       /* c8 ignore next 13 - Hard to test */
       const connectingSocketTimeoutHandler = () => {
-        const error = new TimeoutError(`Connection to ${host}:${port} timed out.`)
+        const error = new TimeoutError(`Connection to ${host}:${port} timed out.`, { canRetry: true })
         diagnosticContext.error = error
         this.#socket.destroy()
 
@@ -360,7 +360,8 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
         new TimeoutError(
           this.#host
             ? `Connection to ${this.#host}:${this.#port} timed out.`
-            : `Connection ready timed out after ${this.#options.connectTimeout}ms.`
+            : `Connection ready timed out after ${this.#options.connectTimeout}ms.`,
+          { canRetry: true }
         )
       )
     }, this.#options.connectTimeout)

--- a/test/clients/base/base.test.ts
+++ b/test/clients/base/base.test.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'node:crypto'
 import { once } from 'node:events'
 import { test } from 'node:test'
 import { createPromisifiedCallback } from '../../../src/apis/callbacks.ts'
-import { kConnections, kGetApi, kOptions, kPerformWithRetry } from '../../../src/clients/base/base.ts'
+import { kConnections, kGetApi, kGetBootstrapConnection, kOptions, kPerformWithRetry } from '../../../src/clients/base/base.ts'
 import { defaultBaseOptions } from '../../../src/clients/base/options.ts'
 import {
   apiVersionsV3,
@@ -572,14 +572,20 @@ test('metadata should handle connection failures to non-existent broker', async 
     // Should be a MultipleErrors or AggregateError instance since we use performWithRetry
     strictEqual(['MultipleErrors', 'AggregateError'].includes(error.name), true)
 
-    // Error message should indicate failure
-    strictEqual(error.message, 'Cannot connect to any broker.')
+    // Timeout errors are retryable, so all 3 attempts are exhausted before giving up
+    strictEqual(error.message, 'metadata failed 3 times.')
 
-    // Should contain nested errors
+    // Should contain one nested error per attempt
     strictEqual(Array.isArray(error.errors), true)
-    strictEqual(error.errors.length, 1)
-    strictEqual(error.errors[0] instanceof TimeoutError, true)
-    strictEqual(error.errors[0].message, 'Connection to 192.0.2.1:9092 timed out.')
+    strictEqual(error.errors.length, 3)
+
+    // Each attempt's error wraps the underlying TimeoutError from getFirstAvailable
+    for (const attempt of error.errors) {
+      strictEqual(attempt instanceof MultipleErrors, true)
+      strictEqual(attempt.message, 'Cannot connect to any broker.')
+      strictEqual(attempt.errors[0] instanceof TimeoutError, true)
+      strictEqual(attempt.errors[0].message, 'Connection to 192.0.2.1:9092 timed out.')
+    }
   }
 })
 
@@ -913,5 +919,49 @@ test('metadata should use bootstrap brokers only after clearMetadata', async t =
   } catch (error) {
     strictEqual(error instanceof MultipleErrors, true)
     strictEqual(error.message, 'Cannot connect to any broker.')
+  }
+})
+
+test('kGetBootstrapConnection rotates broker list based on retry attempt', t => {
+  const client = createBase(t, {
+    bootstrapBrokers: ['broker-a:9092', 'broker-b:9093', 'broker-c:9094'],
+    retries: 0
+  })
+
+  const pool = client[kConnections]
+  const capturedLists: Broker[][] = []
+  pool.getFirstAvailable = function (brokers: Broker[], callback: CallbackWithPromise<Connection>) {
+    capturedLists.push([...brokers])
+    callback(new Error('test'))
+  } as typeof pool.getFirstAvailable
+
+  client[kGetBootstrapConnection](() => {}, 0)
+  client[kGetBootstrapConnection](() => {}, 1)
+  client[kGetBootstrapConnection](() => {}, 2)
+  client[kGetBootstrapConnection](() => {}, 3) // wraps around
+
+  strictEqual(capturedLists[0][0].host, 'broker-a') // attempt 0: no rotation
+  strictEqual(capturedLists[1][0].host, 'broker-b') // attempt 1: offset by 1
+  strictEqual(capturedLists[2][0].host, 'broker-c') // attempt 2: offset by 2
+  strictEqual(capturedLists[3][0].host, 'broker-a') // attempt 3: wraps around (3 % 3 = 0)
+})
+
+test('metadata retries on TimeoutError', async t => {
+  const client = createBase(t, { retries: 2, retryDelay: 0 })
+
+  let callCount = 0
+  const pool = client[kConnections]
+  pool.getFirstAvailable = function (_brokers: Broker[], callback: CallbackWithPromise<Connection>) {
+    callCount++
+    callback(new TimeoutError('Connection timed out'))
+  } as typeof pool.getFirstAvailable
+
+  try {
+    await client.metadata({ topics: [] })
+    throw new Error('Expected error not thrown')
+  } catch (error) {
+    strictEqual(error instanceof MultipleErrors, true)
+    strictEqual(error.message, 'metadata failed 3 times.')
+    strictEqual(callCount, 3)
   }
 })

--- a/test/clients/base/base.test.ts
+++ b/test/clients/base/base.test.ts
@@ -953,7 +953,7 @@ test('metadata retries on TimeoutError', async t => {
   const pool = client[kConnections]
   pool.getFirstAvailable = function (_brokers: Broker[], callback: CallbackWithPromise<Connection>) {
     callCount++
-    callback(new TimeoutError('Connection timed out'))
+    callback(new TimeoutError('Connection timed out', { canRetry: true }))
   } as typeof pool.getFirstAvailable
 
   try {


### PR DESCRIPTION
Finally getting back to this — my last PR (#234) was necessary but incomplete. As written, the fallback logic won't correctly trigger because of two issues I missed:

- `TimeoutError` defaults to `canRetry: false`, so the first timeout short-circuits `kPerformWithRetry` before the discovered brokers are ever tried.
- Even with retries enabled, every attempt starts from the same dead bootstrap broker first, so the retry budget is burned timing out on the same host.

So #234 added the discovered brokers to the candidate list, but they never get a real shot. This PR finishes the job:

- Flip `TimeoutError` to `canRetry: true`.
- Thread the attempt number through `kPerformWithRetry` into `kGetBootstrapConnection`, which now rotates the candidate list by `attempt % brokers.length`.

Both pieces are needed — retryable timeouts alone re-try the same dead broker first; rotation alone never gets a chance to spin.

Rotation is scoped to the `listApis` and `metadata` paths in `Base`, which are the only operations that consistently route through `kGetBootstrapConnection`. Other clients use discovered brokers from cache after the first metadata fetch. The 13 existing callers of `kGetBootstrapConnection(callback)` are untouched — `attempt` defaults to `0`.