### PR TITLE
Fix: Stop requesting topic authorized operations on metadata requests

### DIFF
--- a/src/clients/base/base.ts
+++ b/src/clients/base/base.ts
@@ -627,7 +627,13 @@ export class Base<
                   return
                 }
 
-                api!(connection!, topicsToFetch, autocreateTopics, true, retryCallback)
+                // includeTopicAuthorizedOperations: false. The response's
+                // topic_authorized_operations bitfield is parsed but never read
+                // by the producer/consumer, and requesting it makes IAM brokers
+                // (e.g. MSK) authorize every topic operation and emit a CloudTrail
+                // AccessDenied per denied op (CreateTopic/DeleteTopic/...) — pure
+                // audit-log noise for permissions the client never exercises.
+                api!(connection!, topicsToFetch, autocreateTopics, false, retryCallback)
               })
             }, attempt)
           },


### PR DESCRIPTION
## Summary
The base client (`Producer`/`Consumer`) hardcoded `includeTopicAuthorizedOperations = true` on every Metadata request. This flips it to `false`. The producer/consumer never read the authorized-operations data back, so we were asking brokers to compute it only to discard it.
Single-line change at `src/clients/base/base.ts` (the only metadata call site that passed `true`; the admin client already passes `false`):
```diff
- api!(connection!, topicsToFetch, autocreateTopics, true, retryCallback)
+ api!(connection!, topicsToFetch, autocreateTopics, false, retryCallback)
```
## Why
On IAM-authorizing brokers (Amazon MSK with IAM access control), `includeTopicAuthorizedOperations=true` forces the broker to authorize **every** topic operation (Describe/Read/Write/**Create**/**Delete**/Alter/…) just to populate the `topic_authorized_operations` bitfield in the response. Each operation the principal lacks is emitted to CloudTrail as a separate `AccessDenied` management event with `kafkaAPI: "Metadata"` — e.g. `CreateTopic` and `DeleteTopic` denials for a principal that never intends to create or delete anything.
Because the client refreshes metadata routinely (on connect, on send-error, on metadata-max-age expiry) across many service instances, this produces a high, continuous volume of CloudTrail events with real storage/ingestion cost — for permission checks the client never exercises.
This change eliminates those events **at the source**, for every service using the library, while leaving genuine admin actions (a real topic create/delete or ACL change) fully audited.
## What this does NOT change
- **Auto topic creation** (`autocreateTopics`) — untouched; still defaults to `false`.
- **Admin client** — already passed `false`; unchanged.
- **Produce/consume/commit behavior** — identical. No wire-version or protocol negotiation change.
## Risks
- **`topicAuthorizedOperations` in metadata responses is now a sentinel.** The field is still parsed (it's protocol-mandated in the v8–v12 response regardless of the request flag), but the broker returns the "not requested" sentinel instead of a real bitfield. **Mitigation:** verified by grep that nothing outside the *admin* APIs reads `authorizedOperations`, and the admin metadata call already uses `false`. Any future downstream code that inspects `metadata.topics.get(topic).topicAuthorizedOperations` would now get the sentinel — call it out in review if such a consumer is added.
- **Scope is all brokers, not just MSK.** Non-IAM brokers simply skip computing an unused bitfield (a negligible perf win); no functional impact since the field is unused on the data path.
## Testing
- `pnpm typecheck` passes (boolean → boolean; type-identical change).
- Existing `metadata-vN` request-builder unit tests are unaffected — they call `createRequest` with explicit arguments and don't assert what `base.ts` sends.
- Recommended post-merge validation: confirm produce/consume still work against a real cluster, and that the `Metadata`-triggered `CreateTopic`/`DeleteTopic` `AccessDenied` entries stop appearing in CloudTrail for the affected MSK principals.