### PR TITLE
Log whole error hierarchy for MultipleErrors

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -64,6 +64,10 @@ export class GenericError extends Error {
 
     return null
   }
+
+  toString () {
+    return `Error ${this.code}: ${this.message}`
+  }
 }
 
 export class MultipleErrors extends AggregateError {
@@ -128,6 +132,10 @@ export class MultipleErrors extends AggregateError {
     }
 
     return null
+  }
+
+  toString () {
+    return `Error ${this.code}: ${this.message} (caused by: ${this.errors.map(error => error.toString()).join(', ')})`
   }
 }
 

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -1,4 +1,4 @@
-import { deepStrictEqual, ok } from 'assert'
+import { deepStrictEqual, ok, strictEqual } from 'assert'
 import { test } from 'node:test'
 import {
   AuthenticationError,
@@ -133,6 +133,17 @@ test('MultipleErrors.findBy - recursively finds properties in nested errors', ()
 
   // Direct property of the outer error
   deepStrictEqual(outerError.findBy('outerProp', 'outer-value'), outerError)
+})
+
+test('MultipleErrors - conversion to string', () => {
+  const innerError1 = new GenericError('PLT_KFK_USER', 'inner error')
+  const innerError2 = new GenericError('PLT_KFK_NETWORK', 'another inner error')
+  const middleError = new MultipleErrors('middle errors', [innerError1, innerError2])
+  const outerError = new MultipleErrors('outer errors', [middleError])
+  strictEqual(
+    `${outerError}`,
+    'Error PLT_KFK_MULTIPLE: outer errors (caused by: Error PLT_KFK_MULTIPLE: middle errors (caused by: Error PLT_KFK_USER: inner error, Error PLT_KFK_NETWORK: another inner error))'
+  )
 })
 
 test('AuthenticationError', () => {


### PR DESCRIPTION
Currently, converting `MultipleErrors` to a string will drop all information about sub-errors. This PR overrides the toString method to print the whole error hierarchy.

On-behalf-of: @SAP ospo@sap.com