### PR TITLE
fix(consumer): forget removed partitions in incremental fetch sessions

### DIFF
--- a/src/clients/consumer/consumer.ts
+++ b/src/clients/consumer/consumer.ts
@@ -13,6 +13,7 @@ import {
 import {
   type FetchRequest,
   type FetchRequestForgottenTopicsData,
+  type FetchRequestPartition,
   type FetchRequestTopic,
   type FetchResponse
 } from '../../apis/consumer/fetch-v17.ts'
@@ -134,6 +135,15 @@ interface TopicPartition {
   partitions: number[]
 }
 
+interface FetchSession {
+  id: number
+  epoch: number
+  // Each stream fetches through its own connection pool: sessions cannot be shared across pools
+  pool: ConnectionPool
+  // The per-partition state the broker holds for this session, used to compute incremental requests
+  partitions: Map<string, Map<number, FetchRequestPartition>>
+}
+
 export interface ConsumerEvents extends BaseEvents {
   'consumer:group:join': (payload: ConsumerGroupJoinPayload) => void
   'consumer:group:leave': (payload: ConsumerGroupLeavePayload) => void
@@ -171,7 +181,7 @@ export class Consumer<Key = Buffer, Value = Buffer, HeaderKey = Buffer, HeaderVa
   #memberEpoch: number
   #groupRemoteAssignor: string | null
   #clientRack: string
-  #fetchSessions: Map<number, { id: number; epoch: number; partitions: Map<string, Set<number>> }>
+  #fetchSessions: Map<number, FetchSession>
   #preferredReadReplicas: Map<string, PreferredReadReplica>
   #streams: Set<MessagesStream<Key, Value, HeaderKey, HeaderValue>>
   #lagMonitoring: NodeJS.Timeout | null
@@ -880,33 +890,67 @@ export class Consumer<Key = Buffer, Value = Buffer, HeaderKey = Buffer, HeaderVa
                 retryCallback(error)
                 return
               }
-              const session = this.#fetchSessions.get(node)
+              let session = this.#fetchSessions.get(node)
+              if (session && session.pool !== pool) {
+                session = undefined
+              }
+
               const sessionId = session?.id ?? 0
               const sessionEpoch = session?.epoch ?? 0
 
-              const requestedPartitions = new Map<string, Set<number>>()
+              // The desired state of the session: options.topics always lists all the wanted partitions
+              const desired = new Map<string, Map<number, FetchRequestPartition>>()
               for (const topic of options.topics) {
-                let partitions = requestedPartitions.get(topic.topicId)
+                let partitions = desired.get(topic.topicId)
                 if (!partitions) {
-                  partitions = new Set()
-                  requestedPartitions.set(topic.topicId, partitions)
+                  partitions = new Map()
+                  desired.set(topic.topicId, partitions)
                 }
 
                 for (const partition of topic.partitions) {
-                  partitions.add(partition.partition)
+                  // Copy the partition since the data is mutated in the error paths
+                  partitions.set(partition.partition, { ...partition })
                 }
               }
 
-              // Ask the broker to remove from the incremental fetch session the partitions
-              // which are no longer requested, otherwise it keeps serving them forever (KIP-227)
+              let requestTopics = options.topics
               const forgottenTopicsData: FetchRequestForgottenTopicsData[] = []
+
               if (session) {
+                // Only send the partitions which are new or whose state changed: the broker
+                // keeps serving the unchanged ones from the session (KIP-227)
+                requestTopics = []
+                for (const [topicId, partitions] of desired) {
+                  const cached = session.partitions.get(topicId)
+                  const changed: FetchRequestPartition[] = []
+
+                  for (const partition of partitions.values()) {
+                    const previous = cached?.get(partition.partition)
+
+                    if (
+                      !previous ||
+                      previous.fetchOffset !== partition.fetchOffset ||
+                      previous.currentLeaderEpoch !== partition.currentLeaderEpoch ||
+                      previous.lastFetchedEpoch !== partition.lastFetchedEpoch ||
+                      previous.partitionMaxBytes !== partition.partitionMaxBytes
+                    ) {
+                      changed.push(partition)
+                    }
+                  }
+
+                  if (changed.length > 0) {
+                    requestTopics.push({ topicId, partitions: changed })
+                  }
+                }
+
+                // Ask the broker to remove from the session the partitions which are no
+                // longer wanted, otherwise it keeps serving them forever
                 for (const [topicId, partitions] of session.partitions) {
-                  const stillRequested = requestedPartitions.get(topicId)
+                  const stillDesired = desired.get(topicId)
                   const forgotten: number[] = []
 
-                  for (const partition of partitions) {
-                    if (!stillRequested?.has(partition)) {
+                  for (const partition of partitions.keys()) {
+                    if (!stillDesired?.has(partition)) {
                       forgotten.push(partition)
                     }
                   }
@@ -925,7 +969,7 @@ export class Consumer<Key = Buffer, Value = Buffer, HeaderKey = Buffer, HeaderVa
                 isolationLevel,
                 sessionId,
                 sessionEpoch,
-                options.topics,
+                requestTopics,
                 forgottenTopicsData,
                 this.#clientRack,
                 (error, result) => {
@@ -953,7 +997,7 @@ export class Consumer<Key = Buffer, Value = Buffer, HeaderKey = Buffer, HeaderVa
                     }
                   } else {
                     this.#updatePreferredReadReplicas(metadata!, topicIds, result!)
-                    this.#updateFetchSession(node, sessionEpoch, result!.sessionId, requestedPartitions)
+                    this.#updateFetchSession(node, pool, sessionEpoch, result!.sessionId, desired)
                   }
 
                   retryCallback(error, result)
@@ -982,21 +1026,23 @@ export class Consumer<Key = Buffer, Value = Buffer, HeaderKey = Buffer, HeaderVa
 
   #updateFetchSession (
     node: number,
+    pool: ConnectionPool,
     sentEpoch: number,
     responseSessionId: number,
-    requestedPartitions: Map<string, Set<number>>
+    desired: Map<string, Map<number, FetchRequestPartition>>
   ): void {
     if (!responseSessionId) {
       this.#fetchSessions.delete(node)
       return
     }
 
-    // After a successful incremental fetch the broker session contains exactly the
-    // requested partitions: previous ones were either re-requested or forgotten
+    // After a successful fetch the broker session contains exactly the desired partitions:
+    // unchanged ones already matched it, changed ones were sent and removed ones were forgotten
     this.#fetchSessions.set(node, {
       id: responseSessionId,
       epoch: nextFetchEpoch(sentEpoch),
-      partitions: requestedPartitions
+      pool,
+      partitions: desired
     })
   }
 

--- a/src/clients/consumer/consumer.ts
+++ b/src/clients/consumer/consumer.ts
@@ -10,7 +10,12 @@ import {
   type ConsumerGroupHeartbeatRequest,
   type ConsumerGroupHeartbeatResponse
 } from '../../apis/consumer/consumer-group-heartbeat-v1.ts'
-import { type FetchRequest, type FetchRequestTopic, type FetchResponse } from '../../apis/consumer/fetch-v17.ts'
+import {
+  type FetchRequest,
+  type FetchRequestForgottenTopicsData,
+  type FetchRequestTopic,
+  type FetchResponse
+} from '../../apis/consumer/fetch-v17.ts'
 import { type HeartbeatRequest, type HeartbeatResponse } from '../../apis/consumer/heartbeat-v4.ts'
 import {
   type JoinGroupRequest,
@@ -166,7 +171,7 @@ export class Consumer<Key = Buffer, Value = Buffer, HeaderKey = Buffer, HeaderVa
   #memberEpoch: number
   #groupRemoteAssignor: string | null
   #clientRack: string
-  #fetchSessions: Map<number, { id: number; epoch: number }>
+  #fetchSessions: Map<number, { id: number; epoch: number; partitions: Map<string, Set<number>> }>
   #preferredReadReplicas: Map<string, PreferredReadReplica>
   #streams: Set<MessagesStream<Key, Value, HeaderKey, HeaderValue>>
   #lagMonitoring: NodeJS.Timeout | null
@@ -879,6 +884,39 @@ export class Consumer<Key = Buffer, Value = Buffer, HeaderKey = Buffer, HeaderVa
               const sessionId = session?.id ?? 0
               const sessionEpoch = session?.epoch ?? 0
 
+              const requestedPartitions = new Map<string, Set<number>>()
+              for (const topic of options.topics) {
+                let partitions = requestedPartitions.get(topic.topicId)
+                if (!partitions) {
+                  partitions = new Set()
+                  requestedPartitions.set(topic.topicId, partitions)
+                }
+
+                for (const partition of topic.partitions) {
+                  partitions.add(partition.partition)
+                }
+              }
+
+              // Ask the broker to remove from the incremental fetch session the partitions
+              // which are no longer requested, otherwise it keeps serving them forever (KIP-227)
+              const forgottenTopicsData: FetchRequestForgottenTopicsData[] = []
+              if (session) {
+                for (const [topicId, partitions] of session.partitions) {
+                  const stillRequested = requestedPartitions.get(topicId)
+                  const forgotten: number[] = []
+
+                  for (const partition of partitions) {
+                    if (!stillRequested?.has(partition)) {
+                      forgotten.push(partition)
+                    }
+                  }
+
+                  if (forgotten.length > 0) {
+                    forgottenTopicsData.push({ topic: topicId, partitions: forgotten })
+                  }
+                }
+              }
+
               api!(
                 connection!,
                 options.maxWaitTime ?? this[kOptions].maxWaitTime!,
@@ -888,7 +926,7 @@ export class Consumer<Key = Buffer, Value = Buffer, HeaderKey = Buffer, HeaderVa
                 sessionId,
                 sessionEpoch,
                 options.topics,
-                [],
+                forgottenTopicsData,
                 this.#clientRack,
                 (error, result) => {
                   if (error) {
@@ -915,7 +953,7 @@ export class Consumer<Key = Buffer, Value = Buffer, HeaderKey = Buffer, HeaderVa
                     }
                   } else {
                     this.#updatePreferredReadReplicas(metadata!, topicIds, result!)
-                    this.#updateFetchSession(node, sessionEpoch, result!.sessionId)
+                    this.#updateFetchSession(node, sessionEpoch, result!.sessionId, requestedPartitions)
                   }
 
                   retryCallback(error, result)
@@ -942,13 +980,24 @@ export class Consumer<Key = Buffer, Value = Buffer, HeaderKey = Buffer, HeaderVa
     )
   }
 
-  #updateFetchSession (node: number, sentEpoch: number, responseSessionId: number): void {
+  #updateFetchSession (
+    node: number,
+    sentEpoch: number,
+    responseSessionId: number,
+    requestedPartitions: Map<string, Set<number>>
+  ): void {
     if (!responseSessionId) {
       this.#fetchSessions.delete(node)
       return
     }
 
-    this.#fetchSessions.set(node, { id: responseSessionId, epoch: nextFetchEpoch(sentEpoch) })
+    // After a successful incremental fetch the broker session contains exactly the
+    // requested partitions: previous ones were either re-requested or forgotten
+    this.#fetchSessions.set(node, {
+      id: responseSessionId,
+      epoch: nextFetchEpoch(sentEpoch),
+      partitions: requestedPartitions
+    })
   }
 
   #commit (options: CommitOptions, callback: CallbackWithPromise<void>, rejoinAttempts: number = 0): void {

--- a/src/clients/consumer/messages-stream.ts
+++ b/src/clients/consumer/messages-stream.ts
@@ -811,6 +811,12 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
       for (const { records: recordsBatches, partitionIndex: partition } of topicResponse.partitions) {
         const key = partitionKey(topic, partition)
 
+        // The broker can return partitions which were not requested when they linger
+        // in an incremental fetch session - their data is stale and must not rewind offsets
+        if (!requestedOffsets.has(key)) {
+          continue
+        }
+
         if (!recordsBatches) {
           continue
         }
@@ -1213,7 +1219,15 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
 
     // Create the pre-deserialization requests
     for (const topicResponse of response.responses) {
+      const topic = topicIds.get(topicResponse.topicId)!
+
       for (const { records: recordsBatches, partitionIndex: partition } of topicResponse.partitions) {
+        // The broker can return partitions which were not requested when they linger
+        // in an incremental fetch session - do not run hooks on their stale records
+        if (!requestedOffsets.has(partitionKey(topic, partition))) {
+          continue
+        }
+
         /* c8 ignore next 3 - Hard to test */
         if (!recordsBatches) {
           continue
@@ -1227,7 +1241,7 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
           }
 
           for (const message of batch.records as MessageToConsume[]) {
-            message.topic = topicIds.get(topicResponse.topicId)!
+            message.topic = topic
             message.partition = partition
 
             requests.push([message.key, 'key', message])

--- a/test/clients/consumer/consumer.test.ts
+++ b/test/clients/consumer/consumer.test.ts
@@ -1486,6 +1486,195 @@ test('fetch should send clientRack as the fetch rack id', async t => {
   strictEqual(requestRackId, clientRack)
 })
 
+test('fetch should reuse incremental fetch sessions and forget partitions no longer requested', async t => {
+  const topicId = '00000000-0000-0000-0000-000000000001'
+  const otherTopicId = '00000000-0000-0000-0000-000000000002'
+  const consumer = createConsumer(t)
+  const pool = consumer[kCreateConnectionPool]()
+  const connection = { instanceId: 1, send () {} }
+  const fetchRequests: {
+    sessionId: number
+    sessionEpoch: number
+    forgottenTopicsData: { topic: string; partitions: number[] }[]
+  }[] = []
+
+  t.after(() => pool.close())
+
+  mockMetadata(
+    consumer,
+    () => true,
+    null,
+    null,
+    (_original, _options, callback: CallbackWithPromise<unknown>) => {
+      callback(null, {
+        brokers: new Map([[0, { nodeId: 0, ...broker }]]),
+        topics: new Map()
+      })
+
+      return true
+    }
+  )
+  mockConnectionPoolGet(
+    pool,
+    () => true,
+    null,
+    null,
+    (_original, _broker, callback: CallbackWithPromise<unknown>) => {
+      callback(null, connection)
+      return true
+    }
+  )
+  mockMethod(consumer, kGetApi, () => true, null, null, (_original, _name, callback: CallbackWithPromise<unknown>) => {
+    const api = (
+      _connection: unknown,
+      _maxWaitMs: number,
+      _minBytes: number,
+      _maxBytes: number,
+      _isolationLevel: number,
+      sessionId: number,
+      sessionEpoch: number,
+      _topics: unknown,
+      forgottenTopicsData: { topic: string; partitions: number[] }[],
+      _rackId: string,
+      callback: CallbackWithPromise<FetchResponse>
+    ) => {
+      fetchRequests.push({ sessionId, sessionEpoch, forgottenTopicsData })
+      callback(null, { throttleTimeMs: 0, errorCode: 0, sessionId: 123, responses: [] })
+    }
+
+    callback(null, api)
+    return true
+  })
+
+  function fetchOptions (topics: [string, number[]][]) {
+    return {
+      connectionPool: pool,
+      node: 0,
+      topics: topics.map(([topicId, partitions]) => {
+        return {
+          topicId,
+          partitions: partitions.map(partition => {
+            return {
+              partition,
+              currentLeaderEpoch: 0,
+              fetchOffset: 0n,
+              lastFetchedEpoch: 0,
+              partitionMaxBytes: 1048576
+            }
+          })
+        }
+      })
+    }
+  }
+
+  await consumer.fetch(fetchOptions([[topicId, [0, 1]], [otherTopicId, [0]]]))
+  await consumer.fetch(fetchOptions([[topicId, [0]]]))
+  await consumer.fetch(fetchOptions([[topicId, [0]]]))
+
+  deepStrictEqual(fetchRequests, [
+    { sessionId: 0, sessionEpoch: 0, forgottenTopicsData: [] },
+    {
+      sessionId: 123,
+      sessionEpoch: 1,
+      forgottenTopicsData: [
+        { topic: topicId, partitions: [1] },
+        { topic: otherTopicId, partitions: [0] }
+      ]
+    },
+    { sessionId: 123, sessionEpoch: 2, forgottenTopicsData: [] }
+  ])
+})
+
+test('fetch should start a new session with no forgotten partitions when the broker drops the session', async t => {
+  const topicId = '00000000-0000-0000-0000-000000000001'
+  const consumer = createConsumer(t)
+  const pool = consumer[kCreateConnectionPool]()
+  const connection = { instanceId: 1, send () {} }
+  const fetchRequests: {
+    sessionId: number
+    sessionEpoch: number
+    forgottenTopicsData: { topic: string; partitions: number[] }[]
+  }[] = []
+
+  t.after(() => pool.close())
+
+  mockMetadata(
+    consumer,
+    () => true,
+    null,
+    null,
+    (_original, _options, callback: CallbackWithPromise<unknown>) => {
+      callback(null, {
+        brokers: new Map([[0, { nodeId: 0, ...broker }]]),
+        topics: new Map()
+      })
+
+      return true
+    }
+  )
+  mockConnectionPoolGet(
+    pool,
+    () => true,
+    null,
+    null,
+    (_original, _broker, callback: CallbackWithPromise<unknown>) => {
+      callback(null, connection)
+      return true
+    }
+  )
+  mockMethod(consumer, kGetApi, () => true, null, null, (_original, _name, callback: CallbackWithPromise<unknown>) => {
+    const api = (
+      _connection: unknown,
+      _maxWaitMs: number,
+      _minBytes: number,
+      _maxBytes: number,
+      _isolationLevel: number,
+      sessionId: number,
+      sessionEpoch: number,
+      _topics: unknown,
+      forgottenTopicsData: { topic: string; partitions: number[] }[],
+      _rackId: string,
+      callback: CallbackWithPromise<FetchResponse>
+    ) => {
+      fetchRequests.push({ sessionId, sessionEpoch, forgottenTopicsData })
+      // The broker never establishes a session
+      callback(null, { throttleTimeMs: 0, errorCode: 0, sessionId: 0, responses: [] })
+    }
+
+    callback(null, api)
+    return true
+  })
+
+  function fetchOptions (partitions: number[]) {
+    return {
+      connectionPool: pool,
+      node: 0,
+      topics: [
+        {
+          topicId,
+          partitions: partitions.map(partition => {
+            return {
+              partition,
+              currentLeaderEpoch: 0,
+              fetchOffset: 0n,
+              lastFetchedEpoch: 0,
+              partitionMaxBytes: 1048576
+            }
+          })
+        }
+      ]
+    }
+  }
+
+  await consumer.fetch(fetchOptions([0, 1]))
+  await consumer.fetch(fetchOptions([0]))
+
+  deepStrictEqual(fetchRequests, [
+    { sessionId: 0, sessionEpoch: 0, forgottenTopicsData: [] },
+    { sessionId: 0, sessionEpoch: 0, forgottenTopicsData: [] }
+  ])
+})
+
 test('fetch should route direct requests to cached preferred read replicas', async t => {
   const topic = 'test-topic'
   const topicId = '00000000-0000-0000-0000-000000000001'

--- a/test/clients/consumer/consumer.test.ts
+++ b/test/clients/consumer/consumer.test.ts
@@ -55,6 +55,7 @@ import {
   type ProducerOptions,
   ProtocolError,
   Reader,
+  ResponseError,
   type RecordsBatch,
   sleep,
   syncGroupV5,
@@ -1486,7 +1487,7 @@ test('fetch should send clientRack as the fetch rack id', async t => {
   strictEqual(requestRackId, clientRack)
 })
 
-test('fetch should reuse incremental fetch sessions and forget partitions no longer requested', async t => {
+test('fetch should send incremental fetch requests and forget partitions no longer requested', async t => {
   const topicId = '00000000-0000-0000-0000-000000000001'
   const otherTopicId = '00000000-0000-0000-0000-000000000002'
   const consumer = createConsumer(t)
@@ -1495,6 +1496,7 @@ test('fetch should reuse incremental fetch sessions and forget partitions no lon
   const fetchRequests: {
     sessionId: number
     sessionEpoch: number
+    topics: { topicId: string; partitions: string[] }[]
     forgottenTopicsData: { topic: string; partitions: number[] }[]
   }[] = []
 
@@ -1533,12 +1535,22 @@ test('fetch should reuse incremental fetch sessions and forget partitions no lon
       _isolationLevel: number,
       sessionId: number,
       sessionEpoch: number,
-      _topics: unknown,
+      topics: { topicId: string; partitions: { partition: number; fetchOffset: bigint }[] }[],
       forgottenTopicsData: { topic: string; partitions: number[] }[],
       _rackId: string,
       callback: CallbackWithPromise<FetchResponse>
     ) => {
-      fetchRequests.push({ sessionId, sessionEpoch, forgottenTopicsData })
+      fetchRequests.push({
+        sessionId,
+        sessionEpoch,
+        topics: topics.map(topic => {
+          return {
+            topicId: topic.topicId,
+            partitions: topic.partitions.map(partition => `${partition.partition}@${partition.fetchOffset}`)
+          }
+        }),
+        forgottenTopicsData
+      })
       callback(null, { throttleTimeMs: 0, errorCode: 0, sessionId: 123, responses: [] })
     }
 
@@ -1546,18 +1558,18 @@ test('fetch should reuse incremental fetch sessions and forget partitions no lon
     return true
   })
 
-  function fetchOptions (topics: [string, number[]][]) {
+  function fetchOptions (topics: [string, number[], bigint][]) {
     return {
       connectionPool: pool,
       node: 0,
-      topics: topics.map(([topicId, partitions]) => {
+      topics: topics.map(([topicId, partitions, fetchOffset]) => {
         return {
           topicId,
           partitions: partitions.map(partition => {
             return {
               partition,
               currentLeaderEpoch: 0,
-              fetchOffset: 0n,
+              fetchOffset,
               lastFetchedEpoch: 0,
               partitionMaxBytes: 1048576
             }
@@ -1567,21 +1579,233 @@ test('fetch should reuse incremental fetch sessions and forget partitions no lon
     }
   }
 
-  await consumer.fetch(fetchOptions([[topicId, [0, 1]], [otherTopicId, [0]]]))
-  await consumer.fetch(fetchOptions([[topicId, [0]]]))
-  await consumer.fetch(fetchOptions([[topicId, [0]]]))
+  // Full fetch establishing the session
+  await consumer.fetch(fetchOptions([[topicId, [0, 1], 0n], [otherTopicId, [0], 0n]]))
+  // Same state for partition 0, the others are dropped: only forgotten data is sent
+  await consumer.fetch(fetchOptions([[topicId, [0], 0n]]))
+  // The offset of partition 0 advanced: only that partition is sent
+  await consumer.fetch(fetchOptions([[topicId, [0], 5n]]))
+  // Nothing changed: the request is empty and just polls the session
+  await consumer.fetch(fetchOptions([[topicId, [0], 5n]]))
 
   deepStrictEqual(fetchRequests, [
-    { sessionId: 0, sessionEpoch: 0, forgottenTopicsData: [] },
+    {
+      sessionId: 0,
+      sessionEpoch: 0,
+      topics: [
+        { topicId, partitions: ['0@0', '1@0'] },
+        { topicId: otherTopicId, partitions: ['0@0'] }
+      ],
+      forgottenTopicsData: []
+    },
     {
       sessionId: 123,
       sessionEpoch: 1,
+      topics: [],
       forgottenTopicsData: [
         { topic: topicId, partitions: [1] },
         { topic: otherTopicId, partitions: [0] }
       ]
     },
-    { sessionId: 123, sessionEpoch: 2, forgottenTopicsData: [] }
+    {
+      sessionId: 123,
+      sessionEpoch: 2,
+      topics: [{ topicId, partitions: ['0@5'] }],
+      forgottenTopicsData: []
+    },
+    {
+      sessionId: 123,
+      sessionEpoch: 3,
+      topics: [],
+      forgottenTopicsData: []
+    }
+  ])
+})
+
+test('fetch should not share incremental fetch sessions across connection pools', async t => {
+  const topicId = '00000000-0000-0000-0000-000000000001'
+  const consumer = createConsumer(t)
+  const pool = consumer[kCreateConnectionPool]()
+  const otherPool = consumer[kCreateConnectionPool]()
+  const connection = { instanceId: 1, send () {} }
+  const fetchRequests: { sessionId: number; sessionEpoch: number; partitions: number }[] = []
+
+  t.after(() => pool.close())
+  t.after(() => otherPool.close())
+
+  mockMetadata(
+    consumer,
+    () => true,
+    null,
+    null,
+    (_original, _options, callback: CallbackWithPromise<unknown>) => {
+      callback(null, {
+        brokers: new Map([[0, { nodeId: 0, ...broker }]]),
+        topics: new Map()
+      })
+
+      return true
+    }
+  )
+
+  for (const target of [pool, otherPool]) {
+    mockConnectionPoolGet(
+      target,
+      () => true,
+      null,
+      null,
+      (_original, _broker, callback: CallbackWithPromise<unknown>) => {
+        callback(null, connection)
+        return true
+      }
+    )
+  }
+
+  mockMethod(consumer, kGetApi, () => true, null, null, (_original, _name, callback: CallbackWithPromise<unknown>) => {
+    const api = (
+      _connection: unknown,
+      _maxWaitMs: number,
+      _minBytes: number,
+      _maxBytes: number,
+      _isolationLevel: number,
+      sessionId: number,
+      sessionEpoch: number,
+      topics: { partitions: unknown[] }[],
+      _forgottenTopicsData: unknown[],
+      _rackId: string,
+      callback: CallbackWithPromise<FetchResponse>
+    ) => {
+      fetchRequests.push({ sessionId, sessionEpoch, partitions: topics.reduce((c, t) => c + t.partitions.length, 0) })
+      callback(null, { throttleTimeMs: 0, errorCode: 0, sessionId: 123, responses: [] })
+    }
+
+    callback(null, api)
+    return true
+  })
+
+  function fetchOptions (connectionPool: typeof pool) {
+    return {
+      connectionPool,
+      node: 0,
+      topics: [
+        {
+          topicId,
+          partitions: [
+            {
+              partition: 0,
+              currentLeaderEpoch: 0,
+              fetchOffset: 0n,
+              lastFetchedEpoch: 0,
+              partitionMaxBytes: 1048576
+            }
+          ]
+        }
+      ]
+    }
+  }
+
+  await consumer.fetch(fetchOptions(pool))
+  // A different pool must not reuse the session: full fetch with all partitions
+  await consumer.fetch(fetchOptions(otherPool))
+
+  deepStrictEqual(fetchRequests, [
+    { sessionId: 0, sessionEpoch: 0, partitions: 1 },
+    { sessionId: 0, sessionEpoch: 0, partitions: 1 }
+  ])
+})
+
+test('fetch should retry with a full fetch when the broker evicts the session', async t => {
+  const topicId = '00000000-0000-0000-0000-000000000001'
+  const consumer = createConsumer(t, { retryDelay: 0 })
+  const pool = consumer[kCreateConnectionPool]()
+  const connection = { instanceId: 1, send () {} }
+  const fetchRequests: { sessionId: number; sessionEpoch: number; partitions: number }[] = []
+
+  t.after(() => pool.close())
+
+  mockMetadata(
+    consumer,
+    () => true,
+    null,
+    null,
+    (_original, _options, callback: CallbackWithPromise<unknown>) => {
+      callback(null, {
+        brokers: new Map([[0, { nodeId: 0, ...broker }]]),
+        topics: new Map()
+      })
+
+      return true
+    }
+  )
+  mockConnectionPoolGet(
+    pool,
+    () => true,
+    null,
+    null,
+    (_original, _broker, callback: CallbackWithPromise<unknown>) => {
+      callback(null, connection)
+      return true
+    }
+  )
+  mockMethod(consumer, kGetApi, () => true, null, null, (_original, _name, callback: CallbackWithPromise<unknown>) => {
+    const api = (
+      _connection: unknown,
+      _maxWaitMs: number,
+      _minBytes: number,
+      _maxBytes: number,
+      _isolationLevel: number,
+      sessionId: number,
+      sessionEpoch: number,
+      topics: { partitions: unknown[] }[],
+      _forgottenTopicsData: unknown[],
+      _rackId: string,
+      callback: CallbackWithPromise<FetchResponse>
+    ) => {
+      fetchRequests.push({ sessionId, sessionEpoch, partitions: topics.reduce((c, t) => c + t.partitions.length, 0) })
+
+      // The broker evicted the session: fail the second request (the first incremental one)
+      if (fetchRequests.length === 2) {
+        const response = { throttleTimeMs: 0, errorCode: 70, sessionId: 0, responses: [] }
+        callback(new ResponseError(1, 17, { '': [70, null] }, response), undefined)
+        return
+      }
+
+      callback(null, { throttleTimeMs: 0, errorCode: 0, sessionId: 123, responses: [] })
+    }
+
+    callback(null, api)
+    return true
+  })
+
+  function fetchOptions () {
+    return {
+      connectionPool: pool,
+      node: 0,
+      topics: [
+        {
+          topicId,
+          partitions: [
+            {
+              partition: 0,
+              currentLeaderEpoch: 0,
+              fetchOffset: 0n,
+              lastFetchedEpoch: 0,
+              partitionMaxBytes: 1048576
+            }
+          ]
+        }
+      ]
+    }
+  }
+
+  await consumer.fetch(fetchOptions())
+  // The eviction error is retried transparently with a new full fetch
+  await consumer.fetch(fetchOptions())
+
+  deepStrictEqual(fetchRequests, [
+    { sessionId: 0, sessionEpoch: 0, partitions: 1 },
+    { sessionId: 123, sessionEpoch: 1, partitions: 0 },
+    { sessionId: 0, sessionEpoch: 0, partitions: 1 }
   ])
 })
 

--- a/test/clients/consumer/messages-stream-rebalance.test.ts
+++ b/test/clients/consumer/messages-stream-rebalance.test.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'node:events'
 import { test, type TestContext } from 'node:test'
 import type { CallbackWithPromise } from '../../../src/apis/callbacks.ts'
 import type { FetchRequestTopic, FetchResponse } from '../../../src/apis/consumer/fetch-v17.ts'
+import type { RecordsBatch } from '../../../src/protocol/records.ts'
 import { kConnections, kCreateConnectionPool, kGetApi, kOptions, kPrometheus } from '../../../src/clients/base/base.ts'
 import {
   type Consumer,
@@ -68,6 +69,34 @@ function createFetchResponse (preferredReadReplica: number): FetchResponse {
         ]
       }
     ]
+  }
+}
+
+function createRecordsBatch (firstOffset: bigint, values: string[]): RecordsBatch {
+  return {
+    firstOffset,
+    length: 0,
+    partitionLeaderEpoch: 0,
+    magic: 2,
+    crc: 0,
+    attributes: 0,
+    lastOffsetDelta: values.length - 1,
+    firstTimestamp: 0n,
+    maxTimestamp: 0n,
+    producerId: -1n,
+    producerEpoch: -1,
+    firstSequence: 0,
+    records: values.map((value, i) => {
+      return {
+        length: 0,
+        attributes: 0,
+        timestampDelta: 0n,
+        offsetDelta: i,
+        key: Buffer.from(`key-${i}`),
+        value: Buffer.from(value),
+        headers: []
+      }
+    })
   }
 }
 
@@ -261,6 +290,72 @@ test('should not fetch while offsets are refreshing after a group rejoin', async
   await new Promise(resolve => setTimeout(resolve, 70))
 
   strictEqual(consumer.metadataCalls > baselineMetadataCalls, true)
+
+  stream.destroy()
+})
+
+test('should ignore data for partitions which were not part of the fetch request', async t => {
+  const fetchedOffsets: bigint[] = []
+  let resolveSecondFetch!: () => void
+  const secondFetch = new Promise<void>(resolve => {
+    resolveSecondFetch = resolve
+  })
+
+  // The topic has two partitions led by the same broker, but only partition 0 is assigned:
+  // partition 1 simulates data lingering in the broker incremental fetch session after a rebalance
+  const metadata = createMetadata()
+  metadata.topics.get(topic)!.partitions.push({
+    leader: 1,
+    leaderEpoch: 0,
+    replicas: [1, 2],
+    isr: [1, 2],
+    offlineReplicas: []
+  })
+  metadata.topics.get(topic)!.partitionsCount = 2
+
+  const consumer = createConsumerMock(
+    t,
+    (options, callback) => {
+      fetchedOffsets.push(options.topics[0].partitions[0].fetchOffset)
+
+      if (fetchedOffsets.length === 1) {
+        const response = createFetchResponse(-1)
+        response.responses[0].partitions[0].records = [createRecordsBatch(0n, ['requested-0', 'requested-1'])]
+        response.responses[0].partitions.push({
+          partitionIndex: 1,
+          errorCode: 0,
+          highWatermark: 100n,
+          lastStableOffset: 100n,
+          logStartOffset: 0n,
+          abortedTransactions: [],
+          preferredReadReplica: -1,
+          records: [createRecordsBatch(40n, ['stale-0', 'stale-1'])]
+        })
+
+        callback(null, response)
+        return
+      }
+
+      resolveSecondFetch()
+    },
+    metadata
+  )
+
+  const stream = createStream(consumer)
+  const messages: { partition: number; value: Buffer }[] = []
+  stream.on('data', message => {
+    messages.push(message)
+  })
+
+  await secondFetch
+
+  strictEqual(messages.length, 2)
+  strictEqual(
+    messages.every(message => message.partition === 0),
+    true
+  )
+  strictEqual(stream.offsetsToFetch.get(`${topic}:1`), undefined)
+  strictEqual(fetchedOffsets[1], 2n)
 
   stream.destroy()
 })


### PR DESCRIPTION
## Summary

This PR fixes two defects in the KIP-227 incremental fetch session support introduced in #316 (v2.3.0), and then completes the KIP-227 implementation so the client gains the protocol's intended benefits.

### Commit 1 — fix issues introduced in kip-227 implementation

1. **Partitions were never removed from broker fetch sessions.** Every Fetch request hardcoded `forgottenTopicsData` to `[]`. When a partition moved away from a consumer (rebalance, rolling deploy, preferred-replica change), it remained in the broker-side incremental session, and per the Kafka protocol the broker kept serving that partition's data from a frozen offset in every subsequent fetch response — forever. With low `minBytes` this becomes a hot loop re-downloading the same bytes.
2. **The client ingested the stale data.** In `MessagesStream#pushRecords`, the duplicate guard `offset < requestedOffsets.get(key)` compares against `undefined` for partitions that were not in the request, fails open, and pushes the stale records to handlers. The offset-tracking block also ran unconditionally, rewinding `#offsetsToFetch`/`#offsetsToCommit` and dragging commits backwards.

The fix tracks the partitions each broker session contains, sends the difference as `forgottenTopicsData`, and makes the stream drop response partitions that were not part of the request before any offset tracking.

### Commit 2 — send truly incremental fetch requests

Previously the client re-sent the full topic/partition list in every request, using sessions only for forget semantics and response-side savings. Now `Consumer#fetch` treats `options.topics` as the caller's *desired* session state and diffs it against the per-partition state the broker session holds:

- Only **new or changed** partitions (fetch offset, leader epochs, or `partitionMaxBytes` differ) are sent on the wire.
- Removed partitions are sent in `forgottenTopicsData`.
- An unchanged steady state sends an **empty request** that just polls the session — idle partitions cost nothing per fetch.

Sessions are also **scoped to the originating connection pool**. Each `MessagesStream` fetches through its own pool, so two streams on one consumer would otherwise fight over a node-keyed session, forgetting each other's partitions on every fetch. A pool mismatch now falls back to a full sessionless fetch (the pre-2.3.0 behavior) for that request.

`MessagesStream` needed no changes for this: it still declares its full desired set per node, so the stale-data guard remains correct even when the broker returns data for partitions omitted from the wire request — which is now a legitimate, expected case.

## Why

Observed in production after upgrading 2.2.3 → 2.3.0: a rolling deploy of a consumer group moved partitions between members, and broker bytes-out spiked 10–40x while bytes-in was unchanged — each member kept receiving frozen-offset data for partitions it no longer owned, and per-partition committed offsets intermittently jumped backwards. Reverting to 2.2.3 (sessionless fetches) restored baseline instantly.

With the defects fixed, completing the incremental side delivers what KIP-227 is for: steady-state fetch requests shrink to only what changed, and brokers skip re-validating unchanged partition lists. The benefit scales with partition count and is largest for consumers with many idle partitions.

## Risks

- **Empty incremental requests** are new behavior (previously every request carried the full list). Verified against a real broker that an empty request still long-polls the session and delivers newly arrived data for cached partitions.
- **Session-contents bookkeeping assumes one fetch at a time per node per pool.** `MessagesStream` guarantees this via `#inflightNodes`; direct concurrent `consumer.fetch()` calls to the same node already break the session epoch today and recover through the existing `INVALID_FETCH_SESSION_EPOCH` / `FETCH_SESSION_ID_NOT_FOUND` reset paths, which also clear the tracked state.
- **Lost responses** (request applied broker-side, response never seen) desynchronize the client's session record; the next request then fails with a session error, resets, and retries as a full fetch — same recovery the Java client relies on.
- **Pool-scoped sessions** mean a consumer alternating fetches to one node from different pools degrades to sessionless full fetches (correct, just unoptimized) instead of sharing a session.
- Dropping unrequested partitions in `#pushRecords` is intentionally strict: with the stream declaring its full desired set, any partition outside it is stale by construction.

## Tests

Unit (all fail without their respective fix):

- `fetch should send incremental fetch requests and forget partitions no longer requested` — asserts the exact wire sequence: full fetch → forget-only → changed-partition-only → empty poll, with session id/epoch reuse across two topics
- `fetch should not share incremental fetch sessions across connection pools` — second pool gets a full sessionless fetch
- `fetch should start a new session with no forgotten partitions when the broker drops the session` — full-fetch fallback on `sessionId: 0`
- `should ignore data for partitions which were not part of the fetch request` — stale partition records are not emitted, offsets are not rewound

### Before / after (real broker)

| Scenario | Before | After |
|---|---|---|
| Partition moves away from consumer | Broker re-serves it from a frozen offset on **every** fetch, forever | Forgotten on the next request, never served again |
| Steady state, no offset changes | Full partition list sent every request | Empty request polls the session |
| New data on an idle (omitted) partition | n/a (always sent) | Delivered from the broker-side session |
| Partition re-added after forget | n/a | Served again from the requested offset |

Suites against the Docker cluster: 151/151 `consumer.test.ts`, 71/71 messages-stream / rebalance / autocommit / backpressure / group-protocol, lint and build clean. Memory test (sustained backpressure, 3-broker cluster) shows stable heap.