### PR TITLE
fix: call deduplicateCallback on topics deletion error

### DIFF
--- a/src/clients/admin/admin.ts
+++ b/src/clients/admin/admin.ts
@@ -1125,7 +1125,7 @@ export class Admin extends Base<AdminOptions> {
           },
           (error, response) => {
             if (error) {
-              callback(new MultipleErrors('Deleting topics failed.', [error]))
+              deduplicateCallback(new MultipleErrors('Deleting topics failed.', [error]))
               return
             }
 

--- a/test/clients/admin/admin.test.ts
+++ b/test/clients/admin/admin.test.ts
@@ -1112,6 +1112,33 @@ test('deleteTopics should handle unavailable API errors', async t => {
   }
 })
 
+test('deleteTopics should clear its deduplication cache after a failure', async t => {
+  const admin = createAdmin(t)
+
+  // Force every connection attempt to fail so deleteTopics goes through its error path.
+  mockConnectionPoolGetFirstAvailable(admin[kConnections], () => true)
+
+  // First attempt fails as expected.
+  try {
+    await admin.deleteTopics({ topics: ['test-topic'] })
+    throw new Error('Expected error not thrown')
+  } catch (error) {
+    strictEqual(error instanceof MultipleErrors, true)
+    strictEqual(error.message, 'Deleting topics failed.')
+  }
+
+  // Regression: a previous failure must not leave a stale entry in the deduplication
+  // cache, otherwise a subsequent deletion of the same topics would be queued forever
+  // and never resolve. The second attempt must also reject rather than hang.
+  try {
+    await admin.deleteTopics({ topics: ['test-topic'] })
+    throw new Error('Expected error not thrown')
+  } catch (error) {
+    strictEqual(error instanceof MultipleErrors, true)
+    strictEqual(error.message, 'Deleting topics failed.')
+  }
+})
+
 test('createPartitions should create additional partitions with manual assignments', async t => {
   const admin = createAdmin(t)
   const topicName = `test-topic-${randomUUID()}`


### PR DESCRIPTION
## What

Fix the error path of `Admin#deleteTopics` to call `deduplicateCallback` instead of the raw `callback`.

## Why

On error, `#deleteTopics` invoked the outer `callback` directly and never called `deduplicateCallback`. Because `kPerformDeduplicated` only clears its in-flight entry (and flushes queued callers) when that completion callback fires, a failed `deleteTopics` left a stale entry in the deduplication cache. As a result, any subsequent `deleteTopics` for the same topic set on the same `Admin` instance would be queued forever and never resolve — and concurrent duplicate callers would hang on the first failure too.

A common trigger is deleting a non-existent topic (e.g. test cleanup): the first call errors and poisons the cache, so every later call hangs.

This aligns `#deleteTopics` with `#createTopics`, which already calls `deduplicateCallback(new MultipleErrors(...))` on error.

## Consequences

- Dedup cache is reset on failure, so retries/subsequent calls work instead of hanging.
- All deduplicated callers reject with the same error rather than hanging.
- Single-call error output is unchanged (`MultipleErrors('Deleting topics failed.', [error])`); existing tests still pass.

## Test

Adds a regression test asserting that a second `deleteTopics` for the same topics still rejects (rather than hangs) after a prior failure.