### PR TITLE
fix(admin): allow configs in createTopics options schema

### DIFF
--- a/src/clients/admin/options.ts
+++ b/src/clients/admin/options.ts
@@ -59,7 +59,19 @@ export const createTopicOptionsSchema = {
     },
     partitions: { type: 'number' },
     replicas: { type: 'number' },
-    assignments: createTopicAssignmentsSchema
+    assignments: createTopicAssignmentsSchema,
+    configs: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          value: { type: ['string', 'null'] }
+        },
+        required: ['name'],
+        additionalProperties: false
+      }
+    }
   },
   required: ['topics'],
   additionalProperties: false

--- a/test/clients/admin/admin.test.ts
+++ b/test/clients/admin/admin.test.ts
@@ -875,6 +875,15 @@ test('createTopics should validate options in strict mode', async t => {
   } catch (error) {
     strictEqual(error.message.includes('topics'), true)
   }
+
+  // Test with invalid configs type
+  try {
+    // @ts-expect-error - Intentionally passing invalid options
+    await admin.createTopics({ topics: ['test-topic'], configs: 'not-an-array' })
+    throw new Error('Expected error not thrown')
+  } catch (error) {
+    strictEqual(error.message.includes('configs'), true)
+  }
 })
 
 test('createTopics should accept a per-topic override object in strict mode', async t => {
@@ -893,6 +902,22 @@ test('createTopics should accept a per-topic override object in strict mode', as
   })
 
   strictEqual(created[0].name, topicName)
+
+  // Clean up
+  await admin.deleteTopics({ topics: [topicName] })
+})
+
+test('createTopics should accept the configs option in strict mode', async t => {
+  const admin = createAdmin(t, { strict: true })
+
+  const topicName = `test-topic-${randomUUID()}`
+
+  const created = await admin.createTopics({
+    topics: [topicName],
+    configs: [{ name: 'cleanup.policy', value: 'compact' }]
+  })
+
+  strictEqual(created[0].configuration['cleanup.policy'], 'compact')
 
   // Clean up
   await admin.deleteTopics({ topics: [topicName] })


### PR DESCRIPTION
## Summary

`CreateTopicsOptions.configs` is a real, documented, tested field — the "createTopics with custom configuration" test in `test/clients/admin/admin.test.ts` already exercises it. But `createTopicOptionsSchema` in `src/clients/admin/options.ts` never declared `configs` as a valid property, and the schema has `additionalProperties: false`.

This went unnoticed because `[kValidateOptions]` (in `src/clients/base/base.ts`) skips validation entirely unless the client is created with `{ strict: true }`. So `configs` silently worked for everyone *except* strict-mode users, for whom it fails with:

```
must NOT have additional properties (configs)
```

`configs` support was added in #75; the schema update was apparently missed at the time.

## Changes

- `src/clients/admin/options.ts`: add the missing `configs` property to `createTopicOptionsSchema`, matching the shape already used for `CreateTopicsRequestTopicConfig` (`name`, optional `value`).
- `test/clients/admin/admin.test.ts`: strict-mode regression test asserting `configs` is accepted and applied, plus a validation test for an invalid `configs` type.

## Context

Found this while working on #327 (per-topic overrides for `createTopics`) — kept it out of that PR since it's an unrelated, pre-existing bug, and opened this as a separate fix.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck` (no new errors; two pre-existing unrelated failures on `main`)
- [x] `test/clients/admin/admin.test.ts` — 168/168 passing against a local Kafka cluster
- [x] `options.ts` — 100% line/branch/function coverage
