### PR TITLE
fix: Added AJV options for schema registry.

### DIFF
--- a/docs/confluent-schema-registry.md
+++ b/docs/confluent-schema-registry.md
@@ -35,15 +35,16 @@ Creates a new schema registry instance with type `ConfluentSchemaRegistry<Key, V
 
 Options:
 
-| Property             | Type                           | Required | Description                                              |
-| -------------------- | ------------------------------ | -------- | -------------------------------------------------------- |
-| `url`                | `string`                       | Yes      | URL of the Confluent Schema Registry                     |
-| `auth`               | `object`                       | No       | Authentication configuration                             |
-| `auth.username`      | `string \| CredentialProvider` | No       | Username for Basic authentication                        |
-| `auth.password`      | `string \| CredentialProvider` | No       | Password for Basic authentication                        |
-| `auth.token`         | `string \| CredentialProvider` | No       | Token for Bearer authentication                          |
-| `protobufTypeMapper` | `function`                     | No       | Custom type mapper for Protocol Buffers                  |
-| `jsonValidateSend`   | `boolean`                      | No       | Enable JSON schema validation on send (default: `false`) |
+| Property             | Type                           | Required | Description                                                                  |
+| -------------------- | ------------------------------ | -------- | ---------------------------------------------------------------------------- |
+| `url`                | `string`                       | Yes      | URL of the Confluent Schema Registry                                         |
+| `auth`               | `object`                       | No       | Authentication configuration                                                 |
+| `auth.username`      | `string \| CredentialProvider` | No       | Username for Basic authentication                                            |
+| `auth.password`      | `string \| CredentialProvider` | No       | Password for Basic authentication                                            |
+| `auth.token`         | `string \| CredentialProvider` | No       | Token for Bearer authentication                                              |
+| `protobufTypeMapper` | `function`                     | No       | Custom type mapper for Protocol Buffers                                      |
+| `jsonValidateSend`   | `boolean`                      | No       | Enable JSON schema validation on send (default: `false`)                     |
+| `jsonAjvOptions`     | `object`                       | No       | AJV options for JSON schemas. Defaults to `{ allErrors: true, coerceTypes: false, strict: true }` |
 
 ## Basic Usage
 
@@ -130,6 +131,17 @@ await producer.send({
       }
     }
   ]
+})
+```
+
+Set `jsonAjvOptions.strict` to `false` if the registry contains JSON schemas with non-standard keywords:
+
+```typescript
+const registry = new ConfluentSchemaRegistry({
+  url: 'http://localhost:8081',
+  jsonAjvOptions: {
+    strict: false
+  }
 })
 ```
 

--- a/src/registries/confluent-schema-registry.ts
+++ b/src/registries/confluent-schema-registry.ts
@@ -1,4 +1,5 @@
-import { type ValidateFunction } from 'ajv'
+import { type Options, type ValidateFunction } from 'ajv'
+import { Ajv2020 } from 'ajv/dist/2020.js'
 import avro, { type Type } from 'avsc'
 import { createRequire } from 'node:module'
 import { type parse, type Root } from 'protobufjs'
@@ -16,7 +17,7 @@ import {
   stringDeserializer,
   stringSerializer
 } from '../clients/serde.ts'
-import { ajv, type CredentialProvider, EMPTY_BUFFER, UnsupportedFormatError, UserError } from '../index.ts'
+import { type CredentialProvider, EMPTY_BUFFER, UnsupportedFormatError, UserError } from '../index.ts'
 import { type MessageToConsume, type MessageToProduce } from '../protocol/records.ts'
 import { getCredential } from '../protocol/sasl/utils.ts'
 import { AbstractSchemaRegistry } from './abstract.ts'
@@ -44,6 +45,7 @@ export interface ConfluentSchemaRegistryOptions {
   }
   protobufTypeMapper?: ConfluentSchemaRegistryProtobufTypeMapper
   jsonValidateSend?: boolean
+  jsonAjvOptions?: Options
 }
 
 export interface Schema {
@@ -74,6 +76,7 @@ export class ConfluentSchemaRegistry<
   #protobufParse: typeof parse | undefined
   #protobufTypeMapper: ConfluentSchemaRegistryProtobufTypeMapper
   #jsonValidateSend: boolean
+  #jsonAjv: Ajv2020
   #auth: ConfluentSchemaRegistryOptions['auth'] | undefined
 
   constructor (options: ConfluentSchemaRegistryOptions) {
@@ -82,6 +85,7 @@ export class ConfluentSchemaRegistry<
     this.#schemas = new Map()
     this.#protobufTypeMapper = options.protobufTypeMapper ?? defaultProtobufTypeMapper
     this.#jsonValidateSend = options.jsonValidateSend ?? false
+    this.#jsonAjv = new Ajv2020({ allErrors: true, coerceTypes: false, strict: true, ...options.jsonAjvOptions })
     this.#auth = options.auth
   }
 
@@ -148,7 +152,7 @@ export class ConfluentSchemaRegistry<
           this.#schemas.set(id, { id, type: 'protobuf', schema: this.#protobufParse!(schema).root })
           break
         case 'JSON':
-          this.#schemas.set(id, { id, type: 'json', schema: ajv.compile(JSON.parse(schema)) })
+          this.#schemas.set(id, { id, type: 'json', schema: this.#jsonAjv.compile(JSON.parse(schema)) })
           break
       }
 
@@ -278,7 +282,7 @@ export class ConfluentSchemaRegistry<
           const valid = validate(data)
           if (!valid) {
             throw new UserError(
-              `JSON Schema validation failed before serialization: ${ajv.errorsText(validate.errors)}`,
+              `JSON Schema validation failed before serialization: ${this.#jsonAjv.errorsText(validate.errors)}`,
               { type, data, headers, validationErrors: validate.errors }
             )
           }
@@ -337,7 +341,7 @@ export class ConfluentSchemaRegistry<
 
         if (!valid) {
           throw new UserError(
-            `JSON Schema validation failed before deserialization: ${ajv.errorsText(validate.errors)}`,
+            `JSON Schema validation failed before deserialization: ${this.#jsonAjv.errorsText(validate.errors)}`,
             { type, data: parsed, headers, validationErrors: validate.errors }
           )
         }

--- a/test/registries/confluent-schema-registry.test.ts
+++ b/test/registries/confluent-schema-registry.test.ts
@@ -1,4 +1,4 @@
-import { deepStrictEqual, strictEqual } from 'node:assert'
+import { deepStrictEqual, match, strictEqual } from 'node:assert'
 import { randomUUID } from 'node:crypto'
 import test from 'node:test'
 import { UserError } from '../../src/errors.ts'
@@ -308,6 +308,70 @@ test('supports producing and consuming messages using Confluent Schema Registry 
     deepStrictEqual(structuredClone(messages[0].value), { id: 1, name: 'Alice' })
     deepStrictEqual(structuredClone(messages[1].value), { id: 2, name: 'Bob' })
   }
+})
+
+test('uses strict AJV validation for JSON schemas by default', async () => {
+  const subject = createSubject()
+  const schemaId = await registerSchema(
+    confluentSchemaRegistryUrl,
+    subject,
+    'JSON',
+    JSON.stringify({
+      type: 'object',
+      properties: {
+        id: { type: 'integer', 'x-extension': true }
+      }
+    })
+  )
+
+  const registry = new ConfluentSchemaRegistry<string, Datum, string, string>({
+    url: confluentSchemaRegistryUrl
+  })
+
+  const error = await new Promise<Error | undefined>(resolve => {
+    registry.fetchSchema(schemaId, err => {
+      resolve(err as Error | undefined)
+    })
+  })
+
+  strictEqual(error instanceof Error, true)
+  match(error!.message, /unknown keyword: "x-extension"/)
+})
+
+test('supports disabling strict AJV validation for JSON schemas', async () => {
+  const subject = createSubject()
+  const schemaId = await registerSchema(
+    confluentSchemaRegistryUrl,
+    subject,
+    'JSON',
+    JSON.stringify({
+      type: 'object',
+      properties: {
+        id: { type: 'integer', 'x-extension': true }
+      },
+      required: ['id']
+    })
+  )
+
+  const registry = new ConfluentSchemaRegistry<string, Datum, string, string>({
+    url: confluentSchemaRegistryUrl,
+    jsonAjvOptions: { strict: false }
+  })
+
+  const error = await new Promise<Error | undefined>(resolve => {
+    registry.fetchSchema(schemaId, err => {
+      resolve(err as Error | undefined)
+    })
+  })
+
+  strictEqual(error, undefined)
+
+  const schema = registry.get(schemaId)
+  strictEqual(schema?.type, 'json')
+
+  const validate = schema!.schema as (data: unknown) => boolean
+  strictEqual(validate({ id: 1 }), true)
+  strictEqual(validate({}), false)
 })
 
 test('fails on JSON schema validation when producing', async t => {


### PR DESCRIPTION
## Summary

Added configurable AJV options for Confluent Schema Registry JSON schemas.

This keeps strict AJV validation enabled by default, while allowing users to disable it for registries that include non-standard JSON Schema keywords such as `x-extension`.

## Changes

- Added `jsonAjvOptions` to `ConfluentSchemaRegistryOptions`.
- Switched JSON Schema Registry compilation to a registry-local `Ajv2020` instance.
- Preserved the existing default AJV behavior with `strict: true`.
- Added tests for default strict behavior and `strict: false`.
- Documented `jsonAjvOptions` in the Confluent Schema Registry guide.

Fixes #328
Assisted-By: OpenAI:GPT-5.5 <openai/gpt-5.5>