### PR TITLE
feat: Add deserialization error handler

### DIFF
--- a/docs/confluent-schema-registry.md
+++ b/docs/confluent-schema-registry.md
@@ -283,3 +283,5 @@ JSON schemas are validated using AJV:
   "schema": "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"number\"},\"name\":{\"type\":\"string\"}},\"required\":[\"id\",\"name\"]}"
 }
 ```
+
+JSON validation failures produce a `SchemaValidationError`, which extends `UserError`. The error is passed directly to `onDeserializationError`. When serialization or deserialization fails the operation instead, its outer `UserError` exposes the `SchemaValidationError` as `cause`. The validation error includes `schemaId`, `schemaType`, `phase`, `payloadType`, the decoded `data`, and AJV `validationErrors` so applications can distinguish schema-invalid data from malformed JSON.

--- a/docs/consumer.md
+++ b/docs/consumer.md
@@ -132,13 +132,46 @@ Options:
 | `mode`               | `string`                        | `LATEST` | Where to start fetching new messages.<br/><br/> The valid values are defined in the `MessagesStreamModes` enumeration (see below).                                                                                                                                                                                                             |
 | `fallbackMode`       | `string`                        | `LATEST` | Where to start fetching new messages when offset information is lacking for the consumer group.<br/><br/> The valid values are defined in the `MessagesStreamFallbackModes` enumeration (see below).                                                                                                                                           |
 | `maxFetches`         | `number`                        | `0`      | The maximum number of fetches to perform on each partition before automatically closing the stream. Setting to zero will disable automating closing. <br/><br/>Note that [`Array.fromAsync`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/fromAsync) can be used to create an array out of a stream. |
-| `offsets`            | `TopicWithPartitionAndOffset[]` |          | When manual offset mode is specified, a list of topic-partition-offset triplets.                                                                                                                                                                                                                                                               |
-| `onCorruptedMessage` | `CorruptedMessageHandler`       |          | A callback that will be invoked if a deserialiser throws. The original thrown value is passed unchanged as the final `error` argument and is typed as `unknown`. If the function returns `true`, then the stream will throw an error and thus it will be destroyed. Note that the stream will not wait for the `commit` function to finish so make sure you handle callbacks and promises accordingly. |
-| `context`            | `unknown`                       |          | Opaque user data for the created `MessagesStream`. It is forwarded to the stream-owned `ConnectionPool` and `Connection` instances. Kafka never reads, mutates, or interprets this value. When provided, it overrides the consumer constructor `streamContext` for that stream.                                                                |
+| `offsets`                | `TopicWithPartitionAndOffset[]` |          | When manual offset mode is specified, a list of topic-partition-offset triplets.                                                                                                                                                                                                                                                               |
+| `onDeserializationError` | `DeserializationErrorHandler`   |          | A callback invoked if a deserialiser throws. It receives a context object containing the original thrown value, payload type, raw record, actual offset and timestamp, and commit function. Return `DeserializationErrorActions.SKIP` to continue or `DeserializationErrorActions.FAIL` to destroy the stream.                                                                                           |
+| `onCorruptedMessage`     | `CorruptedMessageHandler`       |          | **Deprecated:** Use `onDeserializationError` instead. A callback that will be invoked if a deserialiser throws. The original thrown value is passed unchanged as the final `error` argument and is typed as `unknown`. If the function returns `true`, then the stream will throw an error and thus it will be destroyed. Note that the stream will not wait for the `commit` function to finish so make sure you handle callbacks and promises accordingly. |
+| `context`                | `unknown`                       |          | Opaque user data for the created `MessagesStream`. It is forwarded to the stream-owned `ConnectionPool` and `Connection` instances. Kafka never reads, mutates, or interprets this value. When provided, it overrides the consumer constructor `streamContext` for that stream.                                                                |
 
 It also accepts all options of the constructor except `deserializers` and `groupId`.
 
 For `consume()`, `maxBytesPerPartition` controls the per-partition fetch limit used by the created `MessagesStream`. If omitted, it uses the consumer constructor `maxBytesPerPartition`; if that is also omitted, it uses the effective `maxBytes` value for the `consume()` call.
+
+### Handling deserialization errors
+
+Use `onDeserializationError` to inspect a failed deserialisation and decide whether to skip the record or fail the stream:
+
+```typescript
+import {
+  DeserializationErrorActions,
+  SchemaValidationError
+} from '@platformatic/kafka'
+
+const stream = await consumer.consume({
+  topics: ['events'],
+  onDeserializationError ({ error, topic, partition, offset, payloadType }) {
+    if (error instanceof SchemaValidationError) {
+      console.error('Schema-invalid message', {
+        topic,
+        partition,
+        offset,
+        payloadType,
+        validationErrors: error.validationErrors
+      })
+
+      return DeserializationErrorActions.SKIP
+    }
+
+    return DeserializationErrorActions.FAIL
+  }
+})
+```
+
+The callback is synchronous. If it returns `SKIP`, the record is not emitted and consumption continues. With autocommit enabled, its offset remains eligible for commit. `onDeserializationError` and the deprecated `onCorruptedMessage` cannot be configured together.
 
 `MessagesStreamModes` modes:
 

--- a/src/clients/consumer/consumer.ts
+++ b/src/clients/consumer/consumer.ts
@@ -377,6 +377,11 @@ export class Consumer<Key = Buffer, Value = Buffer, HeaderKey = Buffer, HeaderVa
       return callback[kCallbackPromise]
     }
 
+    if (options.onCorruptedMessage && options.onDeserializationError) {
+      callback(new UserError('Cannot specify both onCorruptedMessage and onDeserializationError.'))
+      return callback[kCallbackPromise]
+    }
+
     options.autocommit ??= this[kOptions].autocommit! ?? true
     options.maxBytes ??= this[kOptions].maxBytes!
     options.maxBytesPerPartition ??= this[kOptions].maxBytesPerPartition ?? options.maxBytes

--- a/src/clients/consumer/messages-stream.ts
+++ b/src/clients/consumer/messages-stream.ts
@@ -32,11 +32,14 @@ import {
 import type { Consumer } from './consumer.ts'
 import { defaultConsumerOptions } from './options.ts'
 import {
+  DeserializationErrorActions,
   MessagesStreamFallbackModes,
   MessagesStreamModes,
   type CommitOptionsPartition,
   type ConsumeOptions,
   type CorruptedMessageHandler,
+  type DeserializationErrorContext,
+  type DeserializationErrorHandler,
   type GroupAssignment,
   type Offsets
 } from './types.ts'
@@ -96,6 +99,7 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
   #closeCallbacks: Callback<void>[]
   #metricsConsumedMessages: Counter | undefined
   #corruptedMessageHandler: CorruptedMessageHandler
+  #deserializationErrorHandler: DeserializationErrorHandler | undefined
   #context: unknown
   #onConsumerGroupJoin: () => void
   #onBrokerDisconnect: () => void
@@ -138,6 +142,7 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
       context,
       deserializers,
       onCorruptedMessage,
+      onDeserializationError,
       registry,
       beforeDeserialization,
       // The options below are only destructured to avoid being part of structuredClone below
@@ -145,6 +150,10 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
       protocolsMetadata: _protocolsMetadata,
       ...otherOptions
     } = options
+
+    if (onCorruptedMessage && onDeserializationError) {
+      throw new UserError('Cannot specify both onCorruptedMessage and onDeserializationError.')
+    }
 
     if (offsets && mode !== MessagesStreamModes.MANUAL) {
       throw new UserError('Cannot specify offsets when the stream mode is not MANUAL.')
@@ -186,6 +195,7 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
     this.#closed = false
     this.#closeCallbacks = []
     this.#corruptedMessageHandler = onCorruptedMessage ?? defaultCorruptedMessageHandler
+    this.#deserializationErrorHandler = onDeserializationError
     this.#context = context
 
     this.#onConsumerGroupJoin = () => {
@@ -875,23 +885,66 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
               : this.#commit.bind(this, topic, partition, offset + 1n, leaderEpoch)
 
             try {
-              const headers = new Map()
-              for (const [headerKey, headerValue] of record.headers) {
-                headers.set(
-                  /* c8 ignore next 2 - Hard to test */
-                  headerKeyDeserializer(headerKey ?? undefined, messageToConsume),
-                  headerValueDeserializer(headerValue ?? undefined, messageToConsume)
-                )
+              const headers = new Map<HeaderKey, HeaderValue>()
+              let payloadType: BeforeHookPayloadType = 'headerKey'
+              let deserializedKey: Key | undefined
+              let deserializedValue: Value | undefined
+
+              try {
+                for (const [headerKey, headerValue] of record.headers) {
+                  payloadType = 'headerKey'
+                  /* c8 ignore next - Hard to test */
+                  const deserializedHeaderKey = headerKeyDeserializer(headerKey ?? undefined, messageToConsume)
+                  payloadType = 'headerValue'
+                  /* c8 ignore next - Hard to test */
+                  const deserializedHeaderValue = headerValueDeserializer(headerValue ?? undefined, messageToConsume)
+                  headers.set(deserializedHeaderKey as HeaderKey, deserializedHeaderValue as HeaderValue)
+                }
+
+                payloadType = 'key'
+                /* c8 ignore next - Hard to test */
+                deserializedKey = keyDeserializer(record.key ?? undefined, headers, messageToConsume)
+                payloadType = 'value'
+                deserializedValue = valueDeserializer(record.value ?? undefined, headers, messageToConsume)
+              } catch (error) {
+                const context: DeserializationErrorContext = {
+                  error,
+                  payloadType,
+                  record,
+                  topic,
+                  partition,
+                  offset,
+                  timestamp: firstTimestamp + record.timestampDelta,
+                  commit: commit as Message['commit']
+                }
+                const shouldDestroy = this.#deserializationErrorHandler
+                  ? this.#deserializationErrorHandler(context) !== DeserializationErrorActions.SKIP
+                  : this.#corruptedMessageHandler(
+                    record,
+                    topic,
+                    partition,
+                    firstTimestamp,
+                    firstOffset,
+                    commit as Message['commit'],
+                    error
+                  )
+
+                if (shouldDestroy) {
+                  diagnosticContext.error = error
+                  consumerReceivesChannel.error.publish(diagnosticContext)
+
+                  this.destroy(new UserError('Failed to deserialize a message.', { cause: error }))
+                  return
+                }
+
+                continue
               }
-              /* c8 ignore next 2 - Hard to test */
-              const key = keyDeserializer(record.key ?? undefined, headers, messageToConsume)
-              const value = valueDeserializer(record.value ?? undefined, headers, messageToConsume)
 
               this.#metricsConsumedMessages?.inc()
 
               const message: Message = {
-                key,
-                value,
+                key: deserializedKey,
+                value: deserializedValue,
                 headers,
                 topic,
                 partition,
@@ -910,23 +963,11 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
 
               consumerReceivesChannel.asyncEnd.publish(diagnosticContext)
             } catch (error) {
-              const shouldDestroy = this.#corruptedMessageHandler(
-                record,
-                topic,
-                partition,
-                firstTimestamp,
-                firstOffset,
-                commit as Message['commit'],
-                error
-              )
+              diagnosticContext.error = error
+              consumerReceivesChannel.error.publish(diagnosticContext)
 
-              if (shouldDestroy) {
-                diagnosticContext.error = error
-                consumerReceivesChannel.error.publish(diagnosticContext)
-
-                this.destroy(new UserError('Failed to deserialize a message.', { cause: error }))
-                return
-              }
+              this.destroy(new UserError('Failed to process a message.', { cause: error }))
+              return
             } finally {
               consumerReceivesChannel.end.publish(diagnosticContext)
             }

--- a/src/clients/consumer/options.ts
+++ b/src/clients/consumer/options.ts
@@ -95,6 +95,7 @@ export const consumeOptionsSchema = {
       }
     },
     onCorruptedMessage: { function: true },
+    onDeserializationError: { function: true },
     ...groupOptionsProperties,
     ...consumeOptionsProperties
   },

--- a/src/clients/consumer/types.ts
+++ b/src/clients/consumer/types.ts
@@ -5,7 +5,7 @@ import { type ConnectionPool } from '../../network/connection-pool.ts'
 import { type KafkaRecord, type Message } from '../../protocol/records.ts'
 import { type SchemaRegistry } from '../../registries/abstract.ts'
 import { type BaseOptions, type ClusterMetadata, type TopicWithPartitionAndOffset } from '../base/types.ts'
-import { type BeforeDeserializationHook, type Deserializers } from '../serde.ts'
+import { type BeforeDeserializationHook, type BeforeHookPayloadType, type Deserializers } from '../serde.ts'
 
 export interface GroupProtocolSubscription {
   name: string
@@ -37,6 +37,30 @@ export interface PreferredReadReplica {
   expiresAt: number
 }
 
+export const DeserializationErrorActions = {
+  FAIL: 'fail',
+  SKIP: 'skip'
+} as const
+
+export type DeserializationErrorAction =
+  (typeof DeserializationErrorActions)[keyof typeof DeserializationErrorActions]
+
+export interface DeserializationErrorContext {
+  error: unknown
+  payloadType: BeforeHookPayloadType
+  record: KafkaRecord
+  topic: string
+  partition: number
+  offset: bigint
+  timestamp: bigint
+  commit: Message['commit']
+}
+
+export type DeserializationErrorHandler = (context: DeserializationErrorContext) => DeserializationErrorAction
+
+/**
+ * @deprecated Use `DeserializationErrorHandler` instead.
+ */
 export type CorruptedMessageHandler = (
   record: KafkaRecord,
   topic: string,
@@ -125,6 +149,10 @@ export interface StreamOptions {
   fallbackMode?: MessagesStreamFallbackModeValue
   maxFetches?: number
   offsets?: TopicWithPartitionAndOffset[]
+  onDeserializationError?: DeserializationErrorHandler
+  /**
+   * @deprecated Use `onDeserializationError` instead.
+   */
   onCorruptedMessage?: CorruptedMessageHandler
 }
 

--- a/src/registries/confluent-schema-registry.ts
+++ b/src/registries/confluent-schema-registry.ts
@@ -1,4 +1,4 @@
-import { type Options, type ValidateFunction } from 'ajv'
+import { type ErrorObject, type Options, type ValidateFunction } from 'ajv'
 import { Ajv2020 } from 'ajv/dist/2020.js'
 import avro, { type Type } from 'avsc'
 import { createRequire } from 'node:module'
@@ -46,6 +46,35 @@ export interface ConfluentSchemaRegistryOptions {
   protobufTypeMapper?: ConfluentSchemaRegistryProtobufTypeMapper
   jsonValidateSend?: boolean
   jsonAjvOptions?: Options
+}
+
+export type SchemaValidationPhase = 'serialization' | 'deserialization'
+
+export interface SchemaValidationErrorProperties {
+  schemaId: number
+  schemaType: 'json'
+  phase: SchemaValidationPhase
+  payloadType: BeforeHookPayloadType
+  type: BeforeHookPayloadType
+  data: unknown
+  headers?: ReadonlyMap<unknown, unknown>
+  validationErrors: ErrorObject[] | null | undefined
+}
+
+export class SchemaValidationError extends UserError {
+  declare readonly schemaId: number
+  declare readonly schemaType: 'json'
+  declare readonly phase: SchemaValidationPhase
+  declare readonly payloadType: BeforeHookPayloadType
+  declare readonly type: BeforeHookPayloadType
+  declare readonly data: unknown
+  declare readonly headers?: ReadonlyMap<unknown, unknown>
+  declare readonly validationErrors: ErrorObject[] | null | undefined
+
+  constructor (message: string, properties: SchemaValidationErrorProperties) {
+    super(message, properties)
+    this.name = 'SchemaValidationError'
+  }
 }
 
 export interface Schema {
@@ -294,9 +323,18 @@ export class ConfluentSchemaRegistry<
           const validate = schema.schema as ValidateFunction
           const valid = validate(data)
           if (!valid) {
-            throw new UserError(
+            throw new SchemaValidationError(
               `JSON Schema validation failed before serialization: ${this.#jsonAjv.errorsText(validate.errors)}`,
-              { type, data, headers, validationErrors: validate.errors }
+              {
+                schemaId,
+                schemaType: 'json',
+                phase: 'serialization',
+                payloadType: type,
+                type,
+                data,
+                headers,
+                validationErrors: validate.errors
+              }
             )
           }
         }
@@ -353,9 +391,18 @@ export class ConfluentSchemaRegistry<
         const valid = validate(parsed)
 
         if (!valid) {
-          throw new UserError(
+          throw new SchemaValidationError(
             `JSON Schema validation failed before deserialization: ${this.#jsonAjv.errorsText(validate.errors)}`,
-            { type, data: parsed, headers, validationErrors: validate.errors }
+            {
+              schemaId,
+              schemaType: 'json',
+              phase: 'deserialization',
+              payloadType: type,
+              type,
+              data: parsed,
+              headers,
+              validationErrors: validate.errors
+            }
           )
         }
 

--- a/test/clients/consumer/messages-stream.test.ts
+++ b/test/clients/consumer/messages-stream.test.ts
@@ -13,6 +13,7 @@ import {
   type ConsumerOptions,
   consumerReceivesChannel,
   type Deserializers,
+  DeserializationErrorActions,
   instancesChannel,
   jsonDeserializer,
   type KafkaRecord,
@@ -242,6 +243,46 @@ test('should throw error when not specifying offsets with MANUAL mode', async t 
     error => {
       ok(error instanceof UserError)
       strictEqual(error.message, 'Must specify offsets when the stream mode is MANUAL.')
+      return true
+    }
+  )
+})
+
+test('should reject multiple deserialization error handlers', async t => {
+  const consumer = createConsumer(t)
+
+  throws(
+    () => {
+      return new MessagesStream(consumer, {
+        topics: [createTestTopic()],
+        onDeserializationError () {
+          return DeserializationErrorActions.FAIL
+        },
+        onCorruptedMessage () {
+          return true
+        }
+      })
+    },
+    error => {
+      ok(error instanceof UserError)
+      strictEqual(error.message, 'Cannot specify both onCorruptedMessage and onDeserializationError.')
+      return true
+    }
+  )
+
+  await rejects(
+    consumer.consume({
+      topics: [createTestTopic()],
+      onDeserializationError () {
+        return DeserializationErrorActions.FAIL
+      },
+      onCorruptedMessage () {
+        return true
+      }
+    }),
+    error => {
+      ok(error instanceof UserError)
+      strictEqual(error.message, 'Cannot specify both onCorruptedMessage and onDeserializationError.')
       return true
     }
   )
@@ -923,20 +964,29 @@ test('should handle deserialization errors', async t => {
   })
 
   // Consume messages with JSON deserializer for value
-  try {
-    await consumeMessages(t, groupId, topic, {
+  let deserializationError: unknown
+  await rejects(
+    consumeMessages(t, groupId, topic, {
       mode: MessagesStreamModes.EARLIEST,
       deserializers: {
         ...stringDeserializers,
         value: jsonDeserializer
+      },
+      onDeserializationError (context) {
+        deserializationError = context.error
+        strictEqual(context.payloadType, 'value')
+        return DeserializationErrorActions.FAIL
       }
-    })
-    throw new Error('Expected error not thrown')
-  } catch (error) {
-    strictEqual(error instanceof UserError, true)
-    strictEqual(error.message.includes('Failed to deserialize a message.'), true)
-    strictEqual(error.cause.message.includes('Unexpected token \'v\', "value-0" is not valid JSON'), true)
-  }
+    }),
+    error => {
+      ok(error instanceof UserError)
+      strictEqual(error.message, 'Failed to deserialize a message.')
+      strictEqual(error.cause, deserializationError)
+      ok(error.cause instanceof Error)
+      strictEqual(error.cause.message.includes('Unexpected token \'v\', "value-0" is not valid JSON'), true)
+      return true
+    }
+  )
 })
 
 test('should allow resuming deserialization errors', async t => {

--- a/test/registries/confluent-schema-registry.test.ts
+++ b/test/registries/confluent-schema-registry.test.ts
@@ -2,7 +2,15 @@ import { deepStrictEqual, match, strictEqual } from 'node:assert'
 import { randomUUID } from 'node:crypto'
 import test from 'node:test'
 import { UserError } from '../../src/errors.ts'
-import { MessagesStreamModes, noopDeserializer, stringDeserializer, stringSerializer } from '../../src/index.ts'
+import {
+  type DeserializationErrorContext,
+  DeserializationErrorActions,
+  MessagesStreamModes,
+  noopDeserializer,
+  SchemaValidationError,
+  stringDeserializer,
+  stringSerializer
+} from '../../src/index.ts'
 import { ConfluentSchemaRegistry } from '../../src/registries/confluent-schema-registry.ts'
 import {
   confluentSchemaRegistryAuthBasicUrl,
@@ -454,6 +462,8 @@ test('fails on JSON schema validation when producing', async t => {
   } catch (error) {
     strictEqual(error instanceof UserError, true)
     strictEqual(error.message, 'Failed to serialize a message.')
+    strictEqual(error.cause instanceof SchemaValidationError, true)
+    strictEqual(error.cause.phase, 'serialization')
     strictEqual(
       error.cause.message,
       'JSON Schema validation failed before serialization: data must NOT have additional properties'
@@ -514,6 +524,8 @@ test('fails on JSON schema validation when consuming', async t => {
   } catch (error) {
     strictEqual(error instanceof UserError, true)
     strictEqual(error.message, 'Failed to deserialize a message.')
+    strictEqual(error.cause instanceof SchemaValidationError, true)
+    strictEqual(error.cause.phase, 'deserialization')
     strictEqual(
       error.cause.message,
       'JSON Schema validation failed before deserialization: data must NOT have additional properties'
@@ -521,7 +533,7 @@ test('fails on JSON schema validation when consuming', async t => {
   }
 })
 
-test('exposes malformed JSON and JSON schema validation errors to onCorruptedMessage', async t => {
+test('exposes malformed JSON and JSON schema validation errors to onDeserializationError', async t => {
   const topic = await createTopic(t, true)
   const consumerRegistry = new ConfluentSchemaRegistry<string, Datum, string, string>({
     url: confluentSchemaRegistryUrl
@@ -551,33 +563,60 @@ test('exposes malformed JSON and JSON schema validation errors to onCorruptedMes
       }
     }
   })
+  const firstTimestamp = BigInt(Date.now())
+  const secondTimestamp = firstTimestamp + 1000n
 
   await producer.send({
     messages: [
-      { topic, key: 'schema-invalid', value: JSON.stringify({ id: 1, name: 'Alice', foo: 'bar' }) },
-      { topic, key: 'malformed', value: '{"id":' }
+      {
+        topic,
+        key: 'schema-invalid',
+        value: JSON.stringify({ id: 1, name: 'Alice', foo: 'bar' }),
+        timestamp: firstTimestamp
+      },
+      { topic, key: 'malformed', value: '{"id":', timestamp: secondTimestamp }
     ]
   })
 
-  const errors: unknown[] = []
+  const failures: DeserializationErrorContext[] = []
   const consumer = createConsumer(t, { registry: consumerRegistry })
   const stream = await consumer.consume({
     topics: [topic],
     maxFetches: 1,
     mode: MessagesStreamModes.EARLIEST,
-    onCorruptedMessage (_record, _topic, _partition, _firstTimestamp, _firstOffset, _commit, error) {
-      errors.push(error)
-      return false
+    onDeserializationError (context) {
+      failures.push(context)
+      return DeserializationErrorActions.SKIP
     }
   })
 
   const messages = await Array.fromAsync(stream)
   strictEqual(messages.length, 0)
-  strictEqual(errors.length, 2)
-  strictEqual(errors.some(error => error instanceof SyntaxError), true)
+  strictEqual(failures.length, 2)
+  deepStrictEqual(
+    failures.map(({ offset }) => offset),
+    [0n, 1n]
+  )
+  deepStrictEqual(
+    failures.map(({ payloadType }) => payloadType),
+    ['value', 'value']
+  )
+  deepStrictEqual(
+    failures.map(({ timestamp }) => timestamp),
+    [firstTimestamp, secondTimestamp]
+  )
+  strictEqual(failures.every(failure => failure.topic === topic), true)
+  strictEqual(failures.every(({ partition }) => partition === 0), true)
+  strictEqual(failures.every(({ commit }) => typeof commit === 'function'), true)
+  strictEqual(failures.every(({ record }) => Buffer.isBuffer(record.value)), true)
+  strictEqual(failures.some(({ error }) => error instanceof SyntaxError), true)
 
-  const validationError = errors.find(error => error instanceof UserError)
-  strictEqual(validationError instanceof UserError, true)
+  const validationError = failures.map(({ error }) => error).find(error => error instanceof SchemaValidationError)
+  strictEqual(validationError instanceof SchemaValidationError, true)
+  strictEqual(validationError?.schemaId, schemaId)
+  strictEqual(validationError?.schemaType, 'json')
+  strictEqual(validationError?.phase, 'deserialization')
+  strictEqual(validationError?.payloadType, 'value')
   strictEqual(Array.isArray(validationError?.validationErrors), true)
 })
 


### PR DESCRIPTION
Follow-up to #333.

## Summary

- add `onDeserializationError(context)` with the original error, payload type, raw record, and record-level topic/partition/offset/timestamp context
- add explicit `DeserializationErrorActions.FAIL` and `DeserializationErrorActions.SKIP` results
- deprecate `onCorruptedMessage` while preserving its existing behavior
- reject configuring both handlers
- add `SchemaValidationError extends UserError` for stable JSON Schema validation classification
- narrow recovery handling to deserialiser failures and document skip/autocommit semantics

## Validation

- `npm run build`
- `npm run lint`
- `node --test --test-name-pattern='should reject multiple deserialization error handlers' 'test/clients/consumer/messages-stream.test.ts'`
- `git diff --check origin/main...HEAD`

`npm run typecheck` still reports three unrelated errors in existing admin and consumer tests. Kafka and Schema Registry integration tests require Docker, which is unavailable locally; the CI matrix will exercise them.
