### PR TITLE
fix: support multiple JSON Schema drafts

### DIFF
--- a/docs/confluent-schema-registry.md
+++ b/docs/confluent-schema-registry.md
@@ -134,6 +134,8 @@ await producer.send({
 })
 ```
 
+JSON Schema drafts 04, 06, 07, and 2020-12 are supported. The draft is selected from the schema's `$schema` property; schemas without one use the default 2020-12 validator.
+
 Set `jsonAjvOptions.strict` to `false` if the registry contains JSON schemas with non-standard keywords:
 
 ```typescript

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@platformatic/dynamic-buffer": "^0.3.1",
     "@platformatic/wasm-utils": "^0.2.1",
     "ajv": "^8.17.1",
+    "ajv-draft-04": "^1.0.0",
     "avsc": "^5.7.9",
     "debug": "^4.4.3",
     "fastq": "^1.19.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       ajv:
         specifier: ^8.17.1
         version: 8.20.0
+      ajv-draft-04:
+        specifier: ^1.0.0
+        version: 1.0.0(ajv@8.20.0)
       avsc:
         specifier: ^5.7.9
         version: 5.7.9
@@ -1083,6 +1086,14 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  ajv-draft-04@1.0.0:
+    resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
+    peerDependencies:
+      ajv: ^8.5.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
 
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
@@ -3272,6 +3283,10 @@ snapshots:
   acquerello@3.0.1: {}
 
   agent-base@7.1.4: {}
+
+  ajv-draft-04@1.0.0(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
 
   ajv@6.15.0:
     dependencies:

--- a/src/registries/confluent-schema-registry.ts
+++ b/src/registries/confluent-schema-registry.ts
@@ -1,4 +1,4 @@
-import { type ErrorObject, type Options, type ValidateFunction } from 'ajv'
+import { Ajv, type AnySchema, type AnySchemaObject, type ErrorObject, type Options, type ValidateFunction } from 'ajv'
 import { Ajv2020 } from 'ajv/dist/2020.js'
 import avro, { type Type } from 'avsc'
 import { createRequire } from 'node:module'
@@ -23,6 +23,13 @@ import { getCredential } from '../protocol/sasl/utils.ts'
 import { AbstractSchemaRegistry } from './abstract.ts'
 
 const require = createRequire(import.meta.url)
+type JsonSchemaValidator = {
+  compile: (schema: AnySchema) => ValidateFunction
+  errorsText: Ajv['errorsText']
+}
+
+const AjvDraft04 = require('ajv-draft-04') as new (options: Options) => JsonSchemaValidator
+const draft06MetaSchema = require('ajv/dist/refs/json-schema-draft-06.json') as AnySchemaObject
 
 type ConfluentSchemaRegistryMessageToProduce = MessageToProduce<unknown, unknown, unknown, unknown>
 
@@ -105,6 +112,8 @@ export class ConfluentSchemaRegistry<
   #protobufTypeMapper: ConfluentSchemaRegistryProtobufTypeMapper
   #jsonValidateSend: boolean
   #jsonAjv: Ajv2020
+  #jsonAjvDraft7: Ajv
+  #jsonAjvDraft04: JsonSchemaValidator
   #pendingFetches: Map<number, Promise<void>>
   #auth: ConfluentSchemaRegistryOptions['auth'] | undefined
 
@@ -114,7 +123,11 @@ export class ConfluentSchemaRegistry<
     this.#schemas = new Map()
     this.#protobufTypeMapper = options.protobufTypeMapper ?? defaultProtobufTypeMapper
     this.#jsonValidateSend = options.jsonValidateSend ?? false
-    this.#jsonAjv = new Ajv2020({ allErrors: true, coerceTypes: false, strict: true, ...options.jsonAjvOptions })
+    const jsonAjvOptions = { allErrors: true, coerceTypes: false, strict: true, ...options.jsonAjvOptions }
+    this.#jsonAjv = new Ajv2020(jsonAjvOptions)
+    this.#jsonAjvDraft7 = new Ajv(jsonAjvOptions)
+    this.#jsonAjvDraft7.addMetaSchema(draft06MetaSchema)
+    this.#jsonAjvDraft04 = new AjvDraft04(jsonAjvOptions)
     this.#auth = options.auth
     this.#pendingFetches = new Map()
   }
@@ -272,10 +285,28 @@ export class ConfluentSchemaRegistry<
         this.#protobufParse ??= this.#loadProtobuf()
         this.#schemas.set(id, { id, type: 'protobuf', schema: this.#protobufParse!(schema).root })
         break
-      case 'JSON':
-        this.#schemas.set(id, { id, type: 'json', schema: this.#jsonAjv.compile(JSON.parse(schema)) })
+      case 'JSON': {
+        const jsonSchema = JSON.parse(schema) as AnySchema
+        this.#schemas.set(id, { id, type: 'json', schema: this.#getJsonAjv(jsonSchema).compile(jsonSchema) })
         break
+      }
     }
+  }
+
+  #getJsonAjv (schema: AnySchema): JsonSchemaValidator {
+    if (typeof schema !== 'object' || schema === null || typeof schema.$schema !== 'string') {
+      return this.#jsonAjv
+    }
+
+    if (schema.$schema.includes('draft-04')) {
+      return this.#jsonAjvDraft04
+    }
+
+    if (schema.$schema.includes('draft-06') || schema.$schema.includes('draft-07')) {
+      return this.#jsonAjvDraft7
+    }
+
+    return this.#jsonAjv
   }
 
   #schemaSerializer (

--- a/test/registries/confluent-schema-registry.test.ts
+++ b/test/registries/confluent-schema-registry.test.ts
@@ -318,6 +318,77 @@ test('supports producing and consuming messages using Confluent Schema Registry 
   }
 })
 
+test('supports JSON Schema drafts 04, 06, 07, and 2020-12', async () => {
+  const schemas = [
+    {
+      schema: {
+        $schema: 'http://json-schema.org/draft-04/schema#',
+        type: 'number',
+        minimum: 2,
+        exclusiveMinimum: true
+      },
+      valid: 3,
+      invalid: 2
+    },
+    {
+      schema: {
+        $schema: 'http://json-schema.org/draft-06/schema#',
+        type: 'number',
+        exclusiveMinimum: 2
+      },
+      valid: 3,
+      invalid: 2
+    },
+    {
+      schema: {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        type: 'number',
+        exclusiveMinimum: 2
+      },
+      valid: 3,
+      invalid: 2
+    },
+    {
+      schema: {
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        type: 'array',
+        prefixItems: [{ type: 'string' }],
+        items: false,
+        minItems: 1
+      },
+      valid: ['value'],
+      invalid: ['value', 'extra']
+    }
+  ]
+  const originalFetch = globalThis.fetch
+
+  try {
+    for (const { schema, valid, invalid } of schemas) {
+      const registry = new ConfluentSchemaRegistry<string, Datum, string, string>({ url: confluentSchemaRegistryUrl })
+      ;(globalThis as { fetch: typeof fetch }).fetch = async () => {
+        return new Response(JSON.stringify({ schemaType: 'JSON', schema: JSON.stringify(schema) }))
+      }
+
+      await new Promise<void>((resolve, reject) => {
+        registry.fetchSchema(1, error => {
+          if (error) {
+            reject(error)
+            return
+          }
+
+          resolve()
+        })
+      })
+
+      const validate = registry.get(1)?.schema as (data: unknown) => boolean
+      strictEqual(validate(valid), true)
+      strictEqual(validate(invalid), false)
+    }
+  } finally {
+    ;(globalThis as { fetch: typeof fetch }).fetch = originalFetch
+  }
+})
+
 test('deduplicates concurrent fetches for the same JSON schema ID', async () => {
   const subject = createSubject()
   const schemaId = await registerSchema(


### PR DESCRIPTION
## Summary

- support Confluent JSON Schema drafts 04, 06, 07, and 2020-12
- select the appropriate Ajv validator from the schema `$schema` URI
- add regression coverage and document supported drafts

Closes #335

## Tests

- `npm run build`
- `npm run lint`
- `node --no-warnings --test --test-name-pattern='supports JSON Schema drafts' test/registries/confluent-schema-registry.test.ts`
