### PR TITLE
fix: emit group:rebalance when partitions are revoked under consumer protocol

### DIFF
--- a/src/clients/consumer/consumer.ts
+++ b/src/clients/consumer/consumer.ts
@@ -1582,6 +1582,8 @@ export class Consumer<Key = Buffer, Value = Buffer, HeaderKey = Buffer, HeaderVa
       return
     }
 
+    this.emitWithDebug('consumer', 'group:rebalance', { groupId: this.groupId })
+
     for (const stream of this.#streams) {
       stream.pause()
       stream[kAutocommit]()

--- a/test/issues/issue-339.test.ts
+++ b/test/issues/issue-339.test.ts
@@ -1,0 +1,80 @@
+// Related issue: https://github.com/platformatic/kafka/issues/339
+
+import { deepStrictEqual, ok } from 'node:assert'
+import { once } from 'node:events'
+import { test, type TestContext } from 'node:test'
+import { type Consumer, type GroupAssignment, MessagesStreamModes } from '../../src/index.ts'
+import { createConsumer, createGroupId, createTopic, executeWithTimeout, isKafka, retry } from '../helpers.ts'
+
+// Under the consumer group protocol (KIP-848) the new assignment is delivered in the
+// ConsumerGroupHeartbeat response, so the REBALANCE_IN_PROGRESS error that drives the
+// emission in #getRejoinError never happens: a member losing partitions to a new member
+// used to receive no event at all, leaving manual-commit consumers no chance to flush
+// their offsets before the partitions were taken away.
+
+const skipConsumerGroupProtocol = { skip: isKafka(['7.5.0', '7.6.0', '7.7.0', '7.8.0', '7.9.0']) }
+const rebalanceTimeout = 30000
+
+function assignedPartitions (consumer: Consumer, topic: string): number[] {
+  return consumer.assignments?.find(assignment => assignment.topic === topic)?.partitions ?? []
+}
+
+function waitForAssignedPartitions (consumer: Consumer, topic: string, expected: number): Promise<void> {
+  return retry(60, 500, async () => {
+    const partitions = assignedPartitions(consumer, topic)
+
+    if (partitions.length !== expected) {
+      throw new Error(`Expected ${expected} assigned partitions, got ${partitions.length}.`)
+    }
+  })
+}
+
+// joinGroup is a no-op under the consumer protocol: membership only starts once the
+// consumer is actually consuming.
+async function joinByConsuming (t: TestContext, consumer: Consumer, topic: string): Promise<void> {
+  const stream = await consumer.consume({ topics: [topic], mode: MessagesStreamModes.LATEST, maxWaitTime: 200 })
+  t.after(() => stream.close())
+  stream.on('data', () => {})
+}
+
+test('should emit consumer:group:rebalance when partitions are revoked', skipConsumerGroupProtocol, async t => {
+  const topic = await createTopic(t, true, 3)
+  const groupId = createGroupId()
+
+  const consumer1 = createConsumer(t, { groupId, groupProtocol: 'consumer' })
+  const consumer2 = createConsumer(t, { groupId, groupProtocol: 'consumer' })
+
+  await joinByConsuming(t, consumer1, topic)
+  await waitForAssignedPartitions(consumer1, topic, 3)
+
+  // Record the assignment as seen by the event handler: the event must be delivered
+  // before the revocation is applied, otherwise there is nothing left to commit.
+  const assignmentsWhenNotified: (GroupAssignment[] | null)[] = []
+  consumer1.on('consumer:group:rebalance', () => {
+    assignmentsWhenNotified.push(structuredClone(consumer1.assignments))
+  })
+
+  const rebalance = once(consumer1, 'consumer:group:rebalance')
+
+  await joinByConsuming(t, consumer2, topic)
+
+  const payloads = await executeWithTimeout(rebalance, rebalanceTimeout)
+  ok(Array.isArray(payloads), 'consumer1 was not notified about the revocation.')
+  deepStrictEqual(payloads[0], { groupId })
+
+  deepStrictEqual(
+    assignmentsWhenNotified[0],
+    [{ topic, partitions: [0, 1, 2] }],
+    'The event must be emitted while the revoked partitions are still assigned.'
+  )
+
+  // The revocation is then actually applied and the group settles on a shared assignment.
+  await retry(60, 500, async () => {
+    const partitions1 = assignedPartitions(consumer1, topic)
+    const partitions2 = assignedPartitions(consumer2, topic)
+
+    if (partitions1.length === 3 || partitions1.length + partitions2.length !== 3) {
+      throw new Error(`Partitions were not redistributed: ${partitions1.length} and ${partitions2.length}.`)
+    }
+  })
+})


### PR DESCRIPTION
Fixes #339.

## Problem

Under `groupProtocol: 'consumer'` (KIP-848) a member that loses partitions to a new group member receives no event at all. The only emission site for `consumer:group:rebalance` is `#getRejoinError`, which is gated on `protocolError.rebalanceInProgress` - an error that only occurs under the classic protocol. With the consumer protocol the new assignment arrives in the `ConsumerGroupHeartbeat` response and flows straight into `#revokePartitions`, bypassing the emission logic entirely.

The docs list `consumer:group:rebalance` as "emitted when group rebalancing occurs" and list KIP-848 as supported, so the behaviour is also a documentation mismatch.

Practical impact: consumers using manual offset commits get no pre-revocation notification, so they cannot flush pending commits before losing the partitions. The result is redelivered messages - in my case dead-letter records went from 477 to 1452.

## Fix

Emit `consumer:group:rebalance` from `#revokePartitions`, before the streams are paused and autocommitted. Emitting there means the handler still sees the partitions that are about to be revoked, which is exactly what a manual-commit consumer needs in order to flush their offsets in time.

The classic protocol path is untouched, so no event is duplicated there.

## Test

`test/issues/issue-339.test.ts` starts a consumer that owns all 3 partitions of a topic under the consumer protocol, then joins a second consumer to the same group and asserts that:

- the losing member receives `consumer:group:rebalance`;
- the payload carries the `groupId`;
- at the time the handler runs, `assignments` still contains the partitions about to be revoked, i.e. the event is delivered before the revocation is applied;
- the partitions are afterwards redistributed between both members.

Verified in both directions: the test passes with the fix and fails without it (it times out waiting for the event). The test is gated with the existing `isKafka` skip for Confluent 7.5-7.9, which predate KIP-848, mirroring `test/issues/gh-300.test.ts`.
