### PR TITLE
test: fix flaky #updateAssignments metadata error test

### DIFF
--- a/test/clients/consumer/consumer-consumer-group-protocol.test.ts
+++ b/test/clients/consumer/consumer-consumer-group-protocol.test.ts
@@ -2,14 +2,17 @@ import { ok, strictEqual } from 'node:assert'
 import { randomUUID } from 'node:crypto'
 import { once } from 'node:events'
 import { test, type TestContext } from 'node:test'
-import { kClosed, kConnections } from '../../../src/clients/base/base.ts'
+import { kClosed, kConnections, kMetadata } from '../../../src/clients/base/base.ts'
 import {
   consumerGroupHeartbeatV0,
+  MultipleErrors,
   ProduceAcks,
   ResponseError,
   sleep,
   TimeoutError,
   UnsupportedApiError,
+  type CallbackWithPromise,
+  type ClusterMetadata,
   type MessageToProduce,
   type ProducerOptions
 } from '../../../src/index.ts'
@@ -19,6 +22,7 @@ import {
   createTopic,
   isKafka,
   mockAPI,
+  mockedErrorMessage,
   mockMetadata,
   mockUnavailableAPI,
   waitFor
@@ -198,8 +202,65 @@ test('#leaveGroupNewProtocol should handle unavailable API errors', skipConsumer
 test('#updateAssignments should handle metadata error', skipConsumerGroupProtocol, async t => {
   const consumer = createConsumer(t, { groupProtocol: 'consumer', maxWaitTime: 100 })
   const topic = await createTopic(t, true, 1)
-  consumer.on('consumer:heartbeat:start', () => mockMetadata(consumer))
+
+  let metadataErrorDelivered = false
+
+  // #updateAssignments is invoked synchronously while a ConsumerGroupHeartbeat response is being
+  // handled, so the metadata mock is armed only for the duration of that handling. Arming it from a
+  // 'consumer:heartbeat:start' listener instead leaves it live across the whole request/response
+  // round trip, where the stream's own metadata calls can consume it and destroy the stream with the
+  // mocked error - which surfaced as an uncaught exception under load. See #341.
+  mockAPI(consumer[kConnections], consumerGroupHeartbeatV0.api.key, null, null, (
+    originalSend,
+    apiKey,
+    apiVersion,
+    payload,
+    responseParser,
+    hasRequestHeaderTaggedFields,
+    hasResponseHeaderTaggedFields,
+    callback
+  ) => {
+    originalSend(
+      apiKey,
+      apiVersion,
+      payload,
+      responseParser,
+      hasRequestHeaderTaggedFields,
+      hasResponseHeaderTaggedFields,
+      (error: Error | null, response: unknown) => {
+        if (metadataErrorDelivered) {
+          callback(error, response)
+          return
+        }
+
+        const originalMetadata = consumer[kMetadata]
+
+        mockMetadata(consumer, 1, undefined, undefined, (_original, ...args: unknown[]) => {
+          metadataErrorDelivered = true
+          ;(args.at(-1) as CallbackWithPromise<ClusterMetadata>)(
+            new MultipleErrors(mockedErrorMessage, [new Error(mockedErrorMessage + ' (internal)')], {
+              canRetry: false
+            })
+          )
+          return false
+        })
+
+        try {
+          callback(error, response)
+        } finally {
+          consumer[kMetadata] = originalMetadata
+        }
+      }
+    )
+
+    return true
+  })
+
   const stream = await consumer.consume({ topics: [topic] })
-  await once(consumer, 'consumer:heartbeat:end')
+  await waitFor(() => ok(metadataErrorDelivered), { timeout: 10000 })
+
+  // The error was handled rather than thrown, and the assignments were left untouched
+  strictEqual(consumer.assignments, null)
+
   await stream.close()
 })


### PR DESCRIPTION
Fixes #341

## What was happening

The reported stack is the *construction* stack of the `MultipleErrors` (built inside `mockMethod`), so it shows where the mock was **installed**, not where the error escaped. The actual path is different from the one in the issue.

`consumer.on('consumer:heartbeat:start', () => mockMetadata(consumer))` arms a one-shot `kMetadata` mock and leaves it armed for the entire heartbeat request/response round trip. Whichever `kMetadata` call comes next consumes it. Normally that is `#updateAssignments` (`consumer.ts:1623`), the intended target — but the consumer stream's `#refreshOffsets` → `listOffsets` → `kMetadata` (`messages-stream.ts:1084` → `consumer.ts:1124`) fires in the same window and under load can win the race. That path ends in `this.destroy(error)` on the stream, and since the test attaches no `error` listener, Node reports it as an uncaught exception.

Confirmed by forcing the mock onto the `refreshOffsets` call, which reproduces the reported failure exactly:

```
*** MOCK FIRED on refreshOffsets/listOffsets metadata call
=== UNCAUGHT === Cannot connect to any broker.
```

## The fix

`#updateAssignments` runs **synchronously** inside the `ConsumerGroupHeartbeat` response handler (`api` → `groupCallback` → `retryCallback` → `kPerformWithRetry` → `#performGroupOperation` → `#assignPartitions` → `#updateAssignments`, no async hops). The test now uses `mockAPI` to wrap the heartbeat send, arms the metadata mock immediately before delivering the response, and disarms it in a `finally` once handling returns. The mock is live only for the window in which `#updateAssignments` can call metadata, so nothing else can interleave. It re-arms on each heartbeat until one carries an assignment.

The test also asserts now instead of just not-crashing: it waits for the injected error to actually be delivered and checks `consumer.assignments === null`, proving the error was handled and assignments left untouched. If the path ever stops being reached, `waitFor` times out loudly rather than silently losing coverage.

Verified the mock lands on the intended caller:

```
at #updateAssignments (src/clients/consumer/consumer.ts:1623:20)
at #assignPartitions  (src/clients/consumer/consumer.ts:1609:28)
```

## Verification

- Full `test/clients/consumer` suite: 240/240 passing
- 12 concurrent runs of the target test: 12/12 passing
- `eslint`, `prettier --check` and `tsc --noEmit` clean (the 3 pre-existing `tsc` errors in `create-topics-v7.test.ts` and `consumer.test.ts` are unrelated and untouched)

## Not addressed here

Two follow-ups from the issue thread, left out deliberately as separate calls:

- **Reporter.** Confirmed: `cleaner-spec-reporter` renders an uncaught exception as a bare `✖` inline, and the summary gives the test name but never the message or stack. `spec` shows the full error. Switching the reporter across the `test*` scripts is a tooling decision, happy to do it in a separate PR.
- **CI heads-up, unrelated to this issue.** `.github/workflows/ci.yml` pins `pnpm/action-setup@v4` with `version: latest`. `pnpm@11` fails on this repo with `ERROR packages field missing or empty` because `pnpm-workspace.yaml` has no `packages:` key; `pnpm@10` works. Once pnpm 11 becomes `latest`, CI installs will break. Worth pinning the major or adding `packages: - .`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EAFVzr13XmKTU7hsoFwzsg