### PR TITLE
fix: stop uncaught TypeError when a closed connection pool errors

### DIFF
--- a/src/clients/admin/admin.ts
+++ b/src/clients/admin/admin.ts
@@ -95,7 +95,7 @@ import {
   adminTopicsChannel,
   createDiagnosticContext
 } from '../../diagnostic.ts'
-import { MultipleErrors, UserError } from '../../errors.ts'
+import { findErrorBy, MultipleErrors, UserError } from '../../errors.ts'
 import { type Broker, type Connection } from '../../index.ts'
 import { Reader } from '../../protocol/reader.ts'
 import {
@@ -951,7 +951,7 @@ export class Admin extends Base<AdminOptions> {
   }
 
   #handleNotControllerError<T> (error: Error | null, value: T, callback: Callback<T>): void {
-    if (error && (error as MultipleErrors)?.findBy?.('apiCode', 41)) {
+    if (findErrorBy(error, 'apiCode', 41)) {
       this[kMetadata]({ topics: [], forceUpdate: true }, (metadataError, metadata) => {
         /* c8 ignore next 4 - Hard to test */
         if (metadataError) {

--- a/src/clients/base/base.ts
+++ b/src/clients/base/base.ts
@@ -21,8 +21,7 @@ import {
   notifyCreation,
   type ClientType
 } from '../../diagnostic.ts'
-import type { GenericError } from '../../errors.ts'
-import { MultipleErrors, NetworkError, UnsupportedApiError, UserError } from '../../errors.ts'
+import { GenericError, MultipleErrors, NetworkError, UnsupportedApiError, UserError } from '../../errors.ts'
 import { TypedEventEmitter, type TypedEvents } from '../../events.ts'
 import { ConnectionPool, type ConnectionPoolEventPayload } from '../../network/connection-pool.ts'
 import { type Broker, type Connection } from '../../network/connection.ts'
@@ -639,7 +638,10 @@ export class Base<
           },
           (error, metadata) => {
             if (error) {
-              const unknownTopicError = (error as GenericError).findBy('apiCode', 3)
+              // findBy only exists on our own error classes, so brand check before classifying.
+              const kafkaError = GenericError.isGenericError(error) ? (error as GenericError) : null
+
+              const unknownTopicError = kafkaError?.findBy('apiCode', 3)
               if (unknownTopicError) {
                 const topicIndexMatch = unknownTopicError.path?.match(/\/topics\/(\d+)/)
                 /* c8 ignore next 3 - Hard to test  */
@@ -650,7 +652,7 @@ export class Base<
                 return
               }
 
-              const hasStaleMetadata = (error as GenericError).findBy('hasStaleMetadata', true)
+              const hasStaleMetadata = kafkaError?.findBy('hasStaleMetadata', true)
 
               // Stale metadata, we need to fetch everything again
               /* c8 ignore next 4 - Hard to test */

--- a/src/clients/base/base.ts
+++ b/src/clients/base/base.ts
@@ -21,7 +21,7 @@ import {
   notifyCreation,
   type ClientType
 } from '../../diagnostic.ts'
-import { GenericError, MultipleErrors, NetworkError, UnsupportedApiError, UserError } from '../../errors.ts'
+import { findErrorBy, MultipleErrors, NetworkError, UnsupportedApiError, UserError } from '../../errors.ts'
 import { TypedEventEmitter, type TypedEvents } from '../../events.ts'
 import { ConnectionPool, type ConnectionPoolEventPayload } from '../../network/connection-pool.ts'
 import { type Broker, type Connection } from '../../network/connection.ts'
@@ -367,7 +367,12 @@ export class Base<
 
   [kCheckNotClosed] (callback: CallbackWithPromise<any>): boolean {
     if (this[kClosed]) {
-      const error = new NetworkError('Client is closed.', { closed: true, instance: this[kInstance] })
+      // A closed client never reopens, so this must not be retried.
+      const error = new NetworkError('Client is closed.', {
+        canRetry: false,
+        closed: true,
+        instance: this[kInstance]
+      })
       callback(error, undefined)
       return true
     }
@@ -392,9 +397,8 @@ export class Base<
 
     operation((error, result) => {
       if (error) {
-        const genericError = error as GenericError
         // Only retry if all the errors in the chain are retriable
-        const retriable = !genericError.findBy?.('canRetry', false)
+        const retriable = !findErrorBy(error, 'canRetry', false)
         errors.push(error)
 
         if (attempt < retries && retriable && !shouldSkipRetry?.(error)) {
@@ -638,10 +642,7 @@ export class Base<
           },
           (error, metadata) => {
             if (error) {
-              // findBy only exists on our own error classes, so brand check before classifying.
-              const kafkaError = GenericError.isGenericError(error) ? (error as GenericError) : null
-
-              const unknownTopicError = kafkaError?.findBy('apiCode', 3)
+              const unknownTopicError = findErrorBy(error, 'apiCode', 3)
               if (unknownTopicError) {
                 const topicIndexMatch = unknownTopicError.path?.match(/\/topics\/(\d+)/)
                 /* c8 ignore next 3 - Hard to test  */
@@ -652,7 +653,7 @@ export class Base<
                 return
               }
 
-              const hasStaleMetadata = kafkaError?.findBy('hasStaleMetadata', true)
+              const hasStaleMetadata = findErrorBy(error, 'hasStaleMetadata', true)
 
               // Stale metadata, we need to fetch everything again
               /* c8 ignore next 4 - Hard to test */

--- a/src/clients/consumer/consumer.ts
+++ b/src/clients/consumer/consumer.ts
@@ -57,7 +57,7 @@ import {
   consumerOffsetsChannel,
   createDiagnosticContext
 } from '../../diagnostic.ts'
-import { GenericError, NetworkError, type ProtocolError, protocolErrors, UserError } from '../../errors.ts'
+import { findErrorBy, NetworkError, type ProtocolError, protocolErrors, UserError } from '../../errors.ts'
 import { type ConnectionPool } from '../../network/connection-pool.ts'
 import { type Connection } from '../../network/connection.ts'
 import { INT32_SIZE } from '../../protocol/definitions.ts'
@@ -984,16 +984,15 @@ export class Consumer<Key = Buffer, Value = Buffer, HeaderKey = Buffer, HeaderVa
                   if (error) {
                     this.#clearPreferredReadReplicas(options.topics, topicIds)
 
-                    const genericError = error as GenericError
                     if (
-                      genericError.findBy?.('apiId', 'FETCH_SESSION_ID_NOT_FOUND') ||
-                      genericError.findBy?.('apiId', 'INVALID_FETCH_SESSION_EPOCH') ||
-                      genericError.findBy?.('apiId', 'FETCH_SESSION_TOPIC_ID_ERROR')
+                      findErrorBy(error, 'apiId', 'FETCH_SESSION_ID_NOT_FOUND') ||
+                      findErrorBy(error, 'apiId', 'INVALID_FETCH_SESSION_EPOCH') ||
+                      findErrorBy(error, 'apiId', 'FETCH_SESSION_TOPIC_ID_ERROR')
                     ) {
                       this.#fetchSessions.delete(node)
                     }
 
-                    if (genericError.findBy?.('apiId', 'FENCED_LEADER_EPOCH')) {
+                    if (findErrorBy(error, 'apiId', 'FENCED_LEADER_EPOCH')) {
                       this.#fetchSessions.delete(node)
                       this.clearMetadata()
                       for (const topic of options.topics) {
@@ -1289,7 +1288,7 @@ export class Consumer<Key = Buffer, Value = Buffer, HeaderKey = Buffer, HeaderVa
           if (
             this.#useConsumerGroupProtocol &&
             staleMemberEpochRetries < (this[kOptions].retries as number) &&
-            (error as GenericError).findBy?.('apiId', 'STALE_MEMBER_EPOCH')
+            findErrorBy(error, 'apiId', 'STALE_MEMBER_EPOCH')
           ) {
             this.#consumerGroupHeartbeat(this[kOptions] as Required<GroupOptions>, heartbeatError => {
               if (heartbeatError) {
@@ -1977,7 +1976,7 @@ export class Consumer<Key = Buffer, Value = Buffer, HeaderKey = Buffer, HeaderVa
       },
       error => {
         if (error) {
-          const unknownMemberError = (error as GenericError).findBy<ProtocolError>?.('unknownMemberId', true)
+          const unknownMemberError = findErrorBy<ProtocolError>(error, 'unknownMemberId', true)
 
           // This is to avoid throwing an error if a group join was cancelled.
           if (!unknownMemberError) {
@@ -2386,7 +2385,7 @@ export class Consumer<Key = Buffer, Value = Buffer, HeaderKey = Buffer, HeaderVa
   }
 
   #getRejoinError (error: Error): ProtocolError | null {
-    const protocolError = (error as GenericError).findBy<ProtocolError>?.('needsRejoin', true)
+    const protocolError = findErrorBy<ProtocolError>(error, 'needsRejoin', true)
 
     if (!protocolError) {
       return null
@@ -2497,20 +2496,15 @@ export class Consumer<Key = Buffer, Value = Buffer, HeaderKey = Buffer, HeaderVa
   }
 
   #handleError (error: Error | null): Error | null {
-    const kafkaError = error as GenericError
-
-    // findBy only exists on our own error classes, so brand check before classifying.
-    if (error && GenericError.isGenericError(error)) {
-      if (kafkaError.findBy('hasStaleMetadata', true)) {
-        this.clearMetadata()
-      } else if (
-        kafkaError.findBy('code', 'PLT_KFK_NETWORK') ||
-        kafkaError.findBy('apiId', 'COORDINATOR_LOAD_IN_PROGRESS') ||
-        kafkaError.findBy('apiId', 'COORDINATOR_NOT_AVAILABLE') ||
-        kafkaError.findBy('apiId', 'NOT_COORDINATOR')
-      ) {
-        this.#coordinatorId = null
-      }
+    if (findErrorBy(error, 'hasStaleMetadata', true)) {
+      this.clearMetadata()
+    } else if (
+      findErrorBy(error, 'code', 'PLT_KFK_NETWORK') ||
+      findErrorBy(error, 'apiId', 'COORDINATOR_LOAD_IN_PROGRESS') ||
+      findErrorBy(error, 'apiId', 'COORDINATOR_NOT_AVAILABLE') ||
+      findErrorBy(error, 'apiId', 'NOT_COORDINATOR')
+    ) {
+      this.#coordinatorId = null
     }
 
     return error

--- a/src/clients/consumer/consumer.ts
+++ b/src/clients/consumer/consumer.ts
@@ -57,7 +57,7 @@ import {
   consumerOffsetsChannel,
   createDiagnosticContext
 } from '../../diagnostic.ts'
-import { type GenericError, NetworkError, type ProtocolError, protocolErrors, UserError } from '../../errors.ts'
+import { GenericError, NetworkError, type ProtocolError, protocolErrors, UserError } from '../../errors.ts'
 import { type ConnectionPool } from '../../network/connection-pool.ts'
 import { type Connection } from '../../network/connection.ts'
 import { INT32_SIZE } from '../../protocol/definitions.ts'
@@ -2499,7 +2499,8 @@ export class Consumer<Key = Buffer, Value = Buffer, HeaderKey = Buffer, HeaderVa
   #handleError (error: Error | null): Error | null {
     const kafkaError = error as GenericError
 
-    if (kafkaError) {
+    // findBy only exists on our own error classes, so brand check before classifying.
+    if (error && GenericError.isGenericError(error)) {
       if (kafkaError.findBy('hasStaleMetadata', true)) {
         this.clearMetadata()
       } else if (

--- a/src/clients/consumer/messages-stream.ts
+++ b/src/clients/consumer/messages-stream.ts
@@ -15,7 +15,7 @@ import {
   type DiagnosticContext
 } from '../../diagnostic.ts'
 import type { GenericError } from '../../errors.ts'
-import { protocolErrors, UserError } from '../../errors.ts'
+import { findErrorBy, protocolErrors, UserError } from '../../errors.ts'
 import type { ConnectionPool } from '../../network/connection-pool.ts'
 import { IS_CONTROL, type Message, type MessageToConsume } from '../../protocol/records.ts'
 import { runAsyncSeries } from '../../registries/abstract.ts'
@@ -677,7 +677,7 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
     topicIds: Map<string, string>,
     callback: Callback<boolean>
   ): void {
-    if (!error.findBy?.('apiId', 'OFFSET_OUT_OF_RANGE')) {
+    if (!findErrorBy(error, 'apiId', 'OFFSET_OUT_OF_RANGE')) {
       callback(null, false)
       return
     }
@@ -1059,7 +1059,7 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
         // Only destroy the stream when the broker requires a group rejoin
         // (ILLEGAL_GENERATION, UNKNOWN_MEMBER_ID, REBALANCE_IN_PROGRESS).
         // Transient coordinator errors must not tear down the consumption loop.
-        if ((error as GenericError).findBy?.('needsRejoin', true)) {
+        if (findErrorBy(error, 'needsRejoin', true)) {
           this.destroy(error)
         }
         return

--- a/src/clients/producer/producer.ts
+++ b/src/clients/producer/producer.ts
@@ -1399,7 +1399,8 @@ export class Producer<Key = Buffer, Value = Buffer, HeaderKey = Buffer, HeaderVa
   #handleError (error: Error | null): Error | null {
     const kafkaError = error as GenericError
 
-    if (kafkaError) {
+    // findBy only exists on our own error classes, so brand check before classifying.
+    if (error && GenericError.isGenericError(error)) {
       if (
         kafkaError.findBy('code', 'PLT_KFK_NETWORK') ||
         kafkaError.findBy('apiId', 'COORDINATOR_LOAD_IN_PROGRESS') ||

--- a/src/clients/producer/producer.ts
+++ b/src/clients/producer/producer.ts
@@ -22,7 +22,7 @@ import {
   producerSendsChannel,
   producerTransactionsChannel
 } from '../../diagnostic.ts'
-import { GenericError, type ProtocolError, UserError } from '../../errors.ts'
+import { findErrorBy, type GenericError, type ProtocolError, UserError } from '../../errors.ts'
 import { type Broker, type Connection } from '../../network/connection.ts'
 import {
   type CreateRecordsBatchOptions,
@@ -1249,11 +1249,8 @@ export class Producer<Key = Buffer, Value = Buffer, HeaderKey = Buffer, HeaderVa
           if (error) {
             // If the last error was due to stale metadata, we retry the operation with this set of messages
             // since the partition is already set, it should attempt on the new destination
-            /* c8 ignore next 3 - Hard to test */
-            const kafkaError = GenericError.isGenericError(error)
-              ? (error as GenericError & { findBy: (property: string, value: unknown) => GenericError | null })
-              : null
-            const hasStaleMetadata = kafkaError?.findBy('hasStaleMetadata', true)
+            /* c8 ignore next - Hard to test */
+            const hasStaleMetadata = findErrorBy(error, 'hasStaleMetadata', true)
 
             if (hasStaleMetadata && repeatOnStaleMetadata) {
               this.clearMetadata()
@@ -1303,24 +1300,20 @@ export class Producer<Key = Buffer, Value = Buffer, HeaderKey = Buffer, HeaderVa
         [],
         error => {
           /* c8 ignore next 3 - Hard to test */
-          if (!repeatOnStaleMetadata || !GenericError.isGenericError(error)) {
+          if (!repeatOnStaleMetadata) {
             return false
           }
 
-          return !!(
-            error as GenericError & { findBy: (property: string, value: unknown) => GenericError | null }
-          ).findBy('hasStaleMetadata', true)
+          return !!findErrorBy(error, 'hasStaleMetadata', true)
         }
       )
     })
   }
 
   #isProducerStateLost (error: Error): boolean {
-    const kafkaError = error as GenericError
-
     return !!(
-      GenericError.isGenericError(error) &&
-      (kafkaError.findBy('apiId', 'UNKNOWN_PRODUCER_ID') || kafkaError.findBy('apiId', 'OUT_OF_ORDER_SEQUENCE_NUMBER'))
+      findErrorBy(error, 'apiId', 'UNKNOWN_PRODUCER_ID') ||
+      findErrorBy(error, 'apiId', 'OUT_OF_ORDER_SEQUENCE_NUMBER')
     )
   }
 
@@ -1390,25 +1383,20 @@ export class Producer<Key = Buffer, Value = Buffer, HeaderKey = Buffer, HeaderVa
   }
 
   #handleFencingError (error: Error): void {
-    if ((error as GenericError).findBy<ProtocolError>?.('producerFenced', true)) {
+    if (findErrorBy<ProtocolError>(error, 'producerFenced', true)) {
       this.#producerInfo = undefined
       this.#transaction = undefined
     }
   }
 
   #handleError (error: Error | null): Error | null {
-    const kafkaError = error as GenericError
-
-    // findBy only exists on our own error classes, so brand check before classifying.
-    if (error && GenericError.isGenericError(error)) {
-      if (
-        kafkaError.findBy('code', 'PLT_KFK_NETWORK') ||
-        kafkaError.findBy('apiId', 'COORDINATOR_LOAD_IN_PROGRESS') ||
-        kafkaError.findBy('apiId', 'COORDINATOR_NOT_AVAILABLE') ||
-        kafkaError.findBy('apiId', 'NOT_COORDINATOR')
-      ) {
-        this.#coordinatorId = undefined
-      }
+    if (
+      findErrorBy(error, 'code', 'PLT_KFK_NETWORK') ||
+      findErrorBy(error, 'apiId', 'COORDINATOR_LOAD_IN_PROGRESS') ||
+      findErrorBy(error, 'apiId', 'COORDINATOR_NOT_AVAILABLE') ||
+      findErrorBy(error, 'apiId', 'NOT_COORDINATOR')
+    ) {
+      this.#coordinatorId = undefined
     }
 
     return error

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -139,6 +139,24 @@ export class MultipleErrors extends AggregateError {
   }
 }
 
+// findBy only exists on the library's own error classes, but errors also come from user code, Node
+// internals and third parties. This brand checks first, so classification is total: an error that
+// cannot be classified reports no match instead of throwing. Use it for any error whose origin is
+// not statically known.
+export function findErrorBy<ErrorType extends GenericError = GenericError> (
+  error: Error | null | undefined,
+  property: string,
+  value: unknown
+): ErrorType | null {
+  if (!error || !GenericError.isGenericError(error)) {
+    return null
+  }
+
+  // GenericError and MultipleErrors declare findBy with different generic defaults, so the union is
+  // not callable. The brand check above guarantees the call is safe either way.
+  return (error as GenericError).findBy<ErrorType>(property, value)
+}
+
 export * from './protocol/errors.ts'
 
 export class AuthenticationError extends GenericError {

--- a/src/network/connection-pool.ts
+++ b/src/network/connection-pool.ts
@@ -168,7 +168,9 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
 
   #get (broker: Broker, callback: Callback<Connection>): void {
     if (this.#closed) {
-      callback(new Error('Connection pool is closed.'))
+      // A closed pool never reopens, so this must not be retried. It also has to be a library error:
+      // clients classify errors via findBy, which only exists on GenericError subclasses.
+      callback(new NetworkError('Connection pool is closed.', { canRetry: false, closed: true }))
       return
     }
 

--- a/src/network/connection-pool.ts
+++ b/src/network/connection-pool.ts
@@ -170,7 +170,7 @@ export class ConnectionPool extends TypedEventEmitter<ConnectionPoolEvents> {
     if (this.#closed) {
       // A closed pool never reopens, so this must not be retried. It also has to be a library error:
       // clients classify errors via findBy, which only exists on GenericError subclasses.
-      callback(new NetworkError('Connection pool is closed.', { canRetry: false, closed: true }))
+      callback(new NetworkError('Connection pool is closed.', { canRetry: false, closed: true, broker }))
       return
     }
 

--- a/test/clients/base/base.test.ts
+++ b/test/clients/base/base.test.ts
@@ -1,4 +1,4 @@
-import { deepStrictEqual, ok, strictEqual } from 'node:assert'
+import { deepStrictEqual, ok, rejects, strictEqual } from 'node:assert'
 import { randomUUID } from 'node:crypto'
 import { once } from 'node:events'
 import { test } from 'node:test'
@@ -970,6 +970,25 @@ test('kGetBootstrapConnection rotates broker list based on retry attempt', t => 
   strictEqual(capturedLists[1][0].host, 'broker-b') // attempt 1: offset by 1
   strictEqual(capturedLists[2][0].host, 'broker-c') // attempt 2: offset by 2
   strictEqual(capturedLists[3][0].host, 'broker-a') // attempt 3: wraps around (3 % 3 = 0)
+})
+
+test('metadata should not crash when the error is not a library error', async t => {
+  const client = createBase(t, { retries: 0 })
+
+  // A plain Error has no findBy, so classifying it must degrade instead of throwing a TypeError.
+  const plainError = new Error('Connection pool is closed.')
+  const pool = client[kConnections]
+  pool.getFirstAvailable = function (_brokers: Broker[], callback: CallbackWithPromise<Connection>) {
+    callback(plainError)
+  } as typeof pool.getFirstAvailable
+
+  await rejects(
+    () => client.metadata({ topics: [] }),
+    error => {
+      strictEqual(error, plainError)
+      return true
+    }
+  )
 })
 
 test('metadata retries on TimeoutError', async t => {

--- a/test/clients/consumer/consumer.test.ts
+++ b/test/clients/consumer/consumer.test.ts
@@ -35,6 +35,7 @@ import {
   FetchIsolationLevels,
   fetchV17,
   findCoordinatorV6,
+  GenericError,
   type GroupPartitionsAssignments,
   heartbeatV4,
   instancesChannel,
@@ -3894,6 +3895,57 @@ test('commit should invalidate cached coordinator on coordinator connection erro
   )
 
   strictEqual(consumer.coordinatorId, null)
+})
+
+test('commit should not crash when the error is not a library error', async t => {
+  const consumer = createConsumer(t, { retries: 0 })
+  // A plain Error has no findBy, so classifying it must degrade instead of throwing a TypeError.
+  const plainError = new Error('Connection pool is closed.')
+  mockConsumerGroupCoordinator(consumer, 1, plainError)
+
+  const coordinatorId = await consumer.findGroupCoordinator()
+
+  strictEqual(consumer.coordinatorId, coordinatorId)
+
+  await rejects(
+    async () => {
+      await consumer.commit({ offsets: [{ topic: 'test-topic', partition: 0, offset: 100n, leaderEpoch: 0 }] })
+    },
+    error => {
+      strictEqual(error, plainError)
+      return true
+    }
+  )
+
+  // Nothing could be classified, so the cached coordinator is left alone.
+  strictEqual(consumer.coordinatorId, coordinatorId)
+})
+
+test('a closed connection pool should surface a library error rather than an uncaught TypeError', async t => {
+  const consumer = createConsumer(t, { retries: 0 })
+  const topic = await createTopic(t, true)
+
+  // Resolve the coordinator first so the next call asks the pool for a specific broker.
+  await consumer.findGroupCoordinator()
+
+  // Close the pool underneath the running client, which is the state the original crash hit.
+  await consumer[kConnections].close()
+
+  await rejects(
+    async () => {
+      await consumer.listCommittedOffsets({ topics: [{ topic, partitions: [0] }] })
+    },
+    error => {
+      ok(GenericError.isGenericError(error as Error))
+
+      const closedPoolError = (error as GenericError).findBy('closed', true)
+      ok(closedPoolError)
+      strictEqual(closedPoolError.message, 'Connection pool is closed.')
+      strictEqual(closedPoolError.code, 'PLT_KFK_NETWORK')
+      strictEqual(closedPoolError.canRetry, false)
+      return true
+    }
+  )
 })
 
 test('findGroupCoordinator should support both promise and callback API', t => {

--- a/test/clients/consumer/consumer.test.ts
+++ b/test/clients/consumer/consumer.test.ts
@@ -3533,6 +3533,42 @@ test('getLag should return the consumer lag', async t => {
   await Promise.all(consumers.map(consumer => consumer.topics.trackAll(topic)))
   await Promise.all(consumers.map(consumer => consumer.joinGroup()))
 
+  // joinGroup resolves once a consumer synced, but the consumers that joined earlier only rejoin
+  // after their next heartbeat, so the group rebalances again behind this await. Capturing an
+  // assignment before it settles picks a partition that a later rebalance can take away.
+  async function waitForOnePartitionEach (): Promise<void> {
+    let assigned: number[][] = []
+
+    for (let i = 0; i < 100; i++) {
+      assigned = consumers.map(consumer => consumer.assignments?.find(a => a.topic === topic)?.partitions ?? [])
+
+      if (assigned.every(partitions => partitions.length === 1) && new Set(assigned.flat()).size === 3) {
+        return
+      }
+
+      await sleep(50)
+    }
+
+    throw new Error(`The group never settled on one partition per consumer, got ${JSON.stringify(assigned)}.`)
+  }
+
+  // A group join clears the committed offsets a stream reports, and getLag reads exactly those, so
+  // a partition whose offset has not been republished yet reads as unassigned.
+  async function waitForCommittedOffset (
+    stream: MessagesStream<Buffer, Buffer, Buffer, Buffer>,
+    partition: number
+  ): Promise<void> {
+    const key = `${topic}:${partition}`
+
+    for (let i = 0; i < 100 && !stream.offsetsCommitted.has(key); i++) {
+      await sleep(50)
+    }
+
+    ok(stream.offsetsCommitted.has(key), `No committed offset for partition ${partition}.`)
+  }
+
+  await waitForOnePartitionEach()
+
   async function setup (
     consumer: Consumer,
     offset: bigint
@@ -3549,9 +3585,7 @@ test('getLag should return the consumer lag', async t => {
       maxBytes: 10
     })
 
-    if (stream.offsetsCommitted.size === 0) {
-      await once(stream, 'offsets')
-    }
+    await waitForCommittedOffset(stream, partition)
 
     return [partition, stream]
   }
@@ -3562,6 +3596,11 @@ test('getLag should return the consumer lag', async t => {
   const [consumerPartition3, stream3] = await setup(consumer3, 3n)
 
   try {
+    // Creating the later streams can have triggered another join, so recheck before reading the lag.
+    await waitForCommittedOffset(stream1, consumerPartition1)
+    await waitForCommittedOffset(stream2, consumerPartition2)
+    await waitForCommittedOffset(stream3, consumerPartition3)
+
     const lag1 = (await consumer1.getLag({ topics: [topic] })).get(topic)!
     const lag2 = (await consumer2.getLag({ topics: [topic] })).get(topic)!
     const lag3 = (await consumer3.getLag({ topics: [topic] })).get(topic)!

--- a/test/clients/consumer/consumer.test.ts
+++ b/test/clients/consumer/consumer.test.ts
@@ -955,6 +955,9 @@ test('consume should fail when consumer is closed', async t => {
   } catch (error) {
     strictEqual(error instanceof NetworkError, true)
     strictEqual(error.message, 'Client is closed.')
+    // A closed client never reopens, so the error must not be retried.
+    strictEqual(error.canRetry, false)
+    strictEqual(error.closed, true)
   }
 })
 
@@ -3946,6 +3949,9 @@ test('a closed connection pool should surface a library error rather than an unc
       return true
     }
   )
+
+  // The closed pool error is a network error, so the cached coordinator is invalidated.
+  strictEqual(consumer.coordinatorId, null)
 })
 
 test('findGroupCoordinator should support both promise and callback API', t => {

--- a/test/clients/producer/producer.test.ts
+++ b/test/clients/producer/producer.test.ts
@@ -1377,10 +1377,20 @@ test('send should handle errors from Base.metadata in internal calls', async t =
 })
 
 test('send should return produced messages when another destination fails', async t => {
-  const producer = createProducer(t, { retries: 0 })
+  const producer = createProducer(t)
   const testTopic = await createTopic(t, true, 3)
 
-  let partition = -1
+  const messages = [
+    { topic: testTopic, value: Buffer.from('produced-message'), partition: 0 },
+    { topic: testTopic, value: Buffer.from('failed-message'), partition: 1 }
+  ]
+
+  // Produce once with retries still enabled. A freshly created topic can still be settling
+  // leadership, and this test needs the destination that is not mocked to reliably succeed.
+  await producer.send({ messages })
+  producer[kOptions].retries = 0
+
+  let calls = 0
   mockAPI(producer[kConnections], produceV11.api.key, null, null, (
     originalSend,
     apiKey,
@@ -1391,9 +1401,9 @@ test('send should return produced messages when another destination fails', asyn
     hasResponseHeaderTaggedFields,
     callback
   ) => {
-    partition++
+    calls++
 
-    if (partition === 0) {
+    if (calls === 1) {
       callback(new GenericError('PLT_KFK_NETWORK', 'Produce failed.', { canRetry: false }))
     } else {
       originalSend(
@@ -1412,18 +1422,18 @@ test('send should return produced messages when another destination fails', asyn
 
   await rejects(
     async () => {
-      await producer.send({
-        messages: [
-          { topic: testTopic, value: Buffer.from('produced-message'), partition: 0 },
-          { topic: testTopic, value: Buffer.from('failed-message'), partition: 1 }
-        ]
-      })
+      await producer.send({ messages })
     },
     error => {
-      const produced = (error as MultipleErrors).produced?.offsets?.[0] as TopicWithPartitionAndOffset
+      // The two partitions must have different leaders, otherwise there is only one destination and
+      // nothing is left to succeed.
+      strictEqual(calls, 2)
 
-      deepStrictEqual((error as MultipleErrors).produced, { offsets: [produced] })
-      deepStrictEqual(produced.topic, testTopic)
+      const produced = (error as MultipleErrors).produced as ProduceResult
+      const offsets = produced.offsets as TopicWithPartitionAndOffset[]
+
+      strictEqual(offsets.length, 1)
+      strictEqual(offsets[0].topic, testTopic)
       return true
     }
   )

--- a/test/clients/producer/transactions.test.ts
+++ b/test/clients/producer/transactions.test.ts
@@ -193,6 +193,37 @@ test('transaction commit should invalidate cached coordinator on coordinator pro
   strictEqual(producer.coordinatorId, undefined)
 })
 
+test('transaction commit should not crash when the error is not a library error', async t => {
+  const transactionalId = randomUUID()
+  const producer = createProducer(t, {
+    idempotent: true,
+    strict: true,
+    transactionalId
+  })
+  producer[kOptions].retries = 0
+  // A plain Error has no findBy, so classifying it must degrade instead of throwing a TypeError.
+  const plainError = new Error('Connection pool is closed.')
+  mockTransactionCoordinator(producer, 1, plainError)
+
+  const transaction = await producer.beginTransaction()
+  const coordinatorId = producer.coordinatorId
+
+  strictEqual(typeof coordinatorId, 'number')
+
+  await rejects(
+    async () => {
+      await transaction.commit()
+    },
+    error => {
+      strictEqual(error, plainError)
+      return true
+    }
+  )
+
+  // Nothing could be classified, so the cached coordinator is left alone.
+  strictEqual(producer.coordinatorId, coordinatorId)
+})
+
 test('beginTransaction should validate options in strict mode', async t => {
   const producer = createProducer(t, { strict: true })
 

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -14,7 +14,8 @@ import {
   UnsupportedCompressionError,
   UnsupportedError,
   UserError,
-  errorCodes
+  errorCodes,
+  findErrorBy
 } from '../src/index.ts'
 
 test('should export error codes with correct prefix', () => {
@@ -288,6 +289,27 @@ test('ProtocolError FENCED_LEADER_EPOCH has hasStaleMetadata', () => {
   deepStrictEqual(error.code, 'PLT_KFK_PROTOCOL')
   deepStrictEqual(error.apiId, 'FENCED_LEADER_EPOCH')
   deepStrictEqual(error.hasStaleMetadata, true)
+})
+
+test('findErrorBy - classifies library errors and ignores everything else', () => {
+  const error = new GenericError('PLT_KFK_USER', 'error', { foo: 'bar' })
+
+  strictEqual(findErrorBy(error, 'foo', 'bar'), error)
+  strictEqual(findErrorBy(error, 'foo', 'baz'), null)
+
+  // Errors from user code, Node internals or third parties have no findBy, so they must report no
+  // match rather than throwing a TypeError.
+  strictEqual(findErrorBy(new Error('plain'), 'foo', 'bar'), null)
+  strictEqual(findErrorBy(null, 'foo', 'bar'), null)
+  strictEqual(findErrorBy(undefined, 'foo', 'bar'), null)
+})
+
+test('findErrorBy - recurses into nested errors', () => {
+  const nested = new GenericError('PLT_KFK_USER', 'nested', { foo: 'bar' })
+  const error = new MultipleErrors('multiple', [new Error('plain'), nested])
+
+  strictEqual(findErrorBy(error, 'foo', 'bar'), nested)
+  strictEqual(findErrorBy(error, 'foo', 'baz'), null)
 })
 
 test('MultipleErrors.findBy - handles undefined entries in errors array', () => {

--- a/test/network/connection-pool.test.ts
+++ b/test/network/connection-pool.test.ts
@@ -9,6 +9,7 @@ import {
   type ConnectionPoolDiagnosticEvent,
   connectionsPoolGetsChannel,
   ConnectionStatuses,
+  GenericError,
   instancesChannel
 } from '../../src/index.ts'
 import {
@@ -316,6 +317,25 @@ test('get fail when the pool is closed', async t => {
   await connectionPool.close()
 
   await rejects(() => connectionPool.get(broker) as Promise<unknown>, { message: 'Connection pool is closed.' })
+})
+
+test('get should reject with a non retriable library error when the pool is closed', async t => {
+  const { port } = await createServer(t)
+  const broker = { host: 'localhost', port }
+
+  const connectionPool = new ConnectionPool('test-client')
+  t.after(() => connectionPool.close())
+  await connectionPool.close()
+
+  // The clients classify errors via findBy, which only exists on GenericError subclasses.
+  await rejects(() => connectionPool.get(broker) as Promise<unknown>, error => {
+    ok(GenericError.isGenericError(error as Error))
+    deepStrictEqual((error as GenericError).code, 'PLT_KFK_NETWORK')
+    deepStrictEqual((error as GenericError).canRetry, false)
+    deepStrictEqual((error as GenericError).closed, true)
+    deepStrictEqual((error as GenericError).findBy('code', 'PLT_KFK_NETWORK'), error)
+    return true
+  })
 })
 
 test('get should reject with a retriable error when the broker is missing from stale metadata', async t => {

--- a/test/network/connection-pool.test.ts
+++ b/test/network/connection-pool.test.ts
@@ -309,31 +309,23 @@ test('get should support diagnostic channels', async t => {
 })
 
 test('get fail when the pool is closed', async t => {
-  const { port } = await createServer(t)
-  const broker = { host: 'localhost', port }
+  // No server is needed: the pool rejects before it attempts to connect.
+  const broker = { host: 'localhost', port: 9092 }
 
   const connectionPool = new ConnectionPool('test-client')
   t.after(() => connectionPool.close())
   await connectionPool.close()
 
-  await rejects(() => connectionPool.get(broker) as Promise<unknown>, { message: 'Connection pool is closed.' })
-})
-
-test('get should reject with a non retriable library error when the pool is closed', async t => {
-  const { port } = await createServer(t)
-  const broker = { host: 'localhost', port }
-
-  const connectionPool = new ConnectionPool('test-client')
-  t.after(() => connectionPool.close())
-  await connectionPool.close()
-
-  // The clients classify errors via findBy, which only exists on GenericError subclasses.
   await rejects(() => connectionPool.get(broker) as Promise<unknown>, error => {
+    strictEqual((error as Error).message, 'Connection pool is closed.')
+
+    // The clients classify errors via findBy, which only exists on GenericError subclasses.
     ok(GenericError.isGenericError(error as Error))
-    deepStrictEqual((error as GenericError).code, 'PLT_KFK_NETWORK')
-    deepStrictEqual((error as GenericError).canRetry, false)
-    deepStrictEqual((error as GenericError).closed, true)
-    deepStrictEqual((error as GenericError).findBy('code', 'PLT_KFK_NETWORK'), error)
+    strictEqual((error as GenericError).code, 'PLT_KFK_NETWORK')
+    strictEqual((error as GenericError).canRetry, false)
+    strictEqual((error as GenericError).closed, true)
+    deepStrictEqual((error as GenericError).broker, broker)
+    strictEqual((error as GenericError).findBy('code', 'PLT_KFK_NETWORK'), error)
     return true
   })
 })


### PR DESCRIPTION
## Problem

`ConnectionPool.#get` emits a plain `Error` when the pool is already closed, while every sibling
path in that method emits a `GenericError` subclass. That plain error reaches
`Consumer.#handleError` / `Producer.#handleError`, which call `findBy()` on it unconditionally.
`findBy` only exists on the library's own error classes, so it throws:

```
TypeError: kafkaError.findBy is not a function
 ❯ Consumer.#handleError
 ❯ ConnectionPool.#get
 ❯ ConnectionPool.get
 ❯ Consumer[kGetConnection]
 ❯ Consumer.#performMetadata
```

It throws asynchronously out of a retry callback chain where nothing can catch it, so it surfaces
as an uncaught exception and takes down whatever reconnect/retry logic was in flight.

Originally hit by destroying a consumer stream while a metadata fetch was in flight on Node 24,
where stream teardown ordering leaves the pool closed by the time the retry asks for a connection.
The defect is latent on every Node version; Node 24 just makes the branch reliably reachable.

## Changes

1. `ConnectionPool.#get` emits `new NetworkError('Connection pool is closed.', { canRetry: false, closed: true, broker })`.
   A closed pool never reopens, so retrying is pointless, and `kPerformWithRetry` can now read
   `canRetry` instead of retrying blindly.

2. Every `findBy` call site goes through a new `findErrorBy` helper in `errors.ts`, which brand
   checks with `GenericError.isGenericError` and returns `null` for anything it cannot classify.
   The codebase previously guarded three different ways (an optional call, an inline brand check,
   and a cast to an intersection type asserting `findBy` exists) and two sites had no guard at all,
   which is what produced the crash. Classification is now total by construction rather than by
   remembering to guard, and the unchecked `as GenericError` casts that let the missing guards
   compile are gone.

3. `'Client is closed.'` now carries `canRetry: false` too. A closed client never reopens either,
   so the two closed-state errors no longer disagree about retriability. `kCheckNotClosed` runs
   before `kPerformWithRetry`, so no retry loop changes behaviour.

## Tests

- `ConnectionPool` - a closed pool rejects with an error that passes `GenericError.isGenericError`,
  carries `PLT_KFK_NETWORK` / `canRetry: false` / the requested broker, and has a callable `findBy`.
- `Base[kMetadata]` - a plain `Error` from the pool, the exact path from the stack trace above,
  passes through untouched instead of crashing.
- `Consumer` and `Producer` - feeding a plain `Error` through the coordinator paths returns it
  unchanged, never throws, and leaves the cached coordinator alone since nothing could be classified.
- End-to-end - closing the pool underneath a running consumer surfaces a library error carrying the
  closed-pool error rather than an uncaught `TypeError`, and the consumer drops its cached
  coordinator.
- `findErrorBy` itself - matches on library errors, recurses into nested ones, returns `null` for
  plain errors, `null` and `undefined`.

The tests covering the original defect fail on the unfixed source with the reported `TypeError`.

## Pre-existing flaky tests fixed along the way

CI went red twice on this branch on tests unrelated to the fix. Both are pre-existing races, not
regressions: the second red run was on a tree identical to a green one apart from a `Signed-off-by`
trailer, and `getLag` fails on `main` too. They are fixed here rather than re-run away, in separate
commits so they can be split out.

- `send should return produced messages when another destination fails` mocked the first produce
  call to fail and expected the other destination to still return an offset, but ran with retries
  disabled against a topic created milliseconds earlier. Any transient produce failure on the
  destination that was not mocked left `produced.offsets` empty. It now produces once with retries
  enabled to settle leadership before installing the mock. The old expectation also compared
  `produced` against an object built from `produced` itself, so it could only fail with the
  unreadable diff `[] vs [undefined]`; it now asserts that both destinations were called and that
  exactly one offset came back.

- `getLag should return the consumer lag` failed with `-1n` for the partition the consumer owns.
  `joinGroup` resolves once a consumer synced, but consumers that joined earlier only rejoin on
  their next heartbeat, so the group rebalances again behind the `Promise.all` and the test captured
  an assignment a later rebalance took away. A group join also clears the committed offsets a stream
  reports, and `getLag` reads exactly those, so a partition whose offset has not been republished
  yet reads as unassigned. It now waits for every consumer to settle on one distinct partition, and
  for each stream to republish the offset for its own partition. The old guard only checked that
  some offset had been committed, which a stream holding several partitions mid rebalance satisfies
  without the partition under test being ready.

## Verification

CI is green across the full matrix. Locally, against a 3-broker cluster on Node 24.16.0, the only
failures are environmental and reproduce identically on a clean `main`: 4 SASL/GSSAPI tests (the
`kdc` container does not start locally) and `gzip compression works correctly`.
