### PR TITLE
fix: prevent RangeError in runAsyncSeries with synchronous callbacks on large batches

### DIFF
--- a/src/registries/abstract.ts
+++ b/src/registries/abstract.ts
@@ -34,22 +34,49 @@ export function runAsyncSeries<V> (
   index: number,
   callback: Callback<void>
 ): void {
-  if (collection.length === 0 || index >= collection.length) {
+  const length = collection.length
+
+  if (length === 0 || index >= length) {
     callback(null)
     return
   }
 
-  operation(collection[index], error => {
-    if (error) {
-      callback(error)
-      return
-    } else if (index === collection.length - 1) {
-      callback(null)
+  while (index < length) {
+    let invocationReturned = false
+    let cbCalled = false
+    let cbError: Error | null | undefined
+
+    operation(collection[index], error => {
+      if (invocationReturned) {
+        // The callback was invoked asynchronously, so continuing recursively does not grow the current stack.
+        if (error) {
+          callback(error)
+          return
+        }
+        runAsyncSeries(operation, collection, index + 1, callback)
+        return
+      }
+
+      cbCalled = true
+      cbError = error
+    })
+
+    invocationReturned = true
+
+    if (!cbCalled) {
+      // Wait for the async callback to continue the series.
       return
     }
 
-    runAsyncSeries(operation, collection, index + 1, callback)
-  })
+    if (cbError) {
+      callback(cbError)
+      return
+    }
+
+    index++
+  }
+
+  callback(null)
 }
 
 /* c8 ignore start */

--- a/test/registries/abstract.test.ts
+++ b/test/registries/abstract.test.ts
@@ -26,3 +26,29 @@ test('runAsyncSeries should complete with empty collections', async () => {
 
   strictEqual(operationCalls, 0)
 })
+
+test('runAsyncSeries should not blow the call stack on large collections with synchronous operations', async () => {
+  const collection = Array.from({ length: 5_000 }, (_, i) => i)
+  let operationCalls = 0
+
+  await new Promise<void>((resolve, reject) => {
+    runAsyncSeries(
+      (_item: number, callback) => {
+        operationCalls++
+        callback(null)
+      },
+      collection,
+      0,
+      error => {
+        if (error) {
+          reject(error)
+          return
+        }
+
+        resolve()
+      }
+    )
+  })
+
+  strictEqual(operationCalls, collection.length)
+})

--- a/test/registries/abstract.test.ts
+++ b/test/registries/abstract.test.ts
@@ -28,7 +28,7 @@ test('runAsyncSeries should complete with empty collections', async () => {
 })
 
 test('runAsyncSeries should not blow the call stack on large collections with synchronous operations', async () => {
-  const collection = Array.from({ length: 5_000 }, (_, i) => i)
+  const collection = Array.from({ length: 50_000 }, (_, i) => i)
   let operationCalls = 0
 
   await new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
Fixes #353 

### Problem
Producing batches of messages with schema registry enabled can result in `RangeError: Maximum call stack size exceeded`

The issue was initially observed while producing Kafka messages, but it can potentially affect consumers as well.

### Resolution
The signature of runAsyncSeries was left untouched to avoid changing the philosophy of the library.
I also kept performance in mind by preserving the synchronous fast path, without unnecessarily introducing asynchronous scheduling overhead.

To achieve this, synchronous operations are handled with a while loop, so runAsyncSeries does not add a new stack frame per operation. When an async operation is encountered, the current execution returns, and once cb is called a new loop starts from the next index. This recursion is safe in this case, since it starts with a clean stack.




