### PR TITLE
feat: expose consumed key/value schema IDs in message metadata

### DIFF
--- a/docs/confluent-schema-registry.md
+++ b/docs/confluent-schema-registry.md
@@ -364,6 +364,33 @@ const message = {
 }
 ```
 
+## Message Metadata (Consumer)
+
+The schema IDs used to decode a consumed message are exposed on its metadata, alongside the consumer
+information the stream already adds:
+
+```typescript
+for await (const message of stream) {
+  // { value: 2 }
+  console.log(message.metadata.schemas)
+}
+```
+
+The shape mirrors the one used when producing:
+
+```typescript
+message.metadata.schemas = {
+  key?: number,
+  value?: number
+}
+```
+
+Only the payloads which actually carry a Confluent wire format header appear there, so a message
+consumed without a schema has no `schemas` entry at all.
+
+The IDs are recorded before the schema is fetched and before the payload is decoded, so they are
+still available when either step fails.
+
 ## Schema Types
 
 ### AVRO Schema

--- a/docs/consumer.md
+++ b/docs/consumer.md
@@ -255,8 +255,37 @@ When using a schema registry:
 - The registry fetches and caches schemas as needed
 - JSON schemas are validated on receive (and optionally on send)
 - Supports AVRO, Protocol Buffers, and JSON Schema formats
+- The schema IDs used to decode each message are exposed as `message.metadata.schemas`
 
 For more details, see the [Confluent Schema Registry](./confluent-schema-registry.md) documentation.
+
+### Adding custom message metadata
+
+Deserializers and `beforeDeserialization` hooks receive the message being processed and can assign a
+`metadata` object to it. Those properties are merged into the `metadata` of the message pushed to the
+stream, on top of the `consumer` information the stream always adds:
+
+```typescript
+const consumer = new Consumer({
+  groupId: 'my-consumer-group',
+  clientId: 'my-consumer',
+  bootstrapBrokers: ['localhost:9092'],
+  deserializers: {
+    ...stringDeserializers,
+    value (data, headers, message) {
+      message.metadata = { valueLength: data.length }
+      return stringDeserializers.value(data)
+    }
+  }
+})
+
+for await (const message of stream) {
+  console.log(message.metadata.valueLength)
+}
+```
+
+Each message gets its own metadata object, so mutating it never affects the other messages of the
+same batch.
 
 ## Rack-aware fetching
 

--- a/src/clients/consumer/messages-stream.ts
+++ b/src/clients/consumer/messages-stream.ts
@@ -951,7 +951,10 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
                 timestamp: firstTimestamp + record.timestampDelta,
                 offset,
                 commit,
-                metadata: messageMetadata,
+                // Deserializers and hooks can enrich the metadata of the message they processed
+                metadata: messageToConsume.metadata
+                  ? { ...messageMetadata, ...messageToConsume.metadata }
+                  : messageMetadata,
                 toJSON: messageToJSON
               } as Message
 

--- a/src/protocol/records.ts
+++ b/src/protocol/records.ts
@@ -118,6 +118,11 @@ export interface KafkaRecord {
 export interface MessageToConsume extends KafkaRecord {
   topic: string
   partition: number
+  /*
+    Deserializers and before-deserialization hooks can populate this to enrich the metadata of the
+    message which is eventually pushed to the consumer stream.
+  */
+  metadata?: Record<string, unknown>
 }
 
 /*

--- a/src/registries/confluent-schema-registry.ts
+++ b/src/registries/confluent-schema-registry.ts
@@ -96,7 +96,7 @@ export function createUndiciAgent (options: UndiciAgentOptions): UndiciDispatche
 }
 
 export interface ConfluentSchemaRegistryMetadata {
-  schemas?: Record<BeforeHookPayloadType, number>
+  schemas?: Partial<Record<BeforeHookPayloadType, number>>
 }
 
 export type ConfluentSchemaRegistryProtobufTypeMapper = (
@@ -173,6 +173,21 @@ export interface Schema {
   id: number
   type: 'avro' | 'protobuf' | 'json'
   schema: Type | Root | ValidateFunction
+}
+
+export function trackConsumedSchemaId (
+  message: MessageToConsume | undefined,
+  type: BeforeHookPayloadType,
+  schemaId: number
+): void {
+  /* c8 ignore next 3 - The message is always provided for keys and values */
+  if (!message) {
+    return
+  }
+
+  const metadata = (message.metadata ??= {}) as ConfluentSchemaRegistryMetadata
+  metadata.schemas ??= {}
+  metadata.schemas[type] = schemaId
 }
 
 /* c8 ignore next 8 */
@@ -325,7 +340,7 @@ export class ConfluentSchemaRegistry<
     return function beforeDeserialization (
       payload: Buffer | null,
       type: BeforeHookPayloadType,
-      _message: MessageToConsume,
+      message: MessageToConsume,
       callback: Callback<void>
     ) {
       // Extract the schema ID from the message metadata
@@ -336,6 +351,12 @@ export class ConfluentSchemaRegistry<
         callback(null)
         return
       }
+
+      /*
+        Track the schema ID before fetching, so that it is exposed on the message metadata even when
+        the schema cannot be fetched or the payload cannot be decoded.
+      */
+      trackConsumedSchemaId(message, type, schemaId)
 
       // The schema is already fetch
       if (registry.get(schemaId)) {
@@ -564,7 +585,9 @@ export class ConfluentSchemaRegistry<
       return EMPTY_BUFFER
     }
 
-    if (type === 'headerKey' || type === 'headerValue') {
+    const isHeader = type === 'headerKey' || type === 'headerValue'
+
+    if (isHeader) {
       message = headers as unknown as MessageToConsume
     }
 
@@ -572,6 +595,14 @@ export class ConfluentSchemaRegistry<
 
     if (!schemaId) {
       return fallbackDeserializer(data as any)
+    }
+
+    /*
+      Also track the schema ID here, so that it is exposed on the message metadata even when the
+      deserializers are used without the before-deserialization hook of this registry.
+    */
+    if (!isHeader) {
+      trackConsumedSchemaId(message, type, schemaId)
     }
 
     const schema = this.#schemas.get(schemaId)

--- a/test/clients/consumer/messages-stream.test.ts
+++ b/test/clients/consumer/messages-stream.test.ts
@@ -18,6 +18,7 @@ import {
   jsonDeserializer,
   type KafkaRecord,
   kNoopCallbackReturnValue,
+  type MessageToConsume,
   type Message,
   MessagesStream,
   MessagesStreamFallbackModes,
@@ -1953,4 +1954,40 @@ test('should handle async beforeDeserialization hooks errors', async t => {
   } finally {
     process.emitWarning = originalEmitWarning
   }
+})
+
+test('should expose the metadata added by deserializers on the consumed messages', async t => {
+  const groupId = createTestGroupId()
+  const topic = await createTopic(t, true)
+
+  await produceTestMessages(t, topic, 2)
+
+  const consumer = createConsumer(t, groupId, {
+    deserializers: {
+      ...stringDeserializers,
+      value (data?: Buffer, _?: Map<string, string>, message?: MessageToConsume) {
+        message!.metadata = { valueLength: data!.length }
+        return stringDeserializers.value(data)
+      }
+    } as unknown as Deserializers<string, string, string, string>
+  })
+
+  const stream = await consumer.consume({
+    topics: [topic],
+    mode: MessagesStreamModes.EARLIEST,
+    maxFetches: 1
+  })
+
+  const messages: Message<string, string, string, string>[] = []
+  for await (const message of stream) {
+    messages.push(message)
+  }
+
+  strictEqual(messages.length, 2)
+  strictEqual(messages[0].metadata.valueLength, 7)
+  strictEqual(messages[1].metadata.valueLength, 7)
+
+  // The metadata added by the consumer is preserved and each message gets its own object
+  strictEqual((messages[0].metadata.consumer as { groupId: string }).groupId, groupId)
+  ok(messages[0].metadata !== messages[1].metadata)
 })

--- a/test/registries/confluent-schema-registry.test.ts
+++ b/test/registries/confluent-schema-registry.test.ts
@@ -1559,3 +1559,93 @@ test('reuses a single dispatcher across schema fetches', async t => {
   strictEqual(registry.get(1)?.type, 'avro')
   strictEqual(registry.get(2)?.type, 'avro')
 })
+
+test('exposes the schema IDs used while consuming on the message metadata', async t => {
+  const topic = await createTopic(t, true)
+
+  const registry = new ConfluentSchemaRegistry<string, Datum, string, string>({
+    url: confluentSchemaRegistryUrl
+  })
+
+  const subject = createSubject()
+  const schemaId = await registerSchema(
+    confluentSchemaRegistryUrl,
+    subject,
+    'AVRO',
+    JSON.stringify({
+      type: 'record',
+      name: subject,
+      fields: [
+        { name: 'id', type: 'int' },
+        { name: 'name', type: 'string' }
+      ]
+    })
+  )
+
+  const producer = await createProducer(t, { registry })
+  await producer.send({
+    messages: [
+      { topic, key: 'key-1', value: { id: 1, name: 'Alice' }, metadata: { schemas: { value: schemaId } } },
+      { topic, key: 'key-2', value: { id: 2, name: 'Bob' }, metadata: { schemas: { value: schemaId } } }
+    ]
+  })
+
+  const consumer = createConsumer(t, { registry })
+  const stream = await consumer.consume({ topics: [topic], maxFetches: 1, mode: MessagesStreamModes.EARLIEST })
+  const messages = []
+  for await (const message of stream) {
+    messages.push(message)
+  }
+
+  deepStrictEqual(messages[0].metadata.schemas, { value: schemaId })
+  deepStrictEqual(messages[1].metadata.schemas, { value: schemaId })
+
+  // The metadata added by the registry does not replace the one added by the consumer
+  strictEqual((messages[0].metadata.consumer as { groupId: string }).groupId, consumer.groupId)
+
+  // Each message gets its own metadata object
+  ok(messages[0].metadata !== messages[1].metadata)
+})
+
+test('exposes the schema IDs when the registry deserializers are used without the hook', async t => {
+  const topic = await createTopic(t, true)
+
+  const registry = new ConfluentSchemaRegistry<string, Datum, string, string>({
+    url: confluentSchemaRegistryUrl
+  })
+
+  const subject = createSubject()
+  const schemaId = await registerSchema(
+    confluentSchemaRegistryUrl,
+    subject,
+    'AVRO',
+    JSON.stringify({
+      type: 'record',
+      name: subject,
+      fields: [
+        { name: 'id', type: 'int' },
+        { name: 'name', type: 'string' }
+      ]
+    })
+  )
+
+  const producer = await createProducer(t, { registry })
+  await producer.send({
+    messages: [{ topic, key: 'key-1', value: { id: 1, name: 'Alice' }, metadata: { schemas: { value: schemaId } } }]
+  })
+
+  // Preload the schema, as there is no hook to fetch it before deserializing
+  await new Promise<void>((resolve, reject) => {
+    registry.fetchSchema(schemaId, error => (error ? reject(error) : resolve()))
+  })
+
+  const consumer = createConsumer(t, { deserializers: registry.getDeserializers() })
+  const stream = await consumer.consume({ topics: [topic], maxFetches: 1, mode: MessagesStreamModes.EARLIEST })
+  const messages = []
+  for await (const message of stream) {
+    messages.push(message)
+  }
+
+  deepStrictEqual(structuredClone(messages[0].value), { id: 1, name: 'Alice' })
+  deepStrictEqual(messages[0].metadata.schemas, { value: schemaId })
+})


### PR DESCRIPTION
Fixes #346

## Problem

`ConfluentSchemaRegistry` reads the schema ID out of every Confluent wire-format payload to decode it, then throws it away. Applications that need it — observability, auditing, routing, schema provenance — had to reparse the original bytes, which are no longer on the message once the deserializer replaced them.

## Change

Consumed messages now carry `metadata.schemas`, mirroring the shape already used when producing:

```ts
for await (const message of stream) {
  console.log(message.metadata.schemas) // { value: 2 }
}
```

The plumbing is generic rather than registry-specific:

- `MessageToConsume` gains an optional `metadata` object that deserializers and `beforeDeserialization` hooks can populate.
- The stream merges it on top of the consumer metadata when building the `Message`. Each message gets its own object, so the shared per-batch metadata object is never mutated and messages cannot leak metadata into each other.

The registry records the ID in two places:

- in its before-deserialization hook, **before** the schema is fetched and **before** the payload is decoded, so the ID is still available when either step fails;
- in its deserializers, so the IDs are exposed when the deserializers are used on their own, without the hook.

Only payloads that actually carry a wire-format header get an entry, so messages consumed without a schema have no `schemas` key at all.

## Tests

- schema IDs on the metadata when consuming through the registry, coexisting with the `consumer` metadata, with a distinct object per message
- schema IDs when the registry deserializers are used without the hook
- a stream-level test that a plain custom deserializer can enrich the metadata, covering the generic mechanism independently of the registry