### PR TITLE
feat: expose original key/value byte lengths after Schema Registry decode

### DIFF
--- a/docs/confluent-schema-registry.md
+++ b/docs/confluent-schema-registry.md
@@ -391,6 +391,22 @@ consumed without a schema has no `schemas` entry at all.
 The IDs are recorded before the schema is fetched and before the payload is decoded, so they are
 still available when either step fails.
 
+Deserializing replaces `key` and `value` with the decoded values, so their original `.length` is no
+longer reachable. The registry records the on-wire sizes on the message metadata before decoding:
+
+```typescript
+for await (const message of stream) {
+  // { key: 5, value: 21 }
+  console.log(message.metadata.lengths)
+
+  ingressBytes.inc(message.metadata.lengths.value)
+}
+```
+
+The lengths are the sizes of the payloads as they were received, including the 5 bytes of the
+Confluent wire format header when the payload carries one. Payloads which are absent, such as a null
+key, have no entry.
+
 ## Schema Types
 
 ### AVRO Schema

--- a/docs/consumer.md
+++ b/docs/consumer.md
@@ -256,6 +256,7 @@ When using a schema registry:
 - JSON schemas are validated on receive (and optionally on send)
 - Supports AVRO, Protocol Buffers, and JSON Schema formats
 - The schema IDs used to decode each message are exposed as `message.metadata.schemas`
+- The original key and value byte lengths are exposed as `message.metadata.lengths`
 
 For more details, see the [Confluent Schema Registry](./confluent-schema-registry.md) documentation.
 

--- a/src/registries/confluent-schema-registry.ts
+++ b/src/registries/confluent-schema-registry.ts
@@ -99,6 +99,10 @@ export interface ConfluentSchemaRegistryMetadata {
   schemas?: Partial<Record<BeforeHookPayloadType, number>>
 }
 
+export interface ConfluentSchemaRegistryConsumedMetadata {
+  lengths?: { key?: number; value?: number }
+}
+
 export type ConfluentSchemaRegistryProtobufTypeMapper = (
   id: number,
   type: BeforeHookPayloadType,
@@ -188,6 +192,21 @@ export function trackConsumedSchemaId (
   const metadata = (message.metadata ??= {}) as ConfluentSchemaRegistryMetadata
   metadata.schemas ??= {}
   metadata.schemas[type] = schemaId
+}
+
+export function trackConsumedPayloadLength (
+  message: MessageToConsume | undefined,
+  type: 'key' | 'value',
+  data: Buffer
+): void {
+  /* c8 ignore next 3 - The message is always provided for keys and values */
+  if (!message) {
+    return
+  }
+
+  const metadata = (message.metadata ??= {}) as ConfluentSchemaRegistryConsumedMetadata
+  metadata.lengths ??= {}
+  metadata.lengths[type] = data.length
 }
 
 /* c8 ignore next 8 */
@@ -580,6 +599,14 @@ export class ConfluentSchemaRegistry<
     headers?: Map<string, string>,
     message?: MessageToConsume
   ): unknown {
+    /*
+      Deserializing replaces the original payload, so record its size beforehand: it is the only
+      chance callers have to account for the actual ingress size of the message.
+    */
+    if ((type === 'key' || type === 'value') && Buffer.isBuffer(data)) {
+      trackConsumedPayloadLength(message, type, data)
+    }
+
     /* c8 ignore next 3 - Hard to test */
     if (typeof data === 'undefined' || data.length === 0) {
       return EMPTY_BUFFER

--- a/test/registries/confluent-schema-registry.test.ts
+++ b/test/registries/confluent-schema-registry.test.ts
@@ -1649,3 +1649,68 @@ test('exposes the schema IDs when the registry deserializers are used without th
   deepStrictEqual(structuredClone(messages[0].value), { id: 1, name: 'Alice' })
   deepStrictEqual(messages[0].metadata.schemas, { value: schemaId })
 })
+
+test('exposes the original key and value byte lengths on the message metadata', async t => {
+  const topic = await createTopic(t, true)
+
+  const registry = new ConfluentSchemaRegistry<string, Datum, string, string>({
+    url: confluentSchemaRegistryUrl
+  })
+
+  const subject = createSubject()
+  const schemaId = await registerSchema(
+    confluentSchemaRegistryUrl,
+    subject,
+    'AVRO',
+    JSON.stringify({
+      type: 'record',
+      name: subject,
+      fields: [
+        { name: 'id', type: 'int' },
+        { name: 'name', type: 'string' }
+      ]
+    })
+  )
+
+  const producer = await createProducer(t, { registry })
+  await producer.send({
+    messages: [
+      { topic, key: 'key-1', value: { id: 1, name: 'Alice' }, metadata: { schemas: { value: schemaId } } },
+      { topic, key: 'key-2', value: { id: 2, name: 'Bob' }, metadata: { schemas: { value: schemaId } } }
+    ]
+  })
+
+  // Consume the raw payloads to know the exact on-wire sizes
+  const rawConsumer = createConsumer(t, { deserializers: { key: noopDeserializer, value: noopDeserializer } })
+  const rawStream = await rawConsumer.consume({ topics: [topic], maxFetches: 1, mode: MessagesStreamModes.EARLIEST })
+  const rawMessages = []
+  for await (const message of rawStream) {
+    rawMessages.push(message)
+  }
+
+  const consumer = createConsumer(t, { registry })
+  const stream = await consumer.consume({ topics: [topic], maxFetches: 1, mode: MessagesStreamModes.EARLIEST })
+  const messages = []
+  for await (const message of stream) {
+    messages.push(message)
+  }
+
+  deepStrictEqual(structuredClone(messages[0].value), { id: 1, name: 'Alice' })
+  deepStrictEqual(messages[0].metadata.lengths, {
+    key: rawMessages[0].key.length,
+    value: rawMessages[0].value.length
+  })
+  deepStrictEqual(messages[1].metadata.lengths, {
+    key: rawMessages[1].key.length,
+    value: rawMessages[1].value.length
+  })
+
+  // The decoded value is smaller than the payload it came from, which is the whole point
+  ok((messages[0].metadata.lengths as { value: number }).value > 5)
+
+  // The metadata added by the registry does not replace the one added by the consumer
+  strictEqual((messages[0].metadata.consumer as { groupId: string }).groupId, consumer.groupId)
+
+  // Each message gets its own metadata object
+  ok(messages[0].metadata !== messages[1].metadata)
+})


### PR DESCRIPTION
Fixes #348

## Problem

Without a registry, `key`/`value` are `Buffer`s and callers use `.length` to account for the ingress size of a message. With `ConfluentSchemaRegistry` those fields are replaced by the decoded values before delivery, so the on-wire size is gone and throughput or billing metrics can no longer be derived from a consumed message.

## Change

The registry records the size of each key and value payload **before** decoding it, and exposes them on the message metadata:

```ts
for await (const message of stream) {
  console.log(message.metadata.lengths) // { key: 5, value: 21 }
  ingressBytes.inc(message.metadata.lengths.value)
}
```

The sizes are the payloads exactly as received, including the 5 bytes of the Confluent wire-format header when there is one. Absent payloads (e.g. a null key) get no entry.

The plumbing is generic rather than registry-specific:

- `MessageToConsume` gains an optional `metadata` object that deserializers and `beforeDeserialization` hooks can populate.
- The stream merges it on top of the consumer metadata when building the `Message`. Each message gets its own object, so the shared per-batch metadata object is never mutated and messages cannot leak metadata into each other.

## Tests

- lengths asserted against the exact on-wire sizes, obtained by consuming the same topic a second time with `noopDeserializer`, coexisting with the `consumer` metadata, one object per message
- a stream-level test that a plain custom deserializer can enrich the metadata, covering the generic mechanism independently of the registry

## Note

This shares the `MessageToConsume.metadata` plumbing with the PR for #346 (schema IDs on metadata). Whichever lands first, the other needs a trivial rebase — the two features write different keys into the same object.