### PR TITLE
feat: soft-fail Schema Registry decode errors and continue consuming

### DIFF
--- a/docs/confluent-schema-registry.md
+++ b/docs/confluent-schema-registry.md
@@ -445,4 +445,12 @@ JSON schemas are validated using AJV:
 }
 ```
 
+### Surviving decode failures
+
+Set `onDeserializationError` to return `DeserializationErrorActions.CONTINUE` to keep consuming when a
+message cannot be decoded. The message is delivered with its original bytes and the failure is
+reported on `message.metadata.deserializationError`, instead of the stream being destroyed or the
+message being dropped. See
+[Handling deserialization errors](./consumer.md#handling-deserialization-errors).
+
 JSON validation failures produce a `SchemaValidationError`, which extends `UserError`. The error is passed directly to `onDeserializationError`. When serialization or deserialization fails the operation instead, its outer `UserError` exposes the `SchemaValidationError` as `cause`. The validation error includes `schemaId`, `schemaType`, `phase`, `payloadType`, the decoded `data`, and AJV `validationErrors` so applications can distinguish schema-invalid data from malformed JSON.

--- a/docs/consumer.md
+++ b/docs/consumer.md
@@ -171,7 +171,54 @@ const stream = await consumer.consume({
 })
 ```
 
-The callback is synchronous. If it returns `SKIP`, the record is not emitted and consumption continues. With autocommit enabled, its offset remains eligible for commit. `onDeserializationError` and the deprecated `onCorruptedMessage` cannot be configured together.
+The callback is synchronous and must return one of:
+
+| Action     | Behaviour                                                                                       |
+| ---------- | ----------------------------------------------------------------------------------------------- |
+| `FAIL`     | The stream is destroyed with a `UserError` whose `cause` is the original error.                  |
+| `SKIP`     | The record is not emitted and consumption continues.                                             |
+| `CONTINUE` | The record is emitted in a degraded form and consumption continues.                              |
+
+With autocommit enabled, the offset of a skipped or continued record remains eligible for commit.
+`onDeserializationError` and the deprecated `onCorruptedMessage` cannot be configured together.
+
+#### Continuing with the raw payload
+
+`CONTINUE` trades strict schema enforcement for availability: neither the message nor the stream is
+lost when a payload cannot be decoded, which is what you want when a Schema Registry is temporarily
+unreachable or when a subset of the messages is undecodable.
+
+The delivered message keeps whatever was deserialized before the failure and carries the original
+bytes for the payload which failed and for the ones which were never attempted, since deserialization
+proceeds through headers, key and then value. The failure itself is reported on the metadata:
+
+```typescript
+const stream = await consumer.consume({
+  topics: ['events'],
+  onDeserializationError () {
+    return DeserializationErrorActions.CONTINUE
+  }
+})
+
+for await (const message of stream) {
+  const failure = message.metadata.deserializationError
+
+  if (failure) {
+    // message.value is the raw Buffer, failure.payloadType says which payload failed
+    deadLetters.send({ topic: 'events-dlq', value: message.value })
+    continue
+  }
+
+  handle(message.value)
+}
+```
+
+Because the payload types are no longer guaranteed, always check
+`message.metadata.deserializationError` before trusting `key`, `value` or `headers`.
+
+Nothing is logged when a message is continued: at scale that would be a log storm. The error is
+published on the [`plt:kafka:consumer:receives`](./diagnostic.md) diagnostic channel and exposed on
+the message metadata, so applications can report it at whatever rate they choose.
 
 `MessagesStreamModes` modes:
 

--- a/src/clients/consumer/messages-stream.ts
+++ b/src/clients/consumer/messages-stream.ts
@@ -41,6 +41,7 @@ import {
   type DeserializationErrorContext,
   type DeserializationErrorHandler,
   type GroupAssignment,
+  type MessageDeserializationError,
   type Offsets
 } from './types.ts'
 import { partitionKey } from './utils.ts'
@@ -889,6 +890,7 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
               let payloadType: BeforeHookPayloadType = 'headerKey'
               let deserializedKey: Key | undefined
               let deserializedValue: Value | undefined
+              let deserializationError: MessageDeserializationError | undefined
 
               try {
                 for (const [headerKey, headerValue] of record.headers) {
@@ -917,8 +919,8 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
                   timestamp: firstTimestamp + record.timestampDelta,
                   commit: commit as Message['commit']
                 }
-                const shouldDestroy = this.#deserializationErrorHandler
-                  ? this.#deserializationErrorHandler(context) !== DeserializationErrorActions.SKIP
+                const action = this.#deserializationErrorHandler
+                  ? this.#deserializationErrorHandler(context)
                   : this.#corruptedMessageHandler(
                     record,
                     topic,
@@ -928,16 +930,48 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
                     commit as Message['commit'],
                     error
                   )
+                    ? DeserializationErrorActions.FAIL
+                    : DeserializationErrorActions.SKIP
 
-                if (shouldDestroy) {
+                if (action === DeserializationErrorActions.CONTINUE) {
+                  /*
+                    Deliver the message in a degraded form, so that nothing is lost: whatever was
+                    already deserialized is kept, while the payload which failed and the ones which
+                    were never attempted, since deserialization goes headers, key and then value,
+                    are delivered as the original bytes.
+
+                    The error is reported on the message metadata and published on the diagnostic
+                    channel, which is where callers should react to it: logging here would be a log
+                    storm waiting to happen.
+                  */
+                  diagnosticContext.error = error
+                  consumerReceivesChannel.error.publish(diagnosticContext)
+
+                  const headersFailed = payloadType === 'headerKey' || payloadType === 'headerValue'
+
+                  if (headersFailed) {
+                    headers.clear()
+
+                    for (const [headerKey, headerValue] of record.headers) {
+                      headers.set(headerKey as HeaderKey, headerValue as HeaderValue)
+                    }
+                  }
+
+                  if (headersFailed || payloadType === 'key') {
+                    deserializedKey = (record.key ?? undefined) as Key | undefined
+                  }
+
+                  deserializedValue = (record.value ?? undefined) as Value | undefined
+                  deserializationError = { error, payloadType }
+                } else if (action === DeserializationErrorActions.SKIP) {
+                  continue
+                } else {
                   diagnosticContext.error = error
                   consumerReceivesChannel.error.publish(diagnosticContext)
 
                   this.destroy(new UserError('Failed to deserialize a message.', { cause: error }))
                   return
                 }
-
-                continue
               }
 
               this.#metricsConsumedMessages?.inc()
@@ -952,9 +986,11 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
                 offset,
                 commit,
                 // Deserializers and hooks can enrich the metadata of the message they processed
-                metadata: messageToConsume.metadata
-                  ? { ...messageMetadata, ...messageToConsume.metadata }
-                  : messageMetadata,
+                metadata: deserializationError
+                  ? { ...messageMetadata, ...messageToConsume.metadata, deserializationError }
+                  : messageToConsume.metadata
+                    ? { ...messageMetadata, ...messageToConsume.metadata }
+                    : messageMetadata,
                 toJSON: messageToJSON
               } as Message
 

--- a/src/clients/consumer/types.ts
+++ b/src/clients/consumer/types.ts
@@ -39,7 +39,8 @@ export interface PreferredReadReplica {
 
 export const DeserializationErrorActions = {
   FAIL: 'fail',
-  SKIP: 'skip'
+  SKIP: 'skip',
+  CONTINUE: 'continue'
 } as const
 
 export type DeserializationErrorAction =
@@ -54,6 +55,12 @@ export interface DeserializationErrorContext {
   offset: bigint
   timestamp: bigint
   commit: Message['commit']
+}
+
+// Added to the metadata of the messages delivered after a DeserializationErrorActions.CONTINUE
+export interface MessageDeserializationError {
+  error: unknown
+  payloadType: BeforeHookPayloadType
 }
 
 export type DeserializationErrorHandler = (context: DeserializationErrorContext) => DeserializationErrorAction

--- a/test/clients/consumer/messages-stream.test.ts
+++ b/test/clients/consumer/messages-stream.test.ts
@@ -14,6 +14,7 @@ import {
   consumerReceivesChannel,
   type Deserializers,
   DeserializationErrorActions,
+  type DeserializationErrorContext,
   instancesChannel,
   jsonDeserializer,
   type KafkaRecord,
@@ -1990,4 +1991,99 @@ test('should expose the metadata added by deserializers on the consumed messages
   // The metadata added by the consumer is preserved and each message gets its own object
   strictEqual((messages[0].metadata.consumer as { groupId: string }).groupId, groupId)
   ok(messages[0].metadata !== messages[1].metadata)
+})
+
+test('should deliver the raw payload when deserialization errors are continued', async t => {
+  const groupId = createTestGroupId()
+  const topic = await createTopic(t, true)
+
+  const producer = createProducer(t, { serializers: stringSerializers })
+  await producer.send({
+    messages: [
+      { topic, key: 'key-0', value: 'value-0', headers: { headerKey: 'headerValue-0' } },
+      { topic, key: 'key-1', value: '{"a":1}', headers: { headerKey: 'headerValue-1' } }
+    ],
+    acks: ProduceAcks.LEADER
+  })
+
+  const failures: DeserializationErrorContext[] = []
+  const consumer = createConsumer(t, groupId, {
+    deserializers: {
+      ...stringDeserializers,
+      value: jsonDeserializer
+    } as unknown as Deserializers<string, string, string, string>
+  })
+
+  const stream = await consumer.consume({
+    topics: [topic],
+    mode: MessagesStreamModes.EARLIEST,
+    maxFetches: 1,
+    onDeserializationError (context) {
+      failures.push(context)
+      return DeserializationErrorActions.CONTINUE
+    }
+  })
+
+  const messages = await Array.fromAsync(stream)
+
+  strictEqual(messages.length, 2)
+  strictEqual(failures.length, 1)
+  strictEqual(failures[0].payloadType, 'value')
+
+  // The value which could not be parsed is delivered as it was received
+  deepStrictEqual(messages[0].value, Buffer.from('value-0'))
+  deepStrictEqual(messages[0].metadata.deserializationError, {
+    error: failures[0].error,
+    payloadType: 'value'
+  })
+
+  // Whatever was deserialized before the failure is kept
+  strictEqual(messages[0].key, 'key-0')
+  deepStrictEqual(Array.from(messages[0].headers.entries()), [['headerKey', 'headerValue-0']])
+
+  // The messages which could be deserialized are unaffected
+  deepStrictEqual(messages[1].value, { a: 1 })
+  strictEqual(messages[1].metadata.deserializationError, undefined)
+})
+
+test('should deliver the whole message raw when a key deserialization error is continued', async t => {
+  const groupId = createTestGroupId()
+  const topic = await createTopic(t, true)
+
+  const producer = createProducer(t, { serializers: stringSerializers })
+  await producer.send({
+    messages: [{ topic, key: 'key-0', value: 'value-0', headers: { headerKey: 'headerValue-0' } }],
+    acks: ProduceAcks.LEADER
+  })
+
+  const consumer = createConsumer(t, groupId, {
+    deserializers: {
+      ...stringDeserializers,
+      key () {
+        throw new Error('Cannot deserialize the key.')
+      }
+    } as unknown as Deserializers<string, string, string, string>
+  })
+
+  const stream = await consumer.consume({
+    topics: [topic],
+    mode: MessagesStreamModes.EARLIEST,
+    maxFetches: 1,
+    onDeserializationError () {
+      return DeserializationErrorActions.CONTINUE
+    }
+  })
+
+  const messages = await Array.fromAsync(stream)
+
+  strictEqual(messages.length, 1)
+
+  // The key failed, so it and the value which was never attempted are raw, the headers are kept
+  deepStrictEqual(messages[0].key, Buffer.from('key-0'))
+  deepStrictEqual(messages[0].value, Buffer.from('value-0'))
+  deepStrictEqual(Array.from(messages[0].headers.entries()), [['headerKey', 'headerValue-0']])
+  strictEqual(
+    (messages[0].metadata.deserializationError as { payloadType: string }).payloadType,
+    'key'
+  )
 })

--- a/test/registries/confluent-schema-registry.test.ts
+++ b/test/registries/confluent-schema-registry.test.ts
@@ -1714,3 +1714,80 @@ test('exposes the original key and value byte lengths on the message metadata', 
   // Each message gets its own metadata object
   ok(messages[0].metadata !== messages[1].metadata)
 })
+
+test('continues consuming with the raw payload when a message cannot be decoded', async t => {
+  const topic = await createTopic(t, true)
+  const consumerRegistry = new ConfluentSchemaRegistry<string, Datum, string, string>({
+    url: confluentSchemaRegistryUrl
+  })
+  const subject = createSubject()
+  const schemaId = await registerSchema(
+    confluentSchemaRegistryUrl,
+    subject,
+    'JSON',
+    JSON.stringify({
+      type: 'object',
+      properties: {
+        id: { type: 'integer' },
+        name: { type: 'string' }
+      },
+      required: ['id', 'name'],
+      additionalProperties: false
+    })
+  )
+
+  const schemaHeader = Buffer.alloc(5)
+  schemaHeader.writeInt32BE(schemaId, 1)
+
+  const producer = createProducer<string, string>(t, {
+    serializers: {
+      key: stringSerializer,
+      value (value) {
+        return Buffer.concat([schemaHeader, Buffer.from(value!)])
+      }
+    }
+  })
+
+  const invalidPayload = JSON.stringify({ id: 1, name: 'Alice', foo: 'bar' })
+
+  await producer.send({
+    messages: [
+      { topic, key: 'schema-invalid', value: invalidPayload },
+      { topic, key: 'valid', value: JSON.stringify({ id: 2, name: 'Bob' }) }
+    ]
+  })
+
+  const failures: DeserializationErrorContext[] = []
+  const consumer = createConsumer(t, { registry: consumerRegistry })
+  const stream = await consumer.consume({
+    topics: [topic],
+    maxFetches: 1,
+    mode: MessagesStreamModes.EARLIEST,
+    onDeserializationError (context) {
+      failures.push(context)
+      return DeserializationErrorActions.CONTINUE
+    }
+  })
+
+  const messages = await Array.fromAsync(stream)
+
+  // Nothing is lost and the stream is not aborted
+  strictEqual(messages.length, 2)
+  strictEqual(failures.length, 1)
+
+  // The undecodable message is delivered with its original bytes
+  const degraded = messages[0]
+  strictEqual(degraded.key, 'schema-invalid')
+  deepStrictEqual(degraded.value, Buffer.concat([schemaHeader, Buffer.from(invalidPayload)]))
+
+  const { error, payloadType } = degraded.metadata.deserializationError as {
+    error: Error
+    payloadType: string
+  }
+  strictEqual(payloadType, 'value')
+  strictEqual(error instanceof SchemaValidationError, true)
+
+  // The messages which could be decoded are unaffected
+  deepStrictEqual(structuredClone(messages[1].value), { id: 2, name: 'Bob' })
+  strictEqual(messages[1].metadata.deserializationError, undefined)
+})


### PR DESCRIPTION
Fixes #344

## Problem

A deserialization failure could only stop the stream (`FAIL`) or drop the message (`SKIP`). An undecodable payload, a missing schema or a validation failure forced a choice between an outage and silent message loss.

## Change

New `DeserializationErrorActions.CONTINUE`, which delivers the message in a degraded form and keeps consuming:

```ts
const stream = await consumer.consume({
  topics: ['events'],
  onDeserializationError () {
    return DeserializationErrorActions.CONTINUE
  }
})

for await (const message of stream) {
  const failure = message.metadata.deserializationError

  if (failure) {
    // message.value is the raw Buffer, failure.payloadType says which payload failed
    deadLetters.send({ topic: 'events-dlq', value: message.value })
    continue
  }

  handle(message.value)
}
```

Whatever was deserialized before the failure is kept. The payload that failed, and the ones never attempted — deserialization goes headers → key → value — are delivered as the original bytes. Since the payload types are no longer guaranteed, `metadata.deserializationError` is the signal to check before trusting `key`, `value` or `headers`.

## This change is purely additive

`CONTINUE` is a new value nobody returns yet, and every pre-existing return value behaves exactly as before. Verified with a 9-scenario probe run against this branch and against `main`:

| Scenario | main | this PR |
| --- | --- | --- |
| decode error + `FAIL` | destroyed, `Failed to deserialize a message.` | identical |
| decode error + `SKIP` | skipped, stream survives | identical |
| decode error + handler returns `undefined` | destroyed | identical |
| decode error + no handler | destroyed | identical |
| decode error + `onCorruptedMessage` → `false` | skipped | identical |
| decode error + `onCorruptedMessage` → `true` | destroyed | identical |
| hook failure + `SKIP` / `FAIL` / no handler | destroyed | identical |

The dispatch keeps `SKIP` explicit and routes everything else — `FAIL`, `undefined`, a typo — to destroy, exactly as the previous `!== SKIP` test did. The deprecated `onCorruptedMessage` path is untouched.

## Logging

Nothing is logged when a message is continued: at scale that is a log storm. The error is published on the `plt:kafka:consumer:receives` diagnostic channel and carried on the metadata, leaving applications in control of the rate.

## Scope

Failures raised by the `beforeDeserialization` hook, which is where a schema registry fetches its schemas, still destroy the stream as they always did. Routing those through the handler as well is a behaviour change and is split into #363, stacked on this PR.

## Tests

Decode failure continued while its siblings decode normally; a value failure keeping the decoded key and headers; a key failure leaving the value raw too; registry-level coverage of an undecodable message. Verified against a freshly recreated cluster.