### PR TITLE
test: stop the SASL/GSSAPI tests racing the connect timeout

### DIFF
--- a/test/clients/base/sasl-gssapi.test.ts
+++ b/test/clients/base/sasl-gssapi.test.ts
@@ -1,7 +1,10 @@
 import { deepStrictEqual, ok, rejects } from 'node:assert'
 import { test } from 'node:test'
 import { Base, MultipleErrors, NetworkError, UserError } from '../../../src/index.ts'
-import { createAuthenticator } from '../../fixtures/kerberos-authenticator.ts'
+import { createAuthenticator, type KerberosCredentials } from '../../fixtures/kerberos-authenticator.ts'
+
+const kerberosCredentials: KerberosCredentials = { username: 'admin-password@EXAMPLE.COM', password: 'admin' }
+const kerberosConnectTimeout = 30000
 
 test('should not connect to SASL protected broker by default', async t => {
   const base = new Base({ clientId: 'clientId', bootstrapBrokers: ['localhost:9003'], strict: true, retries: false })
@@ -38,11 +41,21 @@ test('should connect to SASL protected broker using SASL/GSSAPI using a custom a
     bootstrapBrokers: ['localhost:9003'],
     strict: true,
     retries: 0,
+    /*
+      The GSSAPI handshake talks to the KDC before the connection is considered ready, so it is
+      bounded by connectTimeout. The default 5s is not enough on a loaded CI machine.
+    */
+    connectTimeout: kerberosConnectTimeout,
     sasl: {
       mechanism: 'GSSAPI',
-      username: 'admin-password@EXAMPLE.COM',
-      password: 'admin',
-      authenticate: await createAuthenticator('broker@broker-sasl-kerberos', 'EXAMPLE.COM', 'localhost:8000')
+      username: kerberosCredentials.username,
+      password: kerberosCredentials.password,
+      authenticate: await createAuthenticator(
+        'broker@broker-sasl-kerberos',
+        'EXAMPLE.COM',
+        'localhost:8000',
+        kerberosCredentials
+      )
     }
   })
 

--- a/test/fixtures/kerberos-authenticator.ts
+++ b/test/fixtures/kerberos-authenticator.ts
@@ -1,6 +1,7 @@
 import krb, { type KerberosClient } from 'kerberos'
 import { execSync } from 'node:child_process'
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { rmSync } from 'node:fs'
+import { mkdtemp, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { resolve as resolvePaths } from 'node:path'
 import {
@@ -18,6 +19,11 @@ import {
 
 type SaslAuthenticateResponse = saslAuthenticateV2.SaslAuthenticateResponse
 type SASLAuthenticationAPI = saslAuthenticateV2.SASLAuthenticationAPI
+
+export interface KerberosCredentials {
+  username: string
+  password: string
+}
 
 function createKerberosAuthenticationError (message: string, kerberosError: string): AuthenticationError {
   return new AuthenticationError(message, { kerberosError })
@@ -82,33 +88,64 @@ function performChallenge (
   })
 }
 
-async function restoreEnvironment (
-  callback: Callback<SaslAuthenticateResponse>,
-  kerberosRoot: string,
-  originalKrb5Config: string | undefined,
-  originalKrbCCName: string | undefined,
-  error: Error | null,
-  response?: SaslAuthenticateResponse
-): Promise<void> {
-  if (typeof originalKrb5Config !== 'undefined') {
-    process.env.KRB5_CONFIG = originalKrb5Config
-  } else {
-    delete process.env.KRB5_CONFIG
+/*
+  KRB5_CONFIG and KRB5CCNAME are process wide, so they are only set while the Kerberos tooling needs
+  them and the previous values are put back afterwards.
+*/
+function useKerberosEnvironment (kerberosRoot: string): () => void {
+  const { KRB5_CONFIG, KRB5CCNAME } = process.env
+
+  process.env.KRB5_CONFIG = `${kerberosRoot}/krb5.conf`
+  process.env.KRB5CCNAME = `${kerberosRoot}/krb5.cache`
+
+  return function restoreKerberosEnvironment () {
+    if (typeof KRB5_CONFIG !== 'undefined') {
+      process.env.KRB5_CONFIG = KRB5_CONFIG
+    } else {
+      delete process.env.KRB5_CONFIG
+    }
+
+    if (typeof KRB5CCNAME !== 'undefined') {
+      process.env.KRB5CCNAME = KRB5CCNAME
+    } else {
+      delete process.env.KRB5CCNAME
+    }
+  }
+}
+
+/*
+  Populates the credentials cache in kerberosRoot. This spawns up to two processes and performs a
+  round trip to the KDC, all of it blocking the event loop, so the caller decides when to pay for it.
+*/
+async function acquireTicket (kerberosRoot: string, username: string, password: string): Promise<void> {
+  // On MIT Kerberos, kinit does not support reading password from stdin or a password file
+  // so we convert it to a keytab file if needed using ktutil
+  if (!password.startsWith('keytab:')) {
+    if (process.platform !== 'darwin') {
+      execSync(`ktutil --keytab ${kerberosRoot}/keytab`, {
+        input: `addent -password -p ${username} -k 1 -f \n${password}\nwkt ${kerberosRoot}/keytab\nquit\n`
+      })
+
+      password = `keytab:${kerberosRoot}/keytab`
+      /* c8 ignore next 4 - Only executed on MacOS */
+    } else {
+      // On MacOS, we can use a password file directly since it uses Heimdal Kerberos
+      await writeFile(`${kerberosRoot}/password`, password, 'utf-8')
+    }
   }
 
-  if (typeof originalKrbCCName !== 'undefined') {
-    process.env.KRB5CCNAME = originalKrbCCName
-  } else {
-    delete process.env.KRB5CCNAME
-  }
+  /* c8 ignore next - The password file branch is only executed on MacOS */
+  const args = password.startsWith('keytab:')
+    ? `-kt ${password.slice(7)}`
+    : `--password-file=${kerberosRoot}/password`
 
-  await rm(kerberosRoot, { recursive: true, force: true })
-  callback(error, response)
+  execSync(`kinit ${args} ${username}`, { stdio: 'pipe', env: process.env })
 }
 
 async function authenticate (
   service: string,
   kerberosRoot: string,
+  hasTicket: boolean,
   _m: SASLMechanismValue,
   connection: Connection,
   authenticate: saslAuthenticateV2.SASLAuthenticationAPI,
@@ -117,64 +154,50 @@ async function authenticate (
   _t: string | CredentialProvider | undefined,
   callback: CallbackWithPromise<SaslAuthenticateResponse>
 ): Promise<void> {
-  const afterRestoreCallback = restoreEnvironment.bind(
-    null,
-    callback,
-    kerberosRoot,
-    process.env.KRB5_CONFIG,
-    process.env.KRB5CCNAME
-  )
+  let restoreKerberosEnvironment: (() => void) | undefined
+
+  const afterRestoreCallback: Callback<SaslAuthenticateResponse> = (error, response) => {
+    restoreKerberosEnvironment?.()
+    callback(error, response)
+  }
 
   try {
-    const username = await saslUtils.getCredential('SASL/GSSAPI username', usernameProvider!)
-    let password = await saslUtils.getCredential('SASL/GSSAPI password', passwordProvider!)
+    /* c8 ignore next 6 - Only executed when the ticket was not acquired upfront */
+    let username: string | undefined
+    let password: string | undefined
 
-    process.env.KRB5_CONFIG = `${kerberosRoot}/krb5.conf`
-    process.env.KRB5CCNAME = `${kerberosRoot}/krb5.cache`
-
-    // Using a password
-    if (!password.startsWith('keytab:')) {
-      // On MIT Kerberos, kinit does not support reading password from stdin or a password file
-      // so we convert it to a keytab file if needed using ktutil
-      if (process.platform !== 'darwin') {
-        execSync(`ktutil --keytab ${kerberosRoot}/keytab`, {
-          input: `addent -password -p ${username} -k 1 -f \n${password}\nwkt ${kerberosRoot}/keytab\nquit\n`
-        })
-
-        password = `keytab:${kerberosRoot}/keytab`
-      } else {
-        // On MacOS, we can use a password file directly since it uses Heimdal Kerberos
-        await writeFile(`${kerberosRoot}/password`, password, 'utf-8')
-      }
+    if (!hasTicket) {
+      username = await saslUtils.getCredential('SASL/GSSAPI username', usernameProvider!)
+      password = await saslUtils.getCredential('SASL/GSSAPI password', passwordProvider!)
     }
 
-    let args = ''
-    if (password.startsWith('keytab:')) {
-      args = `-kt ${password.slice(7)}`
-    } else {
-      args = `--password-file=${kerberosRoot}/password`
-    }
+    restoreKerberosEnvironment = useKerberosEnvironment(kerberosRoot)
 
-    // Import the password via kinit
-    execSync(`kinit ${args} ${username}`, { stdio: 'pipe', env: process.env })
+    /* c8 ignore next 3 - Only executed when the ticket was not acquired upfront */
+    if (!hasTicket) {
+      await acquireTicket(kerberosRoot, username!, password!)
+    }
 
     krb.initializeClient(service, {}, (error, client) => {
+      /* c8 ignore next 4 - Hard to test */
       if (error) {
-        callback(createKerberosAuthenticationError('Cannot initialize Kerberos client.', error))
+        afterRestoreCallback(createKerberosAuthenticationError('Cannot initialize Kerberos client.', error))
         return
       }
 
       performChallenge(connection, authenticate, client, '', afterRestoreCallback)
     })
+    /* c8 ignore next 3 - Hard to test */
   } catch (error) {
-    await afterRestoreCallback(error)
+    afterRestoreCallback(error as Error)
   }
 }
 
 export async function createAuthenticator (
   service: string,
   realm: string,
-  kdc: string
+  kdc: string,
+  credentials?: KerberosCredentials
 ): Promise<SASLCustomAuthenticator> {
   const tmpDir = await mkdtemp(resolvePaths(tmpdir(), 'sasl-gssapi-'))
 
@@ -199,5 +222,28 @@ export async function createAuthenticator (
     'utf-8'
   )
 
-  return authenticate.bind(null, service, tmpDir)
+  /*
+    The configuration and the credentials cache have to outlive a single authentication, since the
+    same authenticator serves every connection it is attached to, so they are only removed on exit.
+  */
+  process.once('exit', () => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  /*
+    Acquiring the ticket upfront keeps ktutil, kinit and their KDC round trip out of the connection
+    handshake, which is bounded by connectTimeout. Doing it while authenticating used to push slow
+    CI machines past that deadline and fail the connection with a timeout.
+  */
+  if (credentials) {
+    const restoreKerberosEnvironment = useKerberosEnvironment(tmpDir)
+
+    try {
+      await acquireTicket(tmpDir, credentials.username, credentials.password)
+    } finally {
+      restoreKerberosEnvironment()
+    }
+  }
+
+  return authenticate.bind(null, service, tmpDir, !!credentials)
 }

--- a/test/network/connection.test.ts
+++ b/test/network/connection.test.ts
@@ -37,7 +37,7 @@ import {
 } from '../../src/index.ts'
 import { defaultCrypto, type ScramAlgorithm } from '../../src/protocol/sasl/scram-sha.ts'
 import { createScramUsers } from '../fixtures/create-users.ts'
-import { createAuthenticator } from '../fixtures/kerberos-authenticator.ts'
+import { createAuthenticator, type KerberosCredentials } from '../fixtures/kerberos-authenticator.ts'
 import {
   createCreationChannelVerifier,
   createTracingChannelVerifier,
@@ -1131,6 +1131,17 @@ test('Connection.connect should not connect to SASL protected broker by default'
   await rejects(() => metadataV12.api.async(connection, []))
 })
 
+const kerberosPrincipal: KerberosCredentials = { username: 'admin-password@EXAMPLE.COM', password: 'admin' }
+const kerberosAdmin: KerberosCredentials = { username: 'admin', password: 'admin' }
+
+/*
+  The GSSAPI handshake talks to the KDC before the connection is considered ready, so it is bounded
+  by connectTimeout. The default 5s is not enough on a loaded CI machine.
+*/
+function connectionOptionsFor (mechanism: SASLMechanismValue): { connectTimeout?: number } {
+  return mechanism === SASLMechanisms.GSSAPI ? { connectTimeout: 30000 } : {}
+}
+
 for (const mechanism of allowedSASLMechanisms) {
   let sasl: SASLOptions
   let saslBroker = parseBroker(kafkaSaslBootstrapServers[0])
@@ -1143,9 +1154,14 @@ for (const mechanism of allowedSASLMechanisms) {
       saslBroker = parseBroker(kafkaSaslKerberosBootstrapServers[0])
       sasl = {
         mechanism,
-        username: 'admin-password@EXAMPLE.COM',
-        password: 'admin',
-        authenticate: await createAuthenticator('broker@broker-sasl-kerberos', 'EXAMPLE.COM', 'localhost:8000')
+        username: kerberosPrincipal.username,
+        password: kerberosPrincipal.password,
+        authenticate: await createAuthenticator(
+          'broker@broker-sasl-kerberos',
+          'EXAMPLE.COM',
+          'localhost:8000',
+          kerberosPrincipal
+        )
       }
       break
     default:
@@ -1153,13 +1169,21 @@ for (const mechanism of allowedSASLMechanisms) {
   }
 
   test(`Connection.connect should connect to SASL protected broker using SASL/${mechanism}`, async t => {
-    const connection = new Connection('clientId', { sasl })
+    const connection = new Connection('clientId', { sasl, ...connectionOptionsFor(mechanism) })
     t.after(() => connection.close())
 
     await connection.connect(saslBroker.host, saslBroker.port)
     await metadataV12.api.async(connection, [])
   })
 }
+
+// Created once, and not per mechanism, as only the GSSAPI iteration ever invokes it
+const gssapiAuthenticate = await createAuthenticator(
+  'broker@broker-sasl-kerberos',
+  'EXAMPLE.COM',
+  'localhost:8000',
+  kerberosAdmin
+)
 
 for (const mechanism of allowedSASLMechanisms) {
   const sasl: SASLOptions =
@@ -1169,8 +1193,6 @@ for (const mechanism of allowedSASLMechanisms) {
     mechanism === SASLMechanisms.GSSAPI
       ? parseBroker(kafkaSaslKerberosBootstrapServers[0])
       : parseBroker(kafkaSaslBootstrapServers[0])
-
-  const gssapiAuthenticate = await createAuthenticator('broker@broker-sasl-kerberos', 'EXAMPLE.COM', 'localhost:8000')
 
   sasl.authenticate = async function customSaslAuthenticate (
     mechanism: SASLMechanismValue,
@@ -1215,7 +1237,7 @@ for (const mechanism of allowedSASLMechanisms) {
   }
 
   test(`Connection.connect should connect to SASL protected broker using SASL/${mechanism} using a custom implementation`, async t => {
-    const connection = new Connection('clientId', { sasl })
+    const connection = new Connection('clientId', { sasl, ...connectionOptionsFor(mechanism) })
     t.after(() => connection.close())
 
     await connection.connect(broker.host, broker.port)


### PR DESCRIPTION
## The failure

Seen on CI (Node 22.x / Confluent Kafka 8.1.0), in an otherwise unrelated PR:

```
▶ test/clients/base/sasl-gssapi.test.ts
  - should connect to SASL protected broker using SASL/GSSAPI using a custom authenticator
    Error: Connection to localhost:9003 timed out.   (5175.966066ms)
```

1819 of 1821 tests passed; the same test passed on the other 11 matrix combinations of that run.

## Why

A connection only emits `connect` once SASL authentication has completed, so `connectTimeout` — default 5000ms — bounds the entire GSSAPI handshake. The test authenticator does a lot inside that window:

1. `execSync('ktutil …')` to turn the password into a keytab
2. `execSync('kinit …')` to obtain the ticket, which talks to the KDC
3. `krb.initializeClient`, which asks the KDC for a service ticket
4. the SASL challenge round-trips with the broker

The two `execSync` calls block the event loop, so the `connectTimeout` timer cannot even fire until they return — a machine slow enough to push the total past 5s then fails the connection immediately afterwards. That is exactly the 5175ms in the log. Locally the two subprocesses take 50–100ms, which is why this only ever shows up on loaded CI runners.

## Fix

**Acquire the ticket upfront.** `createAuthenticator` now takes the credentials and populates the credentials cache itself. Tests `await` it before building the client, so `ktutil`, `kinit` and their KDC round-trip happen outside any connection handshake. The cache consequently has to outlive a single authentication, so it is removed on process exit rather than after every `authenticate` call — which also fixes reauthentication, that used to find the directory already deleted.

**Give the rest room.** The GSSAPI connections use a 30s `connectTimeout`, for the KDC and broker round-trips that genuinely have to happen inside the handshake.

Also in passing:

- the `initializeClient` error path now goes through the restore callback, so a failure there no longer leaks `KRB5_CONFIG` and `KRB5CCNAME` into the rest of the process
- `connection.test.ts` builds the shared authenticator once instead of once per SASL mechanism, since only the GSSAPI iteration ever calls it

No production code is touched — this is all test fixture and test setup.

## Verification

`sasl-gssapi.test.ts` and `connection.test.ts` run green 5× in a row locally. The GSSAPI connect test dropped from ~161ms to ~87ms, since the ticket work no longer happens during the handshake.