### PR TITLE
fix: close active streams when leaving a group with the consumer protocol

### DIFF
--- a/src/clients/consumer/consumer.ts
+++ b/src/clients/consumer/consumer.ts
@@ -1656,7 +1656,45 @@ export class Consumer<Key = Buffer, Value = Buffer, HeaderKey = Buffer, HeaderVa
     })
   }
 
-  #leaveGroupConsumerProtocol (_: boolean, callback: CallbackWithPromise<void>): void {
+  #leaveGroupConsumerProtocol (force: boolean, callback: CallbackWithPromise<void>): void {
+    // Remove streams that might have been exited in the meanwhile
+    for (const stream of this.#streams) {
+      if (stream.closed || stream.destroyed) {
+        this.#streams.delete(stream)
+      }
+    }
+
+    // Active streams must be closed before leaving the group, exactly like in the classic protocol.
+    // Their fetch loop keeps running until they are closed and, since Consumer.close marks the client
+    // as closed before leaving, any fetch scheduled in the meanwhile would fail with "Client is closed."
+    // and destroy the stream with an error the user never asked for.
+    if (this.#streams.size) {
+      if (!force) {
+        callback(new UserError('Cannot leave group while consuming messages.'))
+        return
+      }
+
+      runConcurrentCallbacks(
+        'Closing streams failed.',
+        this.#streams,
+        (stream, concurrentCallback) => {
+          stream.close(concurrentCallback)
+        },
+        error => {
+          /* c8 ignore next 4 - Hard to test */
+          if (error) {
+            callback(error)
+            return
+          }
+
+          // All streams are closed, try the operation again without force
+          this.#leaveGroupConsumerProtocol(false, callback)
+        }
+      )
+
+      return
+    }
+
     // Leave by sending a heartbeat with memberEpoch = -1
     this.#cancelHeartbeat()
     this.#performDeduplicateGroupOperaton<ConsumerGroupHeartbeatResponse>(

--- a/test/clients/consumer/consumer-consumer-group-protocol.test.ts
+++ b/test/clients/consumer/consumer-consumer-group-protocol.test.ts
@@ -1,4 +1,4 @@
-import { ok, strictEqual } from 'node:assert'
+import { deepStrictEqual, ok, rejects, strictEqual } from 'node:assert'
 import { randomUUID } from 'node:crypto'
 import { once } from 'node:events'
 import { test, type TestContext } from 'node:test'
@@ -11,6 +11,7 @@ import {
   sleep,
   TimeoutError,
   UnsupportedApiError,
+  UserError,
   type CallbackWithPromise,
   type ClusterMetadata,
   type MessageToProduce,
@@ -111,6 +112,44 @@ test(
     await Promise.all([stream1.close(), stream2.close()])
   }
 )
+
+test('consumer.close should close active streams with new consumer protocol', skipConsumerGroupProtocol, async t => {
+  const topic = await createTopic(t, true, 3)
+  const consumer = createConsumer(t, { groupProtocol: 'consumer', maxWaitTime: 100 })
+
+  const stream = await consumer.consume({ topics: [topic] })
+  const errors: Error[] = []
+  stream.on('data', () => {})
+  stream.on('error', error => errors.push(error))
+
+  // Wait for the fetch loop to be running against a real assignment
+  await waitFor(() => ok(consumer.assignments?.length), { timeout: 5000 })
+  await once(stream, 'fetch')
+
+  // Without force the consumer refuses to leave the group, as documented and as the classic protocol does
+  await rejects(
+    () => consumer.close(),
+    (error: Error) => {
+      ok(error instanceof UserError)
+      strictEqual(error.message, 'Cannot leave group while consuming messages.')
+      return true
+    }
+  )
+  strictEqual(consumer.closed, false, 'a failed close must leave the consumer usable')
+  strictEqual(stream.closed, false, 'a failed close must leave the stream running')
+
+  // With force the streams are closed before leaving the group. If they were not, their fetch loop
+  // would keep running against a closed client and destroy them with "Client is closed."
+  await consumer.close(true)
+
+  strictEqual(stream.closed, true, 'close(true) must close all the active streams')
+  strictEqual(stream.errored, null, `the stream must not be destroyed with an error, got ${stream.errored}`)
+  deepStrictEqual(
+    errors.map(error => error.message),
+    [],
+    'closing the consumer must not emit any error on its streams'
+  )
+})
 
 test('consumer should handle fenced member epoch error', skipConsumerGroupProtocol, async t => {
   const topic = await createTopic(t, true)

--- a/test/issues/gh-300.test.ts
+++ b/test/issues/gh-300.test.ts
@@ -1,6 +1,6 @@
 // Related issue: https://github.com/platformatic/kafka/issues/300
 
-import { ok, strictEqual } from 'node:assert'
+import { deepStrictEqual, ok, strictEqual } from 'node:assert'
 import { setTimeout as sleep } from 'node:timers/promises'
 import { test } from 'node:test'
 import { MessagesStreamModes, stringDeserializers } from '../../src/index.ts'
@@ -35,18 +35,36 @@ for (const groupProtocol of ['classic', 'consumer'] as const) {
       mode: MessagesStreamModes.LATEST,
       maxWaitTime: 200
     })
+    // createConsumer registered its own `consumer.close(true)` hook before this one and hooks run in
+    // registration order, so the consumer is closed while this stream is still consuming. That is
+    // deliberate: Consumer.close(true) must close the active streams itself.
     t.after(() => stream.close())
     stream.on('data', () => {})
 
+    // The stream has no other error listener, so without this one any stream error would be
+    // rethrown by Node.js as an unhandled 'error' event. The test runner reports that as an
+    // uncaught exception rather than as a failed assertion, which hides what actually went wrong.
+    const errors: Error[] = []
+    stream.on('error', error => errors.push(error))
+
     // The construct refresh hasn't finished yet, so the offsets map is empty
-    strictEqual(stream.offsetsToFetch.size, 0)
+    strictEqual(
+      stream.offsetsToFetch.size,
+      0,
+      'the initial offsets refresh should still be in flight right after consume()'
+    )
 
     stream.pause()
     stream.resume()
 
     await sleep(2000)
 
-    strictEqual(stream.errored, null)
-    ok(stream.offsetsToFetch.size > 0)
+    deepStrictEqual(
+      errors.map(error => error.message),
+      [],
+      'the stream must not emit any error'
+    )
+    strictEqual(stream.errored, null, `the stream must not be destroyed, got ${stream.errored}`)
+    ok(stream.offsetsToFetch.size > 0, 'the initial offsets refresh should have completed by now')
   })
 }


### PR DESCRIPTION
## What failed

`test/issues/gh-300.test.ts` has been the biggest source of CI noise in the repo, failing 6 times in one day across unrelated PRs (#355, #356, #357, #358, #360). Only the `(consumer)` group-protocol variant ever failed; the `classic` one passed in the same run every time.

The log gave nothing away: a bare `✖` with no test name, no duration and no assertion diff, with the test named only in the final summary. That is because `cleaner-spec-reporter` has a `switch` over `error.failureType` with no branch for `uncaughtException` / `unhandledRejection`, so those failures render as an empty cross. In other words the failure was never an assertion and never a rejecting hook (both of those print) — it was an uncaught exception.

## The bug

`Consumer.close(force)` is documented as:

> If `force` is not `true`, then the method will throw an error if any `MessagesStream` created from this consumer is still active.
> If `force` is `true`, then the method will close all `MessagesStream` created from this consumer.

The classic group protocol implements that in `#performLeaveGroup`. The KIP-848 consumer protocol path, `#leaveGroupConsumerProtocol`, ignored both the `force` flag and the stream set entirely — its first parameter was literally named `_`.

So under `groupProtocol: 'consumer'`, `close()` leaves a live stream attached to a client that is already closed. `Consumer.close` flips the closed flag synchronously, before the leave round trip, and from that instant every fetch the stream schedules fails: `MessagesStream.#fetch` calls `Consumer.fetch`, which returns `NetworkError: Client is closed.`, and the stream destroys itself with that error. With no `'error'` listener on the stream — the normal case — the event is unhandled and takes the process down.

The window is the duration of the leave round trip, so the crash fires whenever a fetch response happens to land while the consumer is leaving the group. That is a real user-facing bug, not just a test problem.

gh-300 hit it because `node:test` runs `after` hooks in registration order: `createConsumer`'s `consumer.close(true)` hook is registered before the test's own `stream.close()`, so the test tears down in exactly that shape. The classic variant closes the stream inside `close(true)` and is safe, which is why only the consumer variant ever failed.

## The fix

`#leaveGroupConsumerProtocol` now mirrors `#performLeaveGroup`: prune already closed streams, refuse a non-forced leave with `Cannot leave group while consuming messages.`, and with `force` close every stream before leaving the group. Closing a stream flips its own closed flag first, so its fetch loop stops instead of racing the client shutdown.

Note the behaviour change: `consumer.close()` without `force` on the consumer protocol now rejects when streams are still active, instead of "succeeding" and leaving behind a stream that crashes the process moments later. That matches the documentation and the classic protocol.

The gh-300 test also collects stream errors through an `'error'` listener and carries assertion messages, so any stream error — whatever the cause — is now reported as a failed assertion naming the error rather than disappearing into an unhandled `'error'` event and a blank cross.

## Verification

- Reproduced the exact CI signature: a copy of the gh-300 consumer test with `maxWaitTime: 10` (which cycles the fetch loop ~20x faster and so hits the teardown window on most runs) failed **8 out of 10** runs, each with a bare `✖` and, with an uncaught-exception trap installed, `Error: Client is closed.` thrown from `Consumer.fetch` via the `process.nextTick(#fetch)` in `#pushRecords`.
- Same test after the fix: **0 failures out of 20**.
- The unmodified `gh-300.test.ts`: **25 passes out of 25**.
- New regression test `consumer.close should close active streams with new consumer protocol` fails on `main` and passes with the fix.
- `npm run test:ci`: 1838 passing out of 1839 (1 skipped), coverage gates included. `npm run lint` clean, `npm run typecheck` shows only the 3 errors already present on `main`.
