### PR TITLE
feat: report before-deserialization hook failures through onDeserializationError

### DIFF
--- a/src/clients/consumer/messages-stream.ts
+++ b/src/clients/consumer/messages-stream.ts
@@ -19,7 +19,7 @@ import { findErrorBy, protocolErrors, UserError } from '../../errors.ts'
 import type { ConnectionPool } from '../../network/connection-pool.ts'
 import { IS_CONTROL, type Message, type MessageToConsume } from '../../protocol/records.ts'
 import { runAsyncSeries } from '../../registries/abstract.ts'
-import { kAutocommit, kGetFetchNode, kInstance, kRefreshOffsetsAndFetch } from '../../symbols.ts'
+import { kAutocommit, kDeserializationError, kGetFetchNode, kInstance, kRefreshOffsetsAndFetch } from '../../symbols.ts'
 import { kConnections, kCreateConnectionPool, kInspect, kPrometheus } from '../base/base.ts'
 import type { ClusterMetadata } from '../base/types.ts'
 import { ensureMetric, type Counter } from '../metrics.ts'
@@ -55,6 +55,11 @@ export function noopDeserializer (data?: Buffer): Buffer | undefined {
 
 export function defaultCorruptedMessageHandler (): boolean {
   return true
+}
+
+// A message whose before-deserialization hook failed, tracked until #pushRecords can report it
+type MessageToConsumeWithDeserializationError = MessageToConsume & {
+  [kDeserializationError]?: MessageDeserializationError
 }
 
 function messageToJSON<Key, Value, HeaderKey, HeaderValue> (this: Message<Key, Value, HeaderKey, HeaderValue>) {
@@ -864,7 +869,7 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
 
           // Process messages
           for (const record of batch.records) {
-            const messageToConsume: MessageToConsume = { ...record, topic, partition }
+            const messageToConsume: MessageToConsumeWithDeserializationError = { ...record, topic, partition }
             const offset = batch.firstOffset + BigInt(record.offsetDelta)
 
             if (offset < requestedOffsets.get(key)!) {
@@ -891,8 +896,17 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
               let deserializedKey: Key | undefined
               let deserializedValue: Value | undefined
               let deserializationError: MessageDeserializationError | undefined
+              let hookFailed = false
 
               try {
+                // A before-deserialization hook already failed for this message, report it as is
+                const hookError = messageToConsume[kDeserializationError]
+                if (hookError) {
+                  hookFailed = true
+                  payloadType = hookError.payloadType
+                  throw hookError.error
+                }
+
                 for (const [headerKey, headerValue] of record.headers) {
                   payloadType = 'headerKey'
                   /* c8 ignore next - Hard to test */
@@ -947,7 +961,8 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
                   diagnosticContext.error = error
                   consumerReceivesChannel.error.publish(diagnosticContext)
 
-                  const headersFailed = payloadType === 'headerKey' || payloadType === 'headerValue'
+                  // A hook failure happens before anything is deserialized, so nothing can be kept
+                  const headersFailed = hookFailed || payloadType === 'headerKey' || payloadType === 'headerValue'
 
                   if (headersFailed) {
                     headers.clear()
@@ -969,7 +984,9 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
                   diagnosticContext.error = error
                   consumerReceivesChannel.error.publish(diagnosticContext)
 
-                  this.destroy(new UserError('Failed to deserialize a message.', { cause: error }))
+                  this.destroy(
+                    hookFailed ? (error as Error) : new UserError('Failed to deserialize a message.', { cause: error })
+                  )
                   return
                 }
               }
@@ -1297,7 +1314,7 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
     response: FetchResponse,
     requestedOffsets: Map<string, bigint>
   ) {
-    const requests: [Buffer | null, BeforeHookPayloadType, MessageToConsume][] = []
+    const requests: [Buffer | null, BeforeHookPayloadType, MessageToConsumeWithDeserializationError][] = []
 
     // Create the pre-deserialization requests
     for (const topicResponse of response.responses) {
@@ -1322,7 +1339,7 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
             continue
           }
 
-          for (const message of batch.records as MessageToConsume[]) {
+          for (const message of batch.records as MessageToConsumeWithDeserializationError[]) {
             message.topic = topic
             message.partition = partition
 
@@ -1347,10 +1364,26 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
       (request, cb) => {
         const [data, type, message] = request
 
-        const result = hook(data, type, message, cb) as Promise<void>
+        /*
+          Without an error handler a failing hook destroys the stream, as it always did. With one,
+          the failure is recorded on the message it belongs to and reported to the handler in
+          #pushRecords, together with everything else which can fail while deserializing, so that
+          the caller can skip or degrade that single message instead of losing the stream.
+        */
+        const onHookSettled: Callback<void> = error => {
+          if (error && this.#deserializationErrorHandler) {
+            message[kDeserializationError] ??= { error, payloadType: type }
+            cb(null)
+            return
+          }
+
+          cb(error)
+        }
+
+        const result = hook(data, type, message, onHookSettled) as Promise<void>
 
         if (typeof result?.then === 'function') {
-          result.then(() => cb(null), cb)
+          result.then(() => onHookSettled(null), onHookSettled)
         }
       },
       requests,

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -4,6 +4,7 @@ export const kInstance = Symbol('plt.kafka.base.instance')
 export const kRefreshOffsetsAndFetch = Symbol('plt.kafka.messagesStream.refreshOffsetsAndFetch')
 export const kAutocommit = Symbol('plt.kafka.messagesStream.autocommit')
 export const kGetFetchNode = Symbol('plt.kafka.consumer.getFetchNode')
+export const kDeserializationError = Symbol('plt.kafka.messagesStream.deserializationError')
 
 export const kTransaction = Symbol('plt.kafka.producer.transactions')
 export const kTransactionPrepare = Symbol('plt.kafka.producer.transactions.prepare')

--- a/test/clients/consumer/messages-stream.test.ts
+++ b/test/clients/consumer/messages-stream.test.ts
@@ -2087,3 +2087,99 @@ test('should deliver the whole message raw when a key deserialization error is c
     'key'
   )
 })
+
+test('should continue past a failing beforeDeserialization hook when errors are continued', async t => {
+  const groupId = createTestGroupId()
+  const topic = await createTopic(t, true)
+
+  await produceTestMessages(t, topic, 2)
+
+  const consumer = createConsumer(t, groupId, {
+    deserializers: stringDeserializers as unknown as Deserializers<string, string, string, string>,
+    beforeDeserialization (_payload, type, _message, callback) {
+      callback(type === 'value' ? new UserError('Hook failed.') : null)
+    }
+  })
+
+  const failures: DeserializationErrorContext[] = []
+  const stream = await consumer.consume({
+    topics: [topic],
+    mode: MessagesStreamModes.EARLIEST,
+    maxFetches: 1,
+    onDeserializationError (context) {
+      failures.push(context)
+      return DeserializationErrorActions.CONTINUE
+    }
+  })
+
+  const messages = await Array.fromAsync(stream)
+
+  strictEqual(messages.length, 2)
+  strictEqual(failures.length, 2)
+  strictEqual(failures[0].payloadType, 'value')
+  strictEqual((failures[0].error as UserError).message, 'Hook failed.')
+
+  // Nothing was deserialized, so the whole message is delivered raw
+  deepStrictEqual(messages[0].key, Buffer.from('key-0'))
+  deepStrictEqual(messages[0].value, Buffer.from('value-0'))
+  deepStrictEqual(Array.from(messages[0].headers.entries()), [[Buffer.from('headerKey'), Buffer.from('headerValue-0')]])
+})
+
+test('should skip messages whose beforeDeserialization hook failed when errors are skipped', async t => {
+  const groupId = createTestGroupId()
+  const topic = await createTopic(t, true)
+
+  await produceTestMessages(t, topic, 2)
+
+  const consumer = createConsumer(t, groupId, {
+    deserializers: stringDeserializers as unknown as Deserializers<string, string, string, string>,
+    beforeDeserialization (_payload, type, _message, callback) {
+      callback(type === 'value' ? new UserError('Hook failed.') : null)
+    }
+  })
+
+  const stream = await consumer.consume({
+    topics: [topic],
+    mode: MessagesStreamModes.EARLIEST,
+    maxFetches: 1,
+    onDeserializationError () {
+      return DeserializationErrorActions.SKIP
+    }
+  })
+
+  const messages = await Array.fromAsync(stream)
+  strictEqual(messages.length, 0)
+})
+
+test('should destroy the stream with the original error when a hook failure is not continued', async t => {
+  const groupId = createTestGroupId()
+  const topic = await createTopic(t, true)
+
+  await produceTestMessages(t, topic, 1)
+
+  const consumer = createConsumer(t, groupId, {
+    deserializers: stringDeserializers as unknown as Deserializers<string, string, string, string>,
+    beforeDeserialization (_payload, type, _message, callback) {
+      callback(type === 'value' ? new UserError('Hook failed.') : null)
+    }
+  })
+
+  const stream = await consumer.consume({
+    topics: [topic],
+    mode: MessagesStreamModes.EARLIEST,
+    maxFetches: 1,
+    onDeserializationError () {
+      return DeserializationErrorActions.FAIL
+    }
+  })
+
+  const error = (await Array.fromAsync(stream).catch((error: Error) => error)) as UserError
+
+  /*
+    Routing hook failures through the handler must not change the error the caller already saw:
+    a hook failure which is not continued still surfaces as the error the hook produced.
+  */
+  strictEqual(error instanceof UserError, true)
+  strictEqual(error.message, 'Hook failed.')
+  strictEqual(error.cause, undefined)
+})

--- a/test/registries/confluent-schema-registry.test.ts
+++ b/test/registries/confluent-schema-registry.test.ts
@@ -1791,3 +1791,113 @@ test('continues consuming with the raw payload when a message cannot be decoded'
   deepStrictEqual(structuredClone(messages[1].value), { id: 2, name: 'Bob' })
   strictEqual(messages[1].metadata.deserializationError, undefined)
 })
+
+test('continues consuming with the raw payload when the Schema Registry is unreachable', async t => {
+  const topic = await createTopic(t, true)
+
+  const producerRegistry = new ConfluentSchemaRegistry<string, Datum, string, string>({
+    url: confluentSchemaRegistryUrl
+  })
+
+  const subject = createSubject()
+  const schemaId = await registerSchema(
+    confluentSchemaRegistryUrl,
+    subject,
+    'AVRO',
+    JSON.stringify({
+      type: 'record',
+      name: subject,
+      fields: [
+        { name: 'id', type: 'int' },
+        { name: 'name', type: 'string' }
+      ]
+    })
+  )
+
+  const producer = await createProducer(t, { registry: producerRegistry })
+  await producer.send({
+    messages: [
+      {
+        topic,
+        key: 'key-1',
+        value: { id: 1, name: 'Alice' },
+        headers: { header1: 'value1' },
+        metadata: { schemas: { value: schemaId } }
+      }
+    ]
+  })
+
+  // A registry which cannot be reached, simulating an outage. Retries are disabled as the failure
+  // is the point of the test and each attempt would only add its backoff to the runtime.
+  const consumerRegistry = new ConfluentSchemaRegistry<string, Datum, string, string>({
+    url: 'http://127.0.0.1:1',
+    retries: 0
+  })
+
+  const failures: DeserializationErrorContext[] = []
+  const consumer = createConsumer(t, { registry: consumerRegistry })
+  const stream = await consumer.consume({
+    topics: [topic],
+    maxFetches: 1,
+    mode: MessagesStreamModes.EARLIEST,
+    onDeserializationError (context) {
+      failures.push(context)
+      return DeserializationErrorActions.CONTINUE
+    }
+  })
+
+  const messages = await Array.fromAsync(stream)
+
+  strictEqual(messages.length, 1)
+  strictEqual(failures.length, 1)
+  strictEqual(failures[0].payloadType, 'value')
+
+  // The message carries the bytes as they were received, headers included
+  const rawValue = messages[0].value as unknown as Buffer
+  deepStrictEqual(rawValue.subarray(0, 5), Buffer.from([0, 0, 0, 0, schemaId]))
+  deepStrictEqual(messages[0].key, Buffer.from('key-1'))
+  deepStrictEqual(Array.from(messages[0].headers.entries()), [[Buffer.from('header1'), Buffer.from('"value1"')]])
+  ok(messages[0].metadata.deserializationError)
+
+  // The schema ID is still readable from the Confluent wire format header
+  strictEqual(consumerRegistry.getSchemaId(rawValue, 'value'), schemaId)
+})
+
+test('still destroys the stream on Schema Registry failures without an error handler', async t => {
+  const topic = await createTopic(t, true)
+
+  const producerRegistry = new ConfluentSchemaRegistry<string, Datum, string, string>({
+    url: confluentSchemaRegistryUrl
+  })
+
+  const subject = createSubject()
+  const schemaId = await registerSchema(
+    confluentSchemaRegistryUrl,
+    subject,
+    'AVRO',
+    JSON.stringify({
+      type: 'record',
+      name: subject,
+      fields: [
+        { name: 'id', type: 'int' },
+        { name: 'name', type: 'string' }
+      ]
+    })
+  )
+
+  const producer = await createProducer(t, { registry: producerRegistry })
+  await producer.send({
+    messages: [{ topic, key: 'key-1', value: { id: 1, name: 'Alice' }, metadata: { schemas: { value: schemaId } } }]
+  })
+
+  const consumerRegistry = new ConfluentSchemaRegistry<string, Datum, string, string>({
+    url: 'http://127.0.0.1:1',
+    retries: 0
+  })
+
+  const consumer = createConsumer(t, { registry: consumerRegistry })
+  const stream = await consumer.consume({ topics: [topic], maxFetches: 1, mode: MessagesStreamModes.EARLIEST })
+
+  const error = await Array.fromAsync(stream).catch((error: Error) => error)
+  ok(error instanceof Error)
+})


### PR DESCRIPTION
Follow-up to #360, which landed as a purely additive change. This PR carries the part that alters existing behaviour, so it can be reviewed and released on its own.

## What changes

A failing `beforeDeserialization` hook — which is where a schema registry fetches the schemas it needs — used to destroy the stream **unconditionally**, whatever `onDeserializationError` returned. An intermittent registry outage therefore killed the consumer even for callers who had explicitly asked for bad messages to be skipped.

The hook failure is now recorded on the message it belongs to and reported in `#pushRecords` with a full `DeserializationErrorContext`, so the handler can `SKIP` or `CONTINUE` that single message. Because a hook failure happens before anything is deserialized, a continued message carries the original bytes for key, value **and** headers.

## Behavioural delta, measured

A 9-scenario probe run against `main` and against this branch. `deser` rows are decode failures, `hook` rows are before-deserialization hook failures:

| Scenario | main | this PR |
| --- | --- | --- |
| decode error + `FAIL` | destroyed, wrapped | identical |
| decode error + `SKIP` | skipped | identical |
| decode error + handler returns `undefined` | destroyed | identical |
| decode error + no handler | destroyed | identical |
| decode error + `onCorruptedMessage` → `false` | skipped | identical |
| decode error + `onCorruptedMessage` → `true` | destroyed | identical |
| **hook failure + `SKIP`** | **destroyed** | **skipped, stream survives** |
| hook failure + `FAIL` | destroyed, raw error | identical |
| hook failure + no handler | destroyed, raw error | identical |

**Exactly one row changes**, and it is the one issue #344 is about.

Note in particular that a hook failure under `FAIL` still destroys the stream with the error the hook produced, rather than wrapping it in the `Failed to deserialize a message.` `UserError` used for decode failures. Wrapping would silently change the error existing `FAIL` handlers observe; there is a regression test pinning the raw error.

## Known cost

During a registry outage every affected message attempts its own schema fetch, since the hook runs per payload. That volume is bounded by the `timeout`/`retries` options added in #356. A negative cache for failed schema fetches would remove it entirely — worth a separate issue.

## Tests

- hook failure delivering the whole message raw under `CONTINUE`
- hook failure honouring `SKIP`
- hook failure under `FAIL` destroying with the original, unwrapped error
- registry-level: an unreachable Schema Registry degrading instead of destroying, and still destroying when no handler is configured

97 tests across the two affected files pass locally.