### PR TITLE
fix: parse IPv6 bootstrap broker addresses

### DIFF
--- a/docs/base.md
+++ b/docs/base.md
@@ -25,7 +25,7 @@ Creates a new base client.
 | Property             | Type                   | Default   | Description                                                                                                                                                        |
 | -------------------- | ---------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `clientId`           | `string`               |           | Client ID.                                                                                                                                                         |
-| `clientRack`         | `string`               |           | Client rack identifier sent by consumers as the Fetch and ConsumerGroupHeartbeat rack ID.                                                                            |
+| `clientRack`         | `string`               |           | Client rack identifier sent by consumers as the Fetch and ConsumerGroupHeartbeat rack ID.                                                                          |
 | `bootstrapBrokers`   | `(Broker \| string)[]` |           | Bootstrap brokers.<br/><br/>Each broker can be either an object with `host` and `port` properties or a string in the format `$host:$port`.                         |
 | `timeout`            | `number`               | 5 seconds | Timeout in milliseconds for Kafka requests that support the parameter.                                                                                             |
 | `retries`            | `number` \| `boolean`  | `3`       | Number of times to retry an operation before failing. `true` means "infinity", while `false` means 0                                                               |
@@ -43,6 +43,8 @@ Creates a new base client.
 | `tlsServerName`      | `boolean` \| `string`  |           | A TLS servername to use when connecting. When set to `true` it will use the current target host.                                                                   |
 | `sasl`               | `SASLOptions`          |           | Configures SASL authentication. See section below.                                                                                                                 |
 | `context`            | `unknown`              |           | Opaque user data forwarded to internally created `ConnectionPool` and `Connection` instances. Kafka never reads, mutates, or interprets this value.                |
+
+IPv6 bootstrap hosts must be wrapped in brackets, e.g. `[::1]:9092` or `[2001:db8::1]:9092`. Unbracketed IPv6 addresses are treated as host-only and use the default port.
 
 The readonly `context` getter exposes the same opaque value on the client instance.
 

--- a/src/network/utils.ts
+++ b/src/network/utils.ts
@@ -1,14 +1,42 @@
 import { type Broker } from './connection.ts'
 
+const BRACKETED_BROKER_RE = /^\[([^\]]+)](?::(\d*))?$/
+
 export function parseBroker (broker: Broker | string, defaultPort: number = 9092): Broker {
-  if (typeof broker === 'string') {
-    if (broker.includes(':')) {
-      const [host, port] = broker.split(':')
-      return { host, port: Number(port) }
-    } else {
-      return { host: broker, port: defaultPort }
+  if (typeof broker !== 'string') {
+    const host = stripBrackets(broker.host)
+
+    if (host === broker.host) {
+      return broker
     }
+
+    return { ...broker, host }
   }
 
-  return broker
+  const bracketed = BRACKETED_BROKER_RE.exec(broker)
+  if (bracketed) {
+    return { host: bracketed[1], port: parsePort(bracketed[2], defaultPort) }
+  }
+
+  const separator = broker.lastIndexOf(':')
+
+  // Bare IPv6 addresses contain multiple colons and no port. The host:port form
+  // is unambiguous only with a single colon, or with brackets around the host.
+  if (separator === -1 || broker.indexOf(':') !== separator) {
+    return { host: broker, port: defaultPort }
+  }
+
+  return { host: broker.slice(0, separator), port: parsePort(broker.slice(separator + 1), defaultPort) }
+}
+
+function parsePort (port: string | undefined, defaultPort: number): number {
+  return port === undefined || port.length === 0 ? defaultPort : Number(port)
+}
+
+function stripBrackets (host: string): string {
+  if (host.startsWith('[') && host.endsWith(']')) {
+    return host.slice(1, -1)
+  }
+
+  return host
 }

--- a/test/clients/base/base.test.ts
+++ b/test/clients/base/base.test.ts
@@ -3,7 +3,14 @@ import { randomUUID } from 'node:crypto'
 import { once } from 'node:events'
 import { test } from 'node:test'
 import { createPromisifiedCallback } from '../../../src/apis/callbacks.ts'
-import { kConnections, kGetApi, kGetBootstrapConnection, kOptions, kPerformWithRetry } from '../../../src/clients/base/base.ts'
+import {
+  kBootstrapBrokers,
+  kConnections,
+  kGetApi,
+  kGetBootstrapConnection,
+  kOptions,
+  kPerformWithRetry
+} from '../../../src/clients/base/base.ts'
 import { defaultBaseOptions } from '../../../src/clients/base/options.ts'
 import {
   apiVersionsV3,
@@ -39,6 +46,21 @@ test('constructor should properly set getters', () => {
   deepStrictEqual(base.clientId, 'clientId')
   deepStrictEqual(base.closed, false)
   deepStrictEqual(base.type, 'base')
+})
+
+test('constructor should parse IPv6 bootstrap broker strings', () => {
+  const base = new Base({
+    clientId: 'clientId',
+    bootstrapBrokers: ['[::1]:9092', '[2001:db8::1]:19092', '::1'],
+    retries: false,
+    strict: true
+  })
+
+  deepStrictEqual(base[kBootstrapBrokers], [
+    { host: '::1', port: 9092 },
+    { host: '2001:db8::1', port: 19092 },
+    { host: '::1', port: 9092 }
+  ])
 })
 
 test('constructor should preserve defaults when options are explicitly set to undefined', t => {

--- a/test/network/connection-pool.test.ts
+++ b/test/network/connection-pool.test.ts
@@ -10,7 +10,8 @@ import {
   connectionsPoolGetsChannel,
   ConnectionStatuses,
   GenericError,
-  instancesChannel
+  instancesChannel,
+  parseBroker
 } from '../../src/index.ts'
 import {
   createCreationChannelVerifier,
@@ -20,7 +21,7 @@ import {
   mockMethod
 } from '../helpers.ts'
 
-function createServer (t: TestContext): Promise<{ server: Server; port: number }> {
+function createServer (t: TestContext, host?: string): Promise<{ server: Server; port: number }> {
   const server = createNetworkServer()
   const { promise, resolve, reject } = Promise.withResolvers<{ server: Server; port: number }>()
   const sockets: Socket[] = []
@@ -38,7 +39,7 @@ function createServer (t: TestContext): Promise<{ server: Server; port: number }
     server.close(cb)
   })
 
-  server.listen(0)
+  server.listen(0, host)
   return promise
 }
 
@@ -71,6 +72,18 @@ test('get should return a connection for a broker', async t => {
   const broker = { host: 'localhost', port }
 
   const connection = await connectionPool.get(broker)
+  ok(connection instanceof Connection)
+  deepStrictEqual(connection.status, ConnectionStatuses.CONNECTED)
+  await connection.close()
+})
+
+test('get should connect to a parsed IPv6 bootstrap broker', async t => {
+  const { port } = await createServer(t, '::1')
+
+  const connectionPool = new ConnectionPool('test-client')
+  t.after(() => connectionPool.close())
+
+  const connection = await connectionPool.get(parseBroker(`[::1]:${port}`))
   ok(connection instanceof Connection)
   deepStrictEqual(connection.status, ConnectionStatuses.CONNECTED)
   await connection.close()
@@ -316,18 +329,21 @@ test('get fail when the pool is closed', async t => {
   t.after(() => connectionPool.close())
   await connectionPool.close()
 
-  await rejects(() => connectionPool.get(broker) as Promise<unknown>, error => {
-    strictEqual((error as Error).message, 'Connection pool is closed.')
+  await rejects(
+    () => connectionPool.get(broker) as Promise<unknown>,
+    error => {
+      strictEqual((error as Error).message, 'Connection pool is closed.')
 
-    // The clients classify errors via findBy, which only exists on GenericError subclasses.
-    ok(GenericError.isGenericError(error as Error))
-    strictEqual((error as GenericError).code, 'PLT_KFK_NETWORK')
-    strictEqual((error as GenericError).canRetry, false)
-    strictEqual((error as GenericError).closed, true)
-    deepStrictEqual((error as GenericError).broker, broker)
-    strictEqual((error as GenericError).findBy('code', 'PLT_KFK_NETWORK'), error)
-    return true
-  })
+      // The clients classify errors via findBy, which only exists on GenericError subclasses.
+      ok(GenericError.isGenericError(error as Error))
+      strictEqual((error as GenericError).code, 'PLT_KFK_NETWORK')
+      strictEqual((error as GenericError).canRetry, false)
+      strictEqual((error as GenericError).closed, true)
+      deepStrictEqual((error as GenericError).broker, broker)
+      strictEqual((error as GenericError).findBy('code', 'PLT_KFK_NETWORK'), error)
+      return true
+    }
+  )
 })
 
 test('get should reject with a retriable error when the broker is missing from stale metadata', async t => {

--- a/test/network/connection-pool.test.ts
+++ b/test/network/connection-pool.test.ts
@@ -1,5 +1,6 @@
 import { deepStrictEqual, ok, rejects, strictEqual } from 'node:assert'
 import { type AddressInfo, createServer as createNetworkServer, type Server, type Socket } from 'node:net'
+import { networkInterfaces } from 'node:os'
 import { mock, test, type TestContext } from 'node:test'
 import {
   type Broker,
@@ -20,6 +21,11 @@ import {
   mockedOperationId,
   mockMethod
 } from '../helpers.ts'
+
+// Machines with IPv6 disabled cannot bind to the loopback address, so tests using it are skipped there.
+const hasIPv6Loopback = Object.values(networkInterfaces())
+  .flat()
+  .some(info => info?.address === '::1')
 
 function createServer (t: TestContext, host?: string): Promise<{ server: Server; port: number }> {
   const server = createNetworkServer()
@@ -77,7 +83,7 @@ test('get should return a connection for a broker', async t => {
   await connection.close()
 })
 
-test('get should connect to a parsed IPv6 bootstrap broker', async t => {
+test('get should connect to a parsed IPv6 bootstrap broker', { skip: !hasIPv6Loopback }, async t => {
   const { port } = await createServer(t, '::1')
 
   const connectionPool = new ConnectionPool('test-client')

--- a/test/network/utils.test.ts
+++ b/test/network/utils.test.ts
@@ -1,0 +1,42 @@
+import { deepStrictEqual, strictEqual } from 'node:assert'
+import { test } from 'node:test'
+import { parseBroker } from '../../src/index.ts'
+
+test('parseBroker should parse host:port strings', () => {
+  deepStrictEqual(parseBroker('localhost:9092'), { host: 'localhost', port: 9092 })
+  deepStrictEqual(parseBroker('127.0.0.1:19092'), { host: '127.0.0.1', port: 19092 })
+})
+
+test('parseBroker should use the default port when none is provided', () => {
+  deepStrictEqual(parseBroker('localhost'), { host: 'localhost', port: 9092 })
+  deepStrictEqual(parseBroker('127.0.0.1', 19092), { host: '127.0.0.1', port: 19092 })
+})
+
+test('parseBroker should parse bracketed IPv6 addresses', () => {
+  deepStrictEqual(parseBroker('[::1]:9092'), { host: '::1', port: 9092 })
+  deepStrictEqual(parseBroker('[2001:db8::1]:19092'), { host: '2001:db8::1', port: 19092 })
+  deepStrictEqual(parseBroker('[::ffff:192.0.2.1]:9092'), { host: '::ffff:192.0.2.1', port: 9092 })
+  deepStrictEqual(parseBroker('[fe80::1%lo0]:9092'), { host: 'fe80::1%lo0', port: 9092 })
+})
+
+test('parseBroker should use the default port for bracketed IPv6 hosts without a port', () => {
+  deepStrictEqual(parseBroker('[::1]'), { host: '::1', port: 9092 })
+  deepStrictEqual(parseBroker('[2001:db8::1]', 19092), { host: '2001:db8::1', port: 19092 })
+})
+
+test('parseBroker should treat unbracketed IPv6 addresses as host-only', () => {
+  deepStrictEqual(parseBroker('::1'), { host: '::1', port: 9092 })
+  deepStrictEqual(parseBroker('2001:db8::1'), { host: '2001:db8::1', port: 9092 })
+  deepStrictEqual(parseBroker('2001:db8::1:9092', 19092), { host: '2001:db8::1:9092', port: 19092 })
+})
+
+test('parseBroker should return broker objects unchanged when the host has no brackets', () => {
+  const broker = { host: 'localhost', port: 9092 }
+
+  strictEqual(parseBroker(broker), broker)
+})
+
+test('parseBroker should strip brackets from broker object hosts', () => {
+  deepStrictEqual(parseBroker({ host: '[::1]', port: 9092 }), { host: '::1', port: 9092 })
+  deepStrictEqual(parseBroker({ host: '[2001:db8::1]', port: 19092 }), { host: '2001:db8::1', port: 19092 })
+})


### PR DESCRIPTION
Fixes #364.

Bootstrap broker strings were split on the first colon, which broke IPv6 literals such as `[::1]:9092`. `parseBroker` now understands bracketed IPv6 hosts, treats unbracketed multi-colon addresses as host-only, and strips leftover brackets from broker objects before connecting.
