### PR TITLE
feat: expose record batch leader epoch on consumed messages

### DIFF
--- a/docs/other.md
+++ b/docs/other.md
@@ -151,6 +151,7 @@ The types of the `key`, `value` and `headers` fields are determined by the curre
 | `timestamp` | `bigint`                      | The timestamp of the message. When producing, it defaults to the current timestamp.                 |
 | `headers`   | `Map<HeaderKey, HeaderValue>` | A map with the message headers.                                                                     |
 | `offset`    | `bigint`                      | The message offset                                                                                  |
+| `leaderEpoch` | `number`                    | The leader epoch of the record batch containing the message, or `-1` when unknown. It is suitable as the `leaderEpoch` when committing offsets manually via [`Consumer.commit`](./consumer.md#commitoptions-callback).                     |
 | `commit`    | () => Promise<void>           | A function to commit the offset. This is a no-op if consumer's `autocommit` option was not `false`. |
 
 `Message` also provides a `.toJSON()` method for debugging and logging.

--- a/src/clients/consumer/messages-stream.ts
+++ b/src/clients/consumer/messages-stream.ts
@@ -71,6 +71,7 @@ function messageToJSON<Key, Value, HeaderKey, HeaderValue> (this: Message<Key, V
     partition: this.partition,
     timestamp: this.timestamp.toString(),
     offset: this.offset.toString(),
+    leaderEpoch: this.leaderEpoch,
     metadata: this.metadata
   }
 }
@@ -1001,6 +1002,9 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
                 partition,
                 timestamp: firstTimestamp + record.timestampDelta,
                 offset,
+                // The batch header epoch is the epoch of the record itself, which is what
+                // OffsetCommit expects as committedLeaderEpoch (KIP-320).
+                leaderEpoch: batch.partitionLeaderEpoch,
                 commit,
                 // Deserializers and hooks can enrich the metadata of the message they processed
                 metadata: deserializationError

--- a/src/protocol/records.ts
+++ b/src/protocol/records.ts
@@ -54,6 +54,7 @@ export interface MessageJSON<Key = unknown, Value = unknown, HeaderKey = unknown
   partition: number
   timestamp: string
   offset: string
+  leaderEpoch: number
   metadata: Record<string, unknown>
 }
 
@@ -63,6 +64,7 @@ export interface Message<Key = Buffer, Value = Buffer, HeaderKey = Buffer, Heade
 > {
   headers: Map<HeaderKey, HeaderValue>
   offset: bigint
+  leaderEpoch: number
   metadata: Record<string, unknown>
   commit (callback?: (error?: Error) => void): void | Promise<void>
   toJSON (): MessageJSON<Key, Value, HeaderKey, HeaderValue>

--- a/test/clients/consumer/messages-stream.test.ts
+++ b/test/clients/consumer/messages-stream.test.ts
@@ -331,6 +331,8 @@ test('should support diagnostic channels', async t => {
       const message = context.result as Message
       ok(typeof message.timestamp, 'bigint')
       message.timestamp = 0n
+      ok(message.leaderEpoch >= 0, 'leaderEpoch should be non-negative')
+      message.leaderEpoch = 0
 
       deepStrictEqual(context.result, {
         key: 'key-0',
@@ -340,6 +342,7 @@ test('should support diagnostic channels', async t => {
         partition: 0,
         timestamp: 0n,
         offset: 0n,
+        leaderEpoch: 0,
         metadata: message.metadata,
         commit: noopCallback,
         toJSON: message.toJSON
@@ -407,6 +410,7 @@ test('should expose message.toJSON for easy serialization', async t => {
 
   strictEqual(typeof payload.offset, 'string')
   strictEqual(typeof payload.timestamp, 'string')
+  strictEqual(typeof payload.leaderEpoch, 'number')
   deepStrictEqual(payload.headers, [['headerKey', 'headerValue-0']])
 })
 
@@ -502,6 +506,33 @@ test('should support manual commits', async t => {
   deepStrictEqual(secondBatch[1].key, 'key-2', 'Second message in second batch should be key-2')
 })
 
+test('should expose the record batch leader epoch for manual batched commits', async t => {
+  const groupId = createTestGroupId()
+  const topic = await createTopic(t, true)
+
+  await produceTestMessages(t, topic)
+
+  const { consumer, messages } = await consumeMessages(t, groupId, topic, {
+    mode: MessagesStreamModes.EARLIEST,
+    autocommit: false
+  })
+
+  strictEqual(messages.length, 3, 'Should consume 3 messages')
+
+  for (const message of messages) {
+    ok(message.leaderEpoch >= 0, 'Each message should carry the record batch leader epoch')
+  }
+
+  // Commit the last processed offset using the exposed epoch, as a batching application would
+  const last = messages.at(-1)!
+  await consumer.commit({
+    offsets: [{ topic, partition: last.partition, offset: last.offset + 1n, leaderEpoch: last.leaderEpoch }]
+  })
+
+  const offsets = await consumer.listCommittedOffsets({ topics: [{ topic, partitions: [0] }] })
+  deepStrictEqual(offsets.get(topic), [last.offset + 1n], 'Committed offset should be the last offset + 1')
+})
+
 test('should consume messages with LATEST mode', async t => {
   const groupId = createTestGroupId()
   const topic = await createTopic(t, true)
@@ -569,6 +600,7 @@ test('should consume messages with EARLIEST mode', async t => {
     strictEqual(messages[i].topic, topic, `Message ${i} should have correct topic`)
     strictEqual(typeof messages[i].offset, 'bigint', `Message ${i} should have bigint offset`)
     strictEqual(typeof messages[i].timestamp, 'bigint', `Message ${i} should have bigint timestamp`)
+    ok(messages[i].leaderEpoch >= 0, `Message ${i} should have a non-negative leader epoch`)
     strictEqual(typeof messages[i].commit, 'function', `Message ${i} should have commit function`)
   }
 })


### PR DESCRIPTION
Fixes #366.

`Consumer.commit({ offsets })` requires a `leaderEpoch` per offset, but consumed messages did not expose one, so manual batched commits had to send `-1` and forfeit [KIP-320](https://cwiki.apache.org/confluence/spaces/KAFKA/pages/87295403/KIP-320+Allow+fetchers+to+detect+and+handle+log+truncation) log-truncation validation.

This sets `Message.leaderEpoch` from the record batch header — the epoch of the consumed record itself, matching what the Java client (`SubscriptionState.lastConsumedEpoch`) and librdkafka use for `committedLeaderEpoch`. `-1` remains the unknown sentinel. Internal commit paths (autocommit, `message.commit()`) are unchanged.

- `Message`/`MessageJSON` gain `leaderEpoch: number`; `toJSON()` includes it
- Documented in `docs/other.md`
- Tests cover field shape, `toJSON`, and a manual batched commit using the exposed epoch verified via `listCommittedOffsets`