### PR TITLE
fix: keep committed offsets across overlapping refreshes

### DIFF
--- a/src/clients/consumer/messages-stream.ts
+++ b/src/clients/consumer/messages-stream.ts
@@ -499,7 +499,14 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
   _construct (callback: (error?: Error) => void) {
     this.#refreshOffsetsInflight = true
     this.#refreshOffsets(error => {
+      const wasPending = this.#refreshOffsetsPending
       this.#refreshOffsetsInflight = false
+      this.#refreshOffsetsPending = false
+
+      if (!error && wasPending) {
+        this.#scheduleRefreshOffsetsAndFetch()
+      }
+
       callback(error ?? undefined)
     })
   }
@@ -1180,7 +1187,10 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
         }
 
         if (!topics.length) {
-          this.#assignOffsets(offsets!, new Map(), callback)
+          // No assignment yet: do not seed fallback offsets for the whole topic.
+          // consumer:group:join will refresh once partitions are assigned.
+          this.emit('offsets')
+          callback(null)
           return
         }
 
@@ -1215,6 +1225,7 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
 
     this.#refreshOffsets(error => {
       const shouldDestroyOnError = this.#refreshOffsetsDestroyOnError
+      const wasPending = this.#refreshOffsetsPending
       this.#refreshOffsetsInflight = false
       this.#refreshOffsetsDestroyOnError = false
       this.#refreshOffsetsPending = false
@@ -1229,8 +1240,7 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
       }
 
       // A new one was scheduled while the previous one was inflight, we need to run it immediately
-      /* c8 ignore next 4 - Hard to test */
-      if (this.#refreshOffsetsPending) {
+      if (wasPending) {
         this.#scheduleRefreshOffsetsAndFetch(shouldDestroyOnError)
         return
       }

--- a/test/clients/consumer/messages-stream-rebalance.test.ts
+++ b/test/clients/consumer/messages-stream-rebalance.test.ts
@@ -294,6 +294,179 @@ test('should not fetch while offsets are refreshing after a group rejoin', async
   stream.destroy()
 })
 
+function createOffsetRefreshConsumerMock () {
+  const consumer = new EventEmitter() as any
+
+  consumer.assignments = [{ topic: 'test-topic', partitions: [0] }]
+  consumer.topics = { current: ['test-topic'] }
+  consumer.groupId = 'test-group'
+  consumer.memberId = 'test-member'
+  consumer.generationId = 1
+  consumer.coordinatorId = 1
+  consumer[kPrometheus] = undefined
+  consumer[kGetFetchNode] = (metadata: any, topicName: string, partition: number) => {
+    return metadata.topics.get(topicName).partitions[partition].leader
+  }
+  consumer[kCreateConnectionPool] = () => {
+    return {
+      close (callback: CallbackWithPromise<void>) {
+        callback(null)
+      }
+    }
+  }
+  consumer.metadata = (_: object, callback: CallbackWithPromise<any>) => {
+    callback(null, {
+      topics: new Map([['test-topic', { id: 'test-topic-id', partitions: [{ leader: 1, leaderEpoch: 0 }] }]])
+    })
+  }
+  consumer.listOffsets = (_: object, callback: CallbackWithPromise<any>) => {
+    callback(null, new Map([['test-topic', [0n]]]))
+  }
+  consumer.listCommittedOffsets = (_: object, callback: CallbackWithPromise<any>) => {
+    callback(null, new Map([['test-topic', [10n]]]))
+  }
+  consumer.fetch = (_: object, _callback: CallbackWithPromise<any>) => {}
+
+  return consumer
+}
+
+const committedStreamOptions = {
+  topics: ['test-topic'],
+  mode: MessagesStreamModes.COMMITTED,
+  fallbackMode: MessagesStreamFallbackModes.EARLIEST,
+  maxWaitTime: 1000,
+  maxBytes: 1024,
+  autocommit: false
+}
+
+test('should rerun offset refresh when a group join arrives while a refresh is inflight', { timeout: 5_000 }, async () => {
+  const consumer = createOffsetRefreshConsumerMock()
+  let committedCalls = 0
+  let resolveSecondCommittedStarted!: () => void
+  const secondCommittedStarted = new Promise<void>(resolve => {
+    resolveSecondCommittedStarted = resolve
+  })
+  let resolveThirdCommitted!: () => void
+  const thirdCommitted = new Promise<void>(resolve => {
+    resolveThirdCommitted = resolve
+  })
+
+  consumer.listCommittedOffsets = (_: object, callback: CallbackWithPromise<any>) => {
+    committedCalls++
+
+    if (committedCalls === 2) {
+      resolveSecondCommittedStarted()
+      setTimeout(() => callback(null, new Map([['test-topic', [10n]]])), 50)
+      return
+    }
+
+    callback(null, new Map([['test-topic', [committedCalls === 3 ? 20n : 10n]]]))
+
+    if (committedCalls === 3) {
+      resolveThirdCommitted()
+    }
+  }
+
+  const stream = new MessagesStream(consumer, committedStreamOptions)
+  const constructed = new Promise<void>(resolve => stream.once('offsets', resolve))
+  stream.resume()
+  await constructed
+
+  strictEqual(committedCalls, 1)
+
+  consumer.emit('consumer:group:join')
+  await secondCommittedStarted
+  consumer.emit('consumer:group:join')
+  await thirdCommitted
+
+  strictEqual(committedCalls, 3)
+  strictEqual(stream.offsetsToFetch.get('test-topic:0'), 20n)
+
+  stream.destroy()
+})
+
+test('should not seed fallback offsets when committed mode has no assignments yet', async () => {
+  const consumer = createOffsetRefreshConsumerMock()
+  consumer.assignments = undefined
+  let committedCalls = 0
+
+  consumer.listOffsets = (_: object, callback: CallbackWithPromise<any>) => {
+    callback(null, new Map([['test-topic', [0n, 0n]]]))
+  }
+  consumer.listCommittedOffsets = (_: object, callback: CallbackWithPromise<any>) => {
+    committedCalls++
+    callback(null, new Map([['test-topic', [42n]]]))
+  }
+
+  const stream = new MessagesStream(consumer, committedStreamOptions)
+
+  const initialOffsets = new Promise<void>(resolve => stream.once('offsets', resolve))
+  stream.resume()
+  await initialOffsets
+
+  strictEqual(committedCalls, 0)
+  strictEqual(stream.offsetsToFetch.size, 0)
+
+  const refreshedOffsets = new Promise<void>(resolve => stream.once('offsets', resolve))
+  consumer.assignments = [{ topic: 'test-topic', partitions: [0] }]
+  consumer.emit('consumer:group:join')
+  await refreshedOffsets
+
+  strictEqual(committedCalls, 1)
+  strictEqual(stream.offsetsToFetch.get('test-topic:0'), 42n)
+
+  stream.destroy()
+})
+
+test('should drain a pending offset refresh scheduled during stream construction', { timeout: 5_000 }, async () => {
+  const consumer = createOffsetRefreshConsumerMock()
+  consumer.assignments = undefined
+
+  let listOffsetsCalls = 0
+  let resolveFirstListOffsetsStarted!: () => void
+  const firstListOffsetsStarted = new Promise<void>(resolve => {
+    resolveFirstListOffsetsStarted = resolve
+  })
+  let resolveSecondCommitted!: () => void
+  const secondCommitted = new Promise<void>(resolve => {
+    resolveSecondCommitted = resolve
+  })
+  let committedCalls = 0
+
+  consumer.listOffsets = (_: object, callback: CallbackWithPromise<any>) => {
+    listOffsetsCalls++
+
+    if (listOffsetsCalls === 1) {
+      resolveFirstListOffsetsStarted()
+      setTimeout(() => callback(null, new Map([['test-topic', [0n]]])), 50)
+      return
+    }
+
+    callback(null, new Map([['test-topic', [0n]]]))
+  }
+  consumer.listCommittedOffsets = (_: object, callback: CallbackWithPromise<any>) => {
+    committedCalls++
+    callback(null, new Map([['test-topic', [42n]]]))
+
+    if (committedCalls === 2) {
+      resolveSecondCommitted()
+    }
+  }
+
+  const stream = new MessagesStream(consumer, committedStreamOptions)
+  stream.resume()
+  await firstListOffsetsStarted
+
+  consumer.assignments = [{ topic: 'test-topic', partitions: [0] }]
+  consumer.emit('consumer:group:join')
+  await secondCommitted
+
+  strictEqual(committedCalls, 2)
+  strictEqual(stream.offsetsToFetch.get('test-topic:0'), 42n)
+
+  stream.destroy()
+})
+
 test('should ignore data for partitions which were not part of the fetch request', async t => {
   const fetchedOffsets: bigint[] = []
   let resolveSecondFetch!: () => void


### PR DESCRIPTION
## Summary

`MessagesStream` with `mode: 'committed'` can silently abandon the group's committed offsets during startup/rebalance and start fetching from the fallback position instead.

- `fallbackMode: 'earliest'` → full topic replay (duplicate processing, lag spike, downstream floods)
- `fallbackMode: 'latest'` → unprocessed records are skipped with no error

This still happens on current `main`. It is related to #223: #225 / `v1.28.0` blocked `#fetch` while a refresh is in flight, but three remaining paths still lose committed positions or stall the fetch loop.

## Bug 1 — coalesced refresh is dropped

`#scheduleRefreshOffsetsAndFetch` is supposed to coalesce overlapping refreshes:

1. If a refresh is already in flight, set `#refreshOffsetsPending = true` and return.
2. When the in-flight refresh finishes, if pending was set, run another refresh instead of fetching.

The pending flag was cleared **before** it was read:

```ts
this.#refreshOffsetsPending = false

if (this.#refreshOffsetsPending) { // always false
  this.#scheduleRefreshOffsetsAndFetch(shouldDestroyOnError)
  return
}

this.#fetch()
```

So a `consumer:group:join` that arrives while `listOffsets` / `listCommittedOffsets` is in flight is forgotten, and `#fetch()` continues with whatever is already in `#offsetsToFetch`.

**Fix:** snapshot the flag (`const wasPending = this.#refreshOffsetsPending`) before resetting it, then branch on `wasPending`.

## Bug 2 — empty assignment seeds every partition with fallback

In `mode: 'committed'`, `#refreshOffsets` builds the `OffsetFetch` request from **current** `consumer.assignments`. If that list is empty when `listOffsets` returns, it does **not** call `listCommittedOffsets`. Instead it did:

```ts
if (!topics.length) {
  this.#assignOffsets(offsets!, new Map(), callback)
  return
}
```

`#assignOffsets` first writes the `listOffsets` result (earliest or latest, depending on `fallbackMode`) into `#offsetsToFetch` for **every** partition of the topic, and only then overwrites keys that appear in the commits map. With an empty commits map, every partition is left on the fallback.

`#onConsumerGroupJoin` clears `#offsetsCommitted` / `#partitionsEpochs` but **not** `#offsetsToFetch`. A partition that is assigned later without a successful refresh keeps that fallback position.

This window is common: `MessagesStream` is constructed and `_construct` → `#refreshOffsets` runs before the group join has published assignments.

**Fix:** if there is no assignment, do not call `#assignOffsets`. Emit `'offsets'`, invoke the callback, and wait for the next `consumer:group:join` (that handler already schedules a refresh).

## Bug 3 — pending refresh during `_construct` is never drained

The first refresh does not go through `#scheduleRefreshOffsetsAndFetch`. `_construct` set `#refreshOffsetsInflight` and called `#refreshOffsets` directly. A join in that window set `#refreshOffsetsPending`, but `_construct` never consumed it.

`#fetch` then stayed blocked (`#refreshOffsetsPending === true`) until another join.

**Fix:** `_construct` snapshots `wasPending` and, on success, schedules the coalesced refresh **before** completing construct, so a subsequent `#fetch` still sees inflight.

## What this does not change

- Non-`committed` modes (`earliest` / `latest` / `manual`) still use `listOffsets` as today.
- When assignments exist, committed offsets still override fallback via `#assignOffsets`.
- Partitions with no committed offset (`offset < 0`) still follow `fallbackMode` (`earliest` / `latest` / `fail`).
- The `#fetch` gate on `#refreshOffsetsInflight` / `#refreshOffsetsPending` from #225 is unchanged.

## Tests

In-memory consumer in `test/clients/consumer/messages-stream-rebalance.test.ts` (no Kafka cluster):

- overlapping `consumer:group:join` while `listCommittedOffsets` is delayed → a third refresh runs and `#offsetsToFetch` takes the later committed offset
- `assignments === undefined` during the first refresh → `#offsetsToFetch` stays empty and `listCommittedOffsets` is not called; after join, the committed offset is applied
- join while `_construct`'s `listOffsets` is in flight → the pending refresh is drained (`listCommittedOffsets` runs twice)

## How to reproduce (without this patch)

```ts
const stream = await consumer.consume({
  topics: ['my-topic'],
  mode: MessagesStreamModes.COMMITTED,
  fallbackMode: MessagesStreamFallbackModes.EARLIEST, // or LATEST
  autocommit: true
})
```

Restart the process or trigger a group rebalance (scale replicas, rolling deploy). If join races with the first `listOffsets`, the stream fetches from log-start (or high watermark) instead of the last committed offset, or stalls until the next rebalance.

A matching backport is opened against `v1.x`.

Made with [Cursor](https://cursor.com)