### PR TITLE
feat: preserve duplicate headers on consumed messages

### DIFF
--- a/docs/other.md
+++ b/docs/other.md
@@ -150,6 +150,7 @@ The types of the `key`, `value` and `headers` fields are determined by the curre
 | `value`     | `Value`                       | The value of the message.                                                                           |
 | `timestamp` | `bigint`                      | The timestamp of the message. When producing, it defaults to the current timestamp.                 |
 | `headers`   | `Map<HeaderKey, HeaderValue>` | A map with the message headers.                                                                     |
+| `headerEntries` | `Array<[HeaderKey, HeaderValue]>` | Ordered header entries preserving duplicate keys according to [KIP-82](https://cwiki.apache.org/confluence/spaces/KAFKA/pages/65871723/KIP-82+-+Add+Record+Headers#KIP82AddRecordHeaders-Keyduplicationandordering). |
 | `offset`    | `bigint`                      | The message offset                                                                                  |
 | `leaderEpoch` | `number`                    | The leader epoch of the record batch containing the message, or `-1` when unknown. It is suitable as the `leaderEpoch` when committing offsets manually via [`Consumer.commit`](./consumer.md#commitoptions-callback).                     |
 | `commit`    | () => Promise<void>           | A function to commit the offset. This is a no-op if consumer's `autocommit` option was not `false`. |

--- a/src/clients/consumer/messages-stream.ts
+++ b/src/clients/consumer/messages-stream.ts
@@ -923,12 +923,8 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
                   payloadType = 'headerValue'
                   /* c8 ignore next - Hard to test */
                   const deserializedHeaderValue = headerValueDeserializer(headerValue ?? undefined, messageToConsume)
-                  const entry: [HeaderKey, HeaderValue] = [
-                    deserializedHeaderKey as HeaderKey,
-                    deserializedHeaderValue as HeaderValue
-                  ]
-                  headerEntries.push(entry)
-                  headers.set(...entry)
+                  headers.set(deserializedHeaderKey as HeaderKey, deserializedHeaderValue as HeaderValue)
+                  headerEntries.push([deserializedHeaderKey as HeaderKey, deserializedHeaderValue as HeaderValue])
                 }
 
                 payloadType = 'key'
@@ -983,9 +979,8 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
                     headerEntries.length = 0
 
                     for (const [headerKey, headerValue] of record.headers) {
-                      const entry: [HeaderKey, HeaderValue] = [headerKey as HeaderKey, headerValue as HeaderValue]
-                      headerEntries.push(entry)
-                      headers.set(...entry)
+                      headers.set(headerKey as HeaderKey, headerValue as HeaderValue)
+                      headerEntries.push([headerKey as HeaderKey, headerValue as HeaderValue])
                     }
                   }
 

--- a/src/clients/consumer/messages-stream.ts
+++ b/src/clients/consumer/messages-stream.ts
@@ -66,7 +66,7 @@ function messageToJSON<Key, Value, HeaderKey, HeaderValue> (this: Message<Key, V
   return {
     key: this.key,
     value: this.value,
-    headers: Array.from(this.headers.entries()),
+    headers: this.headerEntries.map(([key, value]): [HeaderKey, HeaderValue] => [key, value]),
     topic: this.topic,
     partition: this.partition,
     timestamp: this.timestamp.toString(),
@@ -900,6 +900,7 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
 
             try {
               const headers = new Map<HeaderKey, HeaderValue>()
+              const headerEntries: Array<[HeaderKey, HeaderValue]> = []
               let payloadType: BeforeHookPayloadType = 'headerKey'
               let deserializedKey: Key | undefined
               let deserializedValue: Value | undefined
@@ -922,7 +923,12 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
                   payloadType = 'headerValue'
                   /* c8 ignore next - Hard to test */
                   const deserializedHeaderValue = headerValueDeserializer(headerValue ?? undefined, messageToConsume)
-                  headers.set(deserializedHeaderKey as HeaderKey, deserializedHeaderValue as HeaderValue)
+                  const entry: [HeaderKey, HeaderValue] = [
+                    deserializedHeaderKey as HeaderKey,
+                    deserializedHeaderValue as HeaderValue
+                  ]
+                  headerEntries.push(entry)
+                  headers.set(...entry)
                 }
 
                 payloadType = 'key'
@@ -974,9 +980,12 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
 
                   if (headersFailed) {
                     headers.clear()
+                    headerEntries.length = 0
 
                     for (const [headerKey, headerValue] of record.headers) {
-                      headers.set(headerKey as HeaderKey, headerValue as HeaderValue)
+                      const entry: [HeaderKey, HeaderValue] = [headerKey as HeaderKey, headerValue as HeaderValue]
+                      headerEntries.push(entry)
+                      headers.set(...entry)
                     }
                   }
 
@@ -1005,6 +1014,7 @@ export class MessagesStream<Key, Value, HeaderKey, HeaderValue> extends Readable
                 key: deserializedKey,
                 value: deserializedValue,
                 headers,
+                headerEntries,
                 topic,
                 partition,
                 timestamp: firstTimestamp + record.timestampDelta,

--- a/src/protocol/records.ts
+++ b/src/protocol/records.ts
@@ -63,6 +63,7 @@ export interface Message<Key = Buffer, Value = Buffer, HeaderKey = Buffer, Heade
   MessageBase<Key, Value>
 > {
   headers: Map<HeaderKey, HeaderValue>
+  headerEntries: Array<[HeaderKey, HeaderValue]>
   offset: bigint
   leaderEpoch: number
   metadata: Record<string, unknown>

--- a/test/clients/consumer/messages-stream.test.ts
+++ b/test/clients/consumer/messages-stream.test.ts
@@ -338,6 +338,7 @@ test('should support diagnostic channels', async t => {
         key: 'key-0',
         value: 'value-0',
         headers: new Map([['headerKey', 'headerValue-0']]),
+        headerEntries: [['headerKey', 'headerValue-0']],
         topic,
         partition: 0,
         timestamp: 0n,
@@ -412,6 +413,89 @@ test('should expose message.toJSON for easy serialization', async t => {
   strictEqual(typeof payload.timestamp, 'string')
   strictEqual(typeof payload.leaderEpoch, 'number')
   deepStrictEqual(payload.headers, [['headerKey', 'headerValue-0']])
+})
+
+test('should preserve duplicate header keys and their order', async t => {
+  const groupId = createTestGroupId()
+  const topic = await createTopic(t, true)
+
+  await produceTestMessages(t, topic, 1)
+
+  const consumer = createConsumer(t, groupId, {
+    beforeDeserialization (_payload, type, message, callback) {
+      if (type === 'key') {
+        message.headers = [
+          [Buffer.from('duplicate'), Buffer.from('first')],
+          [Buffer.from('duplicate'), Buffer.from('second')]
+        ]
+      }
+      callback(null)
+    }
+  })
+  const stream = await consumer.consume({
+    topics: [topic],
+    mode: MessagesStreamModes.EARLIEST,
+    maxFetches: 1
+  })
+
+  const messages = []
+  for await (const message of stream) {
+    messages.push(message)
+  }
+
+  strictEqual(messages.length, 1)
+  deepStrictEqual(messages[0].headerEntries, [
+    ['duplicate', 'first'],
+    ['duplicate', 'second']
+  ])
+  strictEqual(messages[0].headers.get('duplicate'), 'second')
+  const jsonHeaders = messages[0].toJSON().headers
+  deepStrictEqual(jsonHeaders, messages[0].headerEntries)
+  jsonHeaders.pop()
+  jsonHeaders[0][1] = 'changed'
+  strictEqual(messages[0].headerEntries.length, 2)
+  strictEqual(messages[0].headerEntries[0][1], 'first')
+})
+
+test('should preserve duplicate header keys when deserialization errors are continued', async t => {
+  const groupId = createTestGroupId()
+  const topic = await createTopic(t, true)
+
+  await produceTestMessages(t, topic, 1)
+
+  const consumer = createConsumer(t, groupId, {
+    deserializers: {
+      ...stringDeserializers,
+      headerValue () {
+        throw new Error('Cannot deserialize the header value.')
+      }
+    },
+    beforeDeserialization (_payload, type, message, callback) {
+      if (type === 'key') {
+        message.headers = [
+          [Buffer.from('duplicate'), Buffer.from('first')],
+          [Buffer.from('duplicate'), Buffer.from('second')]
+        ]
+      }
+      callback(null)
+    }
+  })
+  const stream = await consumer.consume({
+    topics: [topic],
+    mode: MessagesStreamModes.EARLIEST,
+    maxFetches: 1,
+    onDeserializationError () {
+      return DeserializationErrorActions.CONTINUE
+    }
+  })
+
+  const messages = await Array.fromAsync(stream)
+
+  strictEqual(messages.length, 1)
+  deepStrictEqual(messages[0].headerEntries, [
+    [Buffer.from('duplicate'), Buffer.from('first')],
+    [Buffer.from('duplicate'), Buffer.from('second')]
+  ])
 })
 
 test('should support timed autocommits', async t => {


### PR DESCRIPTION
Fixes https://github.com/platformatic/kafka/issues/373

## Summary

- Expose ordered, deserialized header tuples as `Message.headerEntries`.
- Preserve duplicate keys and wire order as required by [KIP-82](https://cwiki.apache.org/confluence/spaces/KAFKA/pages/65871723/KIP-82+-+Add+Record+Headers#KIP82AddRecordHeaders-Keyduplicationandordering).
- Keep the existing `headers` Map for convenient lookup and use the ordered entries for JSON serialization.
- Preserve entries when deserialization errors use `CONTINUE`.

## Tests

- `./scripts/node --test --test-reporter=cleaner-spec-reporter test/clients/consumer/messages-stream.test.ts`