### PR TITLE
fix: reschedule classic heartbeats after a non-group error

### DIFF
--- a/src/clients/consumer/consumer.ts
+++ b/src/clients/consumer/consumer.ts
@@ -1432,9 +1432,13 @@ export class Consumer<Key = Buffer, Value = Buffer, HeaderKey = Buffer, HeaderVa
             return
           }
 
-          this.emitWithDebug('consumer:heartbeat', 'error', { ...eventPayload, error })
+          // The error was not group related, so we schedule another heartbeat.
+          // Do this before notifying listeners so they can still cancel it.
+          this.#heartbeatInterval = setTimeout(() => {
+            this.#heartbeat(options)
+          }, options.heartbeatInterval)
 
-          // Note that here we purposely do not return, since it was not a group related problem we schedule another heartbeat
+          this.emitWithDebug('consumer:heartbeat', 'error', { ...eventPayload, error })
         } else {
           this.#lastHeartbeat = new Date()
           this.emitWithDebug('consumer:heartbeat', 'end', eventPayload)

--- a/test/clients/consumer/consumer.test.ts
+++ b/test/clients/consumer/consumer.test.ts
@@ -5024,6 +5024,29 @@ test('#heartbeat should handle unavailable API errors', async t => {
   strictEqual(error.message.includes('Unsupported API Heartbeat.'), true)
 })
 
+test('#heartbeat should recover after a non-group error', async t => {
+  const consumer = createConsumer(t, { heartbeatInterval: 500 })
+
+  await consumer.joinGroup()
+
+  // Fail a single heartbeat, then let the following ones succeed
+  mockUnavailableAPI(consumer, 'Heartbeat')
+
+  await once(consumer, 'consumer:heartbeat:error')
+  await once(consumer, 'consumer:heartbeat:end')
+})
+
+test('#heartbeat should keep scheduling heartbeats while a non-group error persists', async t => {
+  const consumer = createConsumer(t, { heartbeatInterval: 500 })
+
+  await consumer.joinGroup()
+
+  mockUnavailableAPI(consumer, 'Heartbeat', false)
+
+  await once(consumer, 'consumer:heartbeat:error')
+  await once(consumer, 'consumer:heartbeat:error')
+})
+
 test('#heartbeat should emit events when it was cancelled while waiting for API response', async t => {
   const consumer = createConsumer(t)
 


### PR DESCRIPTION
Found while working on #374 found that a single non-group heartbeat error silently stops the classic heartbeat loop.

The error path calls `#cancelHeartbeat()`, so the trailing `this.#heartbeatInterval?.refresh()` is a no-op. I think the intention is to schedule another heartbeat from comment
- https://github.com/platformatic/kafka/blob/b9d692d0fb32de179decd23467f911546f5fe519/src/clients/consumer/consumer.ts#L1413-L1443

### Fix

Schedule the replacement heartbeat before emitting the error. This keeps the loop running for non-group errors matching the KIP-848 path. 

Preserves existing observable behavior where `group:rebalance` listeners still see a cancelled timer, and error listeners that leave the group still cancel the new heartbeat