### PR TITLE
close socket

### DIFF
--- a/src/network/connection.ts
+++ b/src/network/connection.ts
@@ -520,7 +520,14 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
 
   #onRequestTimeout (request: Request): void {
     request.timedOut = true
-    request.callback(new TimeoutError('Request timed out'), null)
+    this.#inflightRequests.delete(request.correlationId)
+    this.#afterDrainRequests = this.#afterDrainRequests.filter(r => r !== request)
+
+    this.#status = ConnectionStatuses.CLOSING
+
+    request.callback(new TimeoutError('Request timed out', { canRetry: true }), null)
+
+    this.#socket?.destroy()
   }
 
   #authenticate (host: string, port: number, diagnosticContext: DiagnosticContext): void {
@@ -932,13 +939,15 @@ export class Connection extends TypedEventEmitter<ConnectionEvents> {
     const error = new NetworkError('Connection closed')
 
     for (const request of this.#afterDrainRequests) {
-      if (!request.noResponse) {
+      if (!request.noResponse && !request.timedOut) {
         request.callback(error, undefined)
       }
     }
 
     for (const inflight of this.#inflightRequests.values()) {
-      inflight.callback(error, undefined)
+      if (!inflight.timedOut) {
+        inflight.callback(error, undefined)
+      }
     }
   }
 

--- a/test/network/connection-pool.test.ts
+++ b/test/network/connection-pool.test.ts
@@ -1,4 +1,5 @@
 import { deepStrictEqual, ok, rejects, strictEqual } from 'node:assert'
+import { once } from 'node:events'
 import { type AddressInfo, createServer as createNetworkServer, type Server, type Socket } from 'node:net'
 import { networkInterfaces } from 'node:os'
 import { mock, test, type TestContext } from 'node:test'
@@ -12,7 +13,8 @@ import {
   ConnectionStatuses,
   GenericError,
   instancesChannel,
-  parseBroker
+  parseBroker,
+  Writer
 } from '../../src/index.ts'
 import {
   createCreationChannelVerifier,
@@ -38,11 +40,15 @@ function createServer (t: TestContext, host?: string): Promise<{ server: Server;
     sockets.push(socket)
   })
 
-  t.after((_, cb) => {
+  // Promise-based hook completion (rather than the callback-style (_, cb) signature) avoids a
+  // node:test quirk where a callback-style t.after hook in a non-first test can be misreported
+  // as 'cancelledByParent' ("Promise resolution is still pending but the event loop has already
+  // resolved"), even though the hook itself completes correctly.
+  t.after(async () => {
     for (const socket of sockets) {
       socket.end()
     }
-    server.close(cb)
+    await new Promise<void>(resolve => server.close(() => resolve()))
   })
 
   server.listen(0, host)
@@ -264,6 +270,67 @@ test('get should handle connection disconnect event', async t => {
   ok(newConnection !== connection)
 
   await newConnection.close()
+})
+
+test('get should evict a connection whose request timed out', { timeout: 3000 }, async t => {
+  const { server, port } = await createServer(t)
+
+  // The accepted socket is destroyed explicitly below because it has no way to detect the
+  // client's abrupt destroy() on its own, which would otherwise leave createServer's t.after
+  // cleanup (server.close()) hanging.
+  let serverSocket: Socket | undefined
+  server.on('connection', socket => {
+    serverSocket = socket
+    socket.on('error', () => {})
+  })
+
+  const connectionPool = new ConnectionPool('test-client', { requestTimeout: 500 })
+  t.after(() => connectionPool.close())
+
+  const broker = { host: 'localhost', port }
+  const connection = await connectionPool.get(broker)
+
+  function payloadFn () {
+    const writer = Writer.create()
+    writer.appendInt32(42)
+    return writer
+  }
+
+  try {
+    await rejects(
+      () =>
+        new Promise<string>((resolve, reject) => {
+          connection.send(
+            0, // apiKey
+            0, // apiVersion
+            payloadFn,
+            function () {
+              return 'Success'
+            }, // Dummy parser
+            false, // hasRequestHeaderTaggedFields
+            false, // hasResponseHeaderTaggedFields
+            (err, returnValue) => {
+              if (err) {
+                reject(err)
+              } else {
+                resolve(returnValue!)
+              }
+            }
+          )
+        }),
+      { message: 'Request timed out' }
+    )
+
+    await once(connectionPool, 'disconnect')
+
+    // The dead connection must be evicted so the next get() for the same broker opens a fresh one.
+    const newConnection = await connectionPool.get(broker)
+    ok(newConnection !== connection)
+
+    await newConnection.close()
+  } finally {
+    serverSocket?.destroy()
+  }
 })
 
 test('get should handle errors and remove connection', async t => {

--- a/test/network/connection-pool.test.ts
+++ b/test/network/connection-pool.test.ts
@@ -40,10 +40,6 @@ function createServer (t: TestContext, host?: string): Promise<{ server: Server;
     sockets.push(socket)
   })
 
-  // Promise-based hook completion (rather than the callback-style (_, cb) signature) avoids a
-  // node:test quirk where a callback-style t.after hook in a non-first test can be misreported
-  // as 'cancelledByParent' ("Promise resolution is still pending but the event loop has already
-  // resolved"), even though the hook itself completes correctly.
   t.after(async () => {
     for (const socket of sockets) {
       socket.end()

--- a/test/network/connection-pool.test.ts
+++ b/test/network/connection-pool.test.ts
@@ -37,14 +37,17 @@ function createServer (t: TestContext, host?: string): Promise<{ server: Server;
   server.once('listening', () => resolve({ server, port: (server.address() as AddressInfo).port }))
   server.once('error', reject)
   server.on('connection', socket => {
+    // Swallow socket errors (e.g. ECONNRESET) from a client that tears its connection down abruptly;
+    // without an 'error' listener the accepted socket would rethrow and crash the test process.
+    socket.on('error', () => {})
     sockets.push(socket)
   })
 
-  t.after(async () => {
+  t.after((_, cb) => {
     for (const socket of sockets) {
-      socket.end()
+      socket.destroy()
     }
-    await new Promise<void>(resolve => server.close(() => resolve()))
+    server.close(cb)
   })
 
   server.listen(0, host)
@@ -269,16 +272,7 @@ test('get should handle connection disconnect event', async t => {
 })
 
 test('get should evict a connection whose request timed out', { timeout: 3000 }, async t => {
-  const { server, port } = await createServer(t)
-
-  // The accepted socket is destroyed explicitly below because it has no way to detect the
-  // client's abrupt destroy() on its own, which would otherwise leave createServer's t.after
-  // cleanup (server.close()) hanging.
-  let serverSocket: Socket | undefined
-  server.on('connection', socket => {
-    serverSocket = socket
-    socket.on('error', () => {})
-  })
+  const { port } = await createServer(t)
 
   const connectionPool = new ConnectionPool('test-client', { requestTimeout: 500 })
   t.after(() => connectionPool.close())
@@ -292,41 +286,42 @@ test('get should evict a connection whose request timed out', { timeout: 3000 },
     return writer
   }
 
-  try {
-    await rejects(
-      () =>
-        new Promise<string>((resolve, reject) => {
-          connection.send(
-            0, // apiKey
-            0, // apiVersion
-            payloadFn,
-            function () {
-              return 'Success'
-            }, // Dummy parser
-            false, // hasRequestHeaderTaggedFields
-            false, // hasResponseHeaderTaggedFields
-            (err, returnValue) => {
-              if (err) {
-                reject(err)
-              } else {
-                resolve(returnValue!)
-              }
+  // Start listening for 'disconnect' BEFORE the request can time out. #onRequestTimeout invokes the
+  // callback and then destroys the socket, so the pool can emit 'disconnect' right after the timeout
+  // error rejects — attaching this listener only afterwards would race that emission.
+  const disconnected = once(connectionPool, 'disconnect')
+
+  await rejects(
+    () =>
+      new Promise<string>((resolve, reject) => {
+        connection.send(
+          0, // apiKey
+          0, // apiVersion
+          payloadFn,
+          function () {
+            return 'Success'
+          }, // Dummy parser
+          false, // hasRequestHeaderTaggedFields
+          false, // hasResponseHeaderTaggedFields
+          (err, returnValue) => {
+            if (err) {
+              reject(err)
+            } else {
+              resolve(returnValue!)
             }
-          )
-        }),
-      { message: 'Request timed out' }
-    )
+          }
+        )
+      }),
+    { message: 'Request timed out' }
+  )
 
-    await once(connectionPool, 'disconnect')
+  await disconnected
 
-    // The dead connection must be evicted so the next get() for the same broker opens a fresh one.
-    const newConnection = await connectionPool.get(broker)
-    ok(newConnection !== connection)
+  // The dead connection must be evicted so the next get() for the same broker opens a fresh one.
+  const newConnection = await connectionPool.get(broker)
+  ok(newConnection !== connection)
 
-    await newConnection.close()
-  } finally {
-    serverSocket?.destroy()
-  }
+  await newConnection.close()
 })
 
 test('get should handle errors and remove connection', async t => {

--- a/test/network/connection.test.ts
+++ b/test/network/connection.test.ts
@@ -63,11 +63,11 @@ function createServer (t: TestContext): Promise<{ server: Server; port: number }
     sockets.push(socket)
   })
 
-  t.after((_, cb) => {
+  t.after(async () => {
     for (const socket of sockets) {
       socket.end()
     }
-    server.close(cb)
+    await new Promise<void>(resolve => server.close(() => resolve()))
   })
 
   server.listen(0)
@@ -561,6 +561,192 @@ test('Connection.send should time out eventually (custom timeout)', async t => {
     strictEqual(elapsed >= customTimeout, true, 'Should not time out before the custom timeout')
     // Allow 10% tolerance
     strictEqual(elapsed < customTimeout * 1.1, true, 'Should time out with custom timeout')
+  }
+})
+
+test('Connection.send should destroy the socket and close the connection when a request times out', { timeout: 3000 }, async t => {
+  const { server, port } = await createServer(t)
+  const customTimeout = 500
+  const connection = new Connection('test-client', { requestTimeout: customTimeout })
+  t.after(() => connection.close())
+
+  let serverSocket: Socket | undefined
+  server.on('connection', socket => {
+    serverSocket = socket
+    socket.on('error', () => {})
+  })
+
+  await connection.connect('localhost', port)
+
+  function payloadFn () {
+    const writer = Writer.create()
+    writer.appendInt32(42)
+    return writer
+  }
+
+  try {
+    let callCount = 0
+
+    await rejects(
+      () =>
+        new Promise<string>((resolve, reject) => {
+          connection.send(
+            0, // apiKey
+            0, // apiVersion
+            payloadFn,
+            function () {
+              return 'Success'
+            }, // Dummy parser
+            false, // hasRequestHeaderTaggedFields
+            false, // hasResponseHeaderTaggedFields
+            (err, returnValue) => {
+              callCount++
+              if (err) {
+                reject(err)
+              } else {
+                resolve(returnValue!)
+              }
+            }
+          )
+        }),
+      { message: 'Request timed out' }
+    )
+
+    // The status flip happens synchronously inside #onRequestTimeout, before the async socket
+    // 'close' event ever fires — checking it here (rather than only after awaiting 'close' below)
+    // guards against a concurrent ConnectionPool#get() being handed this connection while it still
+    // reports CONNECTED despite already being torn down.
+    strictEqual(connection.status === ConnectionStatuses.CONNECTED, false, 'status must not still report CONNECTED once the timeout has fired')
+
+    // #onClose runs synchronously as part of the socket 'close' sequence, before the 'close'
+    // event that once() below is waiting for is emitted — so by the time this resolves, #onClose
+    // has already had its chance to (incorrectly) re-invoke this request's callback a second time
+    // if the #inflightRequests removal / !request.timedOut guard in #onRequestTimeout/#onClose regressed.
+    await once(connection, 'close')
+    strictEqual(connection.status, ConnectionStatuses.CLOSED)
+    strictEqual(callCount, 1, 'the timed-out request callback must not be invoked a second time by the close cascade')
+  } finally {
+    serverSocket?.destroy()
+  }
+})
+
+test('Connection.send should fail other in-flight requests immediately when a sibling request times out', { timeout: 5000 }, async t => {
+  const { server, port } = await createServer(t)
+  const customTimeout = 2000
+  const connection = new Connection('test-client', { requestTimeout: customTimeout, maxInflights: 2 })
+  t.after(() => connection.close())
+
+  let serverSocket: Socket | undefined
+  server.on('connection', socket => {
+    serverSocket = socket
+    socket.on('error', () => {})
+  })
+
+  await connection.connect('localhost', port)
+
+  function payloadFn () {
+    const writer = Writer.create()
+    writer.appendInt32(42)
+    return writer
+  }
+
+  function sendOne (): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+      connection.send(
+        0, // apiKey
+        0, // apiVersion
+        payloadFn,
+        function () {
+          return 'Success'
+        }, // Dummy parser
+        false, // hasRequestHeaderTaggedFields
+        false, // hasResponseHeaderTaggedFields
+        (err, returnValue) => {
+          if (err) {
+            reject(err)
+          } else {
+            resolve(returnValue!)
+          }
+        }
+      )
+    })
+  }
+
+  try {
+    const startTime = performance.now()
+    const firstPromise = sendOne()
+
+    await scheduler.wait(customTimeout / 2)
+    const secondPromise = sendOne()
+
+    await rejects(() => firstPromise, { message: 'Request timed out' })
+    await rejects(() => secondPromise, { code: 'PLT_KFK_NETWORK', message: 'Connection closed' })
+
+    const secondElapsed = performance.now() - startTime
+    // Without the fix, the second request only fails once its OWN timer elapses at roughly
+    // (customTimeout / 2) + customTimeout = 3000ms. With the fix it fails via the close cascade
+    // shortly after the first request's timeout, i.e. around customTimeout = 2000ms.
+    strictEqual(secondElapsed < customTimeout * 1.3, true, `second request should fail via cascade (took ${secondElapsed}ms)`)
+  } finally {
+    serverSocket?.destroy()
+  }
+})
+
+test('Connection.send should deliver a retriable timeout error so the client can self-heal', { timeout: 3000 }, async t => {
+  const { server, port } = await createServer(t)
+  const customTimeout = 500
+  const connection = new Connection('test-client', { requestTimeout: customTimeout })
+  t.after(() => connection.close())
+
+  // Accept the connection but never respond. Destroyed explicitly below for the same reason as the
+  // preceding timeout tests — the accepted socket cannot detect the client's abrupt destroy().
+  let serverSocket: Socket | undefined
+  server.on('connection', socket => {
+    serverSocket = socket
+    socket.on('error', () => {})
+  })
+
+  await connection.connect('localhost', port)
+
+  function payloadFn () {
+    const writer = Writer.create()
+    writer.appendInt32(42)
+    return writer
+  }
+
+  try {
+    let capturedError: Error | null = null
+    await rejects(
+      () =>
+        new Promise<string>((resolve, reject) => {
+          connection.send(
+            0, // apiKey
+            0, // apiVersion
+            payloadFn,
+            function () {
+              return 'Success'
+            }, // Dummy parser
+            false, // hasRequestHeaderTaggedFields
+            false, // hasResponseHeaderTaggedFields
+            (err, returnValue) => {
+              if (err) {
+                capturedError = err
+                reject(err)
+              } else {
+                resolve(returnValue!)
+              }
+            }
+          )
+        }),
+      { message: 'Request timed out' }
+    )
+
+    // The timeout error must be retriable so kPerformWithRetry (and the ListOffsets metadata-refresh
+    // gate) re-issues the request on a fresh connection, rather than surfacing a dead-end failure.
+    strictEqual((capturedError as unknown as { canRetry?: boolean } | null)?.canRetry, true, 'timeout error must carry canRetry === true')
+    strictEqual(NetworkError.isRetryable(capturedError), true, 'timeout error must be retriable per NetworkError.isRetryable')
+  } finally {
+    serverSocket?.destroy()
   }
 })
 


### PR DESCRIPTION
A request that exceeds requestTimeout no longer fails into a permanent livelock. On timeout we now destroy the underlying socket (so the connection pool evicts it) and deliver a retriable TimeoutError, so the next attempt dials a fresh connection instead of writing back into a dead one. Recovery is bounded by retries × requestTimeout; no library-wide defaults change.

The bug
When a broker vanishes without a clean FIN/RST — OOM-kill, hard network partition, container SIGKILL — the client is left with a half-open socket: the local kernel still believes it's ESTABLISHED, so writes disappear into the void and reads block forever. The request eventually hits requestTimeout, but the old handler
did two things wrong:

Left the dead socket in the pool. It stayed cached under host:port, still reporting CONNECTED.
Delivered a non-retriable error. canRetry defaulted to false, closing both kPerformWithRetry's retry gate and the metadata-refresh path.